### PR TITLE
Add shell.nix to provide a dev shell with python3.10 + poetry

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{
+  pkgs ? import (builtins.fetchGit {
+    url = "https://github.com/NixOS/nixpkgs/";
+    ref = "nixos-22.11";
+  }) {}
+}:
+
+pkgs.mkShell {
+  name = "fawltydeps-env";
+  buildInputs = with pkgs; [
+    (python310.withPackages (pypkgs: with pypkgs; [
+      poetry
+    ]))
+  ];
+  shellHook = ''
+    poetry env use "$(which python)"
+    poetry install
+    source "$(poetry env info --path)/bin/activate"
+  '';
+}


### PR DESCRIPTION
Objective: With this (and Nix available on your machine), running
`nix-shell` is sufficient to start developing on FawltyDeps.

The shell hook does the initial setup + install of the poetry
environment, and then enters the poetry shell, leaving you inside the
poetry virtualenv where fawltydeps and its dependencies are already
installed.
