### PR TITLE
Pylint configuration 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,10 +32,7 @@ jobs:
       - name: Check formatting with Black
         run: poetry run black fawltydeps tests --check 
       - name: Run linter
-        run: |
-          poetry run pylint fawltydeps
-          poetry run pylint tests --disable=C0116,C0103
-
+        run: poetry run pylint fawltydeps tests
       - name: Run import sort checker
         run: poetry run isort fawltydeps tests --check-only
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ mypy = "^0.991"
 [tool.isort]
 profile = "black"
 
+[tool.pylint.tests]
+disable = "C0116,C0103"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Add overriding linter configuration for `tests` module only. 

Part of solution to  #16 .

Getting rid of:
```
C0116: Missing function or method docstring (missing-function-docstring)
C0103: Function name "test_parse_code__on_parse_error__propagates_SyntaxError" doesn't conform to snake_case naming style (invalid-name)
```