### PR TITLE
Add license, repository and classifiers to metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,16 @@ repository = "https://github.com/tweag/FawltyDeps"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Software Development :: Quality Assurance"
+    "Topic :: Software Development :: Quality Assurance",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Utilities",
+    "Typing :: Typed",
 ]
 
 [tool.poetry.scripts]


### PR DESCRIPTION
More precise metadata will help the project to be discovered by potential users.
- Classifiers are taken from the [list of tags](https://pypi.org/classifiers/) and you can filter all PyPI projects by that.
- License is nice to have and repository will also be of use when we publish FawltyDeps on PyPI.
- We can also think about [kewords](https://python-poetry.org/docs/pyproject#keywords).
