### PR TITLE
Using Nox inside our GitHub CI actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,9 +23,9 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-poetry-tests-${{ hashFiles('poetry.lock') }}
       - name: Install project
-        run: poetry install --no-interaction --sync --with=test
-      - name: Run tests
-        run: poetry run pytest
+        run: poetry install --no-interaction --sync --with=nox,test
+      - name: Run tests on Python ${{ matrix.python-version }}
+        run: poetry run nox --no-venv --no-install --non-interactive -s tests
 
   lint:
     strategy:
@@ -47,11 +47,9 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-poetry-lint-${{ hashFiles('poetry.lock') }}
       - name: Install project
-        run: poetry install --no-interaction --sync --with=lint
-      - name: Run type-checking
-        run: poetry run mypy fawltydeps tests
-      - name: Run linter
-        run: poetry run pylint fawltydeps tests
+        run: poetry install --no-interaction --sync --no-root --only=nox,lint
+      - name: Run linters on Python ${{ matrix.python-version }}
+        run: poetry run nox --no-venv --no-install --non-interactive -s lint
 
   format:
     strategy:
@@ -73,11 +71,9 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-poetry-format-${{ hashFiles('poetry.lock') }}
       - name: Install project
-        run: poetry install --no-interaction --sync --with=format
-      - name: Check formatting with Black
-        run: poetry run black . --check
-      - name: Run import sort checker
-        run: poetry run isort fawltydeps tests --check-only
+        run: poetry install --no-interaction --sync --no-root --only=nox,format
+      - name: Run formatting checks
+        run: poetry run nox --no-venv --no-install --non-interactive -s format
 
 # Inspiration for the CI setup:
 # https://github.com/marketplace/actions/python-poetry-action

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,6 +28,14 @@ def install_groups(
     Auto-skip the `poetry export` step if the poetry.lock file is unchanged
     since the last time this session was run.
     """
+    if isinstance(session.virtualenv, nox.virtualenv.PassthroughEnv):
+        session.warn(
+            "Running outside a Nox virtualenv! We will skip installation here, "
+            "and simply assume that the necessary dependency groups have "
+            "already been installed by other means!"
+        )
+        return
+
     lockdata = Path("poetry.lock").read_bytes()
     digest = hashlib.blake2b(lockdata).hexdigest()
     requirements_txt = Path(session.cache_dir, session.name, "reqs_from_poetry.txt")


### PR DESCRIPTION
(This PR depends on #23 and adds the following commit on top)

Rephrase GitHub Actions in terms of Nox actions

This reduces duplication of GitHub vs local/Nox CI actions by changing
the GitHub actions to call out to Nox.

That said, this is not a full-fledged embrace of the Nox way: Nox will
usually install dependencies in its own virtualenvs. However, these
would come in addition to Poetry's virtualenv, and we have not currently
set up caching for anything but the Poetry virtualenvs.

Work around this by setting up the appropriate Python version and
installing all the necessary dependencies in the Poetry virtualenv
(i.e. outside of Nox). We can then run Nox with `--no-venv --no-install`
to explicitly disable the Nox virtualenvs (which also disables the
Python version parametrization inside Nox).

For this to work, we also need to adjust our `install_groups()` helper in
`noxfile.py` to detect when it's running without Nox virtualenvs and skip
installation in this case.

In summary, this avoids an extra layer of virtualenvs and should also
retain the same useful caching of the Poetry virtualenvs, but at the
cost of running the Nox sessions in a slightly different way compared
to running Nox in your local development environment: We do Python
version parametrization and dependency installation the Github Actions +
Poetry way, and then only use Nox to abstract away the actual commands
run inside each CI action.

Time will tell if this creates too many issues to be worthwhile.