### PR TITLE
Ignore dot directories when traversing directory trees

### DIFF
--- a/fawltydeps/extract_dependencies.py
+++ b/fawltydeps/extract_dependencies.py
@@ -2,7 +2,6 @@
 
 import ast
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, Iterator
@@ -10,6 +9,7 @@ from typing import Any, Dict, Iterator
 from pkg_resources import parse_requirements
 
 from fawltydeps.types import DeclaredDependency
+from fawltydeps.utils import walk_dir
 
 if sys.version_info >= (3, 11):
     import tomllib  # pylint: disable=E1101
@@ -254,10 +254,8 @@ def extract_dependencies(path: Path) -> Iterator[DeclaredDependency]:
             logger.error("Parsing file %s is not supported", path.name)
 
     else:
-        for root, _dirs, files in os.walk(path):
-            for filename in files:
-                if filename in parsers:
-                    parser = parsers[filename]
-                    current_path = Path(root, filename)
-                    logger.debug(f"Extracting dependency from {current_path}.")
-                    yield from parser(current_path.read_text(), path_hint=current_path)
+        for file in walk_dir(path):
+            if file.name in parsers:
+                parser = parsers[file.name]
+                logger.debug(f"Extracting dependency from {file}.")
+                yield from parser(file.read_text(), path_hint=file)

--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -3,12 +3,12 @@
 import ast
 import json
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import Iterator, Optional
 
 from fawltydeps.types import ParsedImport
+from fawltydeps.utils import walk_dir
 
 logger = logging.getLogger(__name__)
 
@@ -104,13 +104,11 @@ def parse_dir(path: Path) -> Iterator[ParsedImport]:
     they appear in the file. Modules that are imported by several files will
     be yielded multiple times.
     """
-    for root, _dirs, files in os.walk(path):
-        for filename in files:
-            path = Path(root, filename)
-            if path.suffix == ".py":
-                yield from parse_python_file(path)
-            elif path.suffix == ".ipynb":
-                yield from parse_notebook_file(path)
+    for file in walk_dir(path):
+        if file.suffix == ".py":
+            yield from parse_python_file(file)
+        elif file.suffix == ".ipynb":
+            yield from parse_notebook_file(file)
 
 
 def parse_any_arg(arg: Path) -> Iterator[ParsedImport]:

--- a/fawltydeps/utils.py
+++ b/fawltydeps/utils.py
@@ -1,0 +1,18 @@
+"""Common utilities"""
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+
+def walk_dir(path: Path) -> Iterator[Path]:
+    """Walk a directory structure and yield Path objects for each file within.
+
+    Wrapper around os.walk() that yields Path objects for files found (directly
+    or transitively) under the given directory. Directories whose name start
+    with a dot are skipped.
+    """
+    for root, dirs, files in os.walk(path):
+        dirs[:] = [d for d in dirs if not d.startswith(".")]
+        for filename in files:
+            yield Path(root, filename)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,11 @@ def project_with_requirements(write_tmp_files):
                 pandas
                 tensorflow>=2
                 """,
+            # This file should be ignored:
+            ".venv/requirements.txt": """\
+                foo_package
+                bar_package
+                """,
             "python_file.py": "import django",
         }
     )

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -319,3 +319,15 @@ def test_parse_dir__imports__are_extracted_in_order_of_encounter(tmp_path):
         ["sys", "foo"], tmp_path / "first.py", [1, 2]
     ) + construct_imports(["sys", "xyzzy"], tmp_path / "subdir/second.py", [1, 2])
     assert list(parse_dir(tmp_path)) == expect
+
+
+def test_parse_dir__files_in_dot_dirs__are_ignored(write_tmp_files):
+    tmp_path = write_tmp_files(
+        {
+            "test1.py": "import numpy",
+            ".venv/test2.py": "import pandas",
+        }
+    )
+
+    expect = {ParsedImport("numpy", tmp_path / "test1.py", 1)}
+    assert set(parse_dir(tmp_path)) == expect


### PR DESCRIPTION
We have noticed that running fawltydeps on itself generates lots of
unexpected output and takes a lot of time. This is because the default
behavior looks for all code and deps under the current dir, which
includes various code and projects that are stored in various "hidden"
directories such as .venv/, .pytest_cache/, .nox/, or similar.
These dirs are not interesting to analyze, and should be ignored.

(In the future we want to make this configurable, but this is a good
default for now.)

Create a walk_dir() helper function in a new fawltydeps.utils module,
and use it from both extract_imports and extract_depenedencies.

Add some tests, too.
