### PR TITLE
Refactor human-readable output

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -159,7 +159,7 @@ def main() -> int:
     parser.add_argument(
         "--code",
         type=parse_path_or_stdin,
-        default=Path.cwd(),
+        default=Path("."),
         help=(
             "Code to parse for import statements (file or directory, use '-' "
             "to read code from stdin; defaults to the current directory)"
@@ -168,7 +168,7 @@ def main() -> int:
     parser.add_argument(
         "--deps",
         type=Path,
-        default=Path.cwd(),
+        default=Path("."),
         help=(
             "Where to find dependency declarations (file or directory, defaults"
             " to looking for requirements.txt/.in/setup.py/pyproject.toml in "

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -365,10 +365,10 @@ def test__no_options__defaults_to_check_action_in_current_dir(
     expect = [
         "These imports appear to be undeclared dependencies:",
         "- 'requests' imported at:",
-        f"    {str(tmp_path / 'code.py')}:1",
+        "    code.py:1",
         "These dependencies appear to be unused (i.e. not imported):",
         "- 'pandas' declared in:",
-        f"    {tmp_path / 'requirements.txt'}",
+        "    requirements.txt",
     ]
     output, errors, returncode = run_fawltydeps(cwd=tmp_path)
     assert output.splitlines() == expect


### PR DESCRIPTION
- `main`: Print locations alongside unused dependencies
- `main`: Change output format for `--list-imports`
- `main`: Change output format for `--list-deps`
