### PR TITLE
Allow for less verbose run of listing imports and dependencies

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -196,11 +196,7 @@ def main() -> int:
         "--quiet",
         action="count",
         default=0,
-        help=(
-            "Decrease log level (WARNING by default, -q: ERROR, -qq: FATAL)"
-            " and verbosity of the output (without location details by default,"
-            " -q, -qq: without location details)"
-        ),
+        help="Decrease log level (WARNING by default, -q: ERROR, -qq: FATAL)",
     )
 
     args = parser.parse_args()
@@ -218,7 +214,7 @@ def main() -> int:
 
     analysis.print_human_readable(sys.stdout, details=verbose_report)
     if not verbose_report:
-        print("\nFor a more verbose report re-run with `-v` option.\n")
+        print("\nFor a more verbose report re-run with the `-v` option.\n")
 
     # Exit codes:
     # 0 - success, no problems found

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -265,7 +265,7 @@ def test_check__simple_project_imports_match_dependencies__prints_verbose_option
         declares=["requests", "pandas"],
     )
 
-    expect = ["For a more verbose report re-run with `-v` option."]
+    expect = ["For a more verbose report re-run with the `-v` option."]
     output, errors, returncode = run_fawltydeps(
         "--check", f"--code={tmp_path}", f"--deps={tmp_path}"
     )
@@ -461,7 +461,7 @@ def test__quiet_check__writes_only_names_of_unused_and_undeclared(
         "These dependencies appear to be unused (i.e. not imported):",
         "- 'pandas'",
         "",
-        "For a more verbose report re-run with `-v` option.",
+        "For a more verbose report re-run with the `-v` option.",
     ]
     output, errors, returncode = run_fawltydeps("--check", cwd=tmp_path)
     assert output.splitlines() == expect


### PR DESCRIPTION
Option without details returns a list of imports/dependencies in alphabetical order.

As it happens, to easier add real-world project we need to have a way to just list imports and dependencies of the project.
This PR is allowing `-q` option in the command line tool to reduce the printed information to list of imports/dependencies in alphabetical order.