### PR TITLE
First party import parsing with isort

### DIFF
--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -10,12 +10,12 @@ from typing import Iterable, Iterator, Optional, Tuple
 import isort
 
 from fawltydeps.types import ArgParseError, Location, ParsedImport, PathOrSpecial
-from fawltydeps.utils import walk_dir
+from fawltydeps.utils import dirs_between, walk_dir
 
 logger = logging.getLogger(__name__)
 
 
-def make_isort_config(path: Path, src_paths: Tuple[Path] = ()) -> isort.Config:
+def make_isort_config(path: Path, src_paths: Tuple[Path, ...] = ()) -> isort.Config:
     """Configure isort to correctly classify import statements.
 
     In order for isort to correctly differentiate between first- and third-party
@@ -158,7 +158,9 @@ def parse_dir(path: Path) -> Iterator[ParsedImport]:
     across several files) will be yielded multiple times.
     """
     for file in walk_dir(path):
-        local_context = make_isort_config(path=path, src_paths=file.parents)
+        local_context = make_isort_config(
+            path=path, src_paths=tuple(dirs_between(path, file.parent))
+        )
         if file.suffix == ".py":
             yield from parse_python_file(file, local_context=local_context)
         elif file.suffix == ".ipynb":

--- a/fawltydeps/utils.py
+++ b/fawltydeps/utils.py
@@ -16,3 +16,10 @@ def walk_dir(path: Path) -> Iterator[Path]:
         dirs[:] = [d for d in dirs if not d.startswith(".")]
         for filename in files:
             yield Path(root, filename)
+
+
+def dirs_between(parent: Path, child: Path) -> Iterator[Path]:
+    """Yield directories between 'parent' and 'child', inclusive."""
+    yield child
+    if child != parent:
+        yield from dirs_between(parent, child.parent)

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -4,8 +4,6 @@ import logging
 from textwrap import dedent
 from typing import List, Tuple, Union
 
-import sys
-
 import pytest
 
 from fawltydeps.extract_imports import (
@@ -495,6 +493,11 @@ def test_parse_dir__imports__are_extracted_in_order_of_encounter(write_tmp_files
             },
             [],
             id="__ignore_imports_from_uncle",
+        ),
+        pytest.param(
+            {"tests/test_my_application.py": "import pytest", "pytest.ini": "[pytest]"},
+            [("pytest", "tests/test_my_application.py", 1)],
+            id="__ignore_imports_from_non_python_files",
         ),
     ],
 )


### PR DESCRIPTION
This PR is an update to #93 

Doing experiments on the detect-waste project, we discovered, that the `isort` configuration needs the correct handling of local imports with grandparents and other family members (like uncles). 

The current implementation improvements:
1. removed global variable for the state of the `Config`. `isort` configuration is currently passed as a function argument - we have code that is to be parsed and the local context in which we should look for local imports.
2. added parents of the file (between root and the file)
3. added test cases based on detect-waste example.