### PR TITLE
types: Fix numerical sorting of Location objects

### DIFF
--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field, replace
 from functools import total_ordering
 from operator import attrgetter
 from pathlib import Path
-from typing import List, NamedTuple, Optional, Union
+from typing import List, NamedTuple, Optional, Tuple, Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal  # pylint: disable=E1101
@@ -56,7 +56,7 @@ class Location:
     # instances of 'PosixPath' and 'NoneType'.
     # Instead, we must implement our own. Do so based on a comparable/sortable
     # string created/cached together with the instance.
-    _sort_key: str = field(init=False, repr=False)  # see .__post_init__()
+    _sort_key: Tuple[str, int, int] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Initialize a sort key that uniquely reflects this instance.
@@ -68,9 +68,12 @@ class Location:
         - Unspecified members sort together, and separate from specified members
         - Paths sort alphabetically, the other members sort numerically
         """
-        object.__setattr__(
-            self, "_sort_key", repr((self.path, self.cellno, self.lineno))
+        sortable_tuple = (
+            repr(self.path),
+            -1 if self.cellno is None else self.cellno,
+            -1 if self.lineno is None else self.lineno,
         )
+        object.__setattr__(self, "_sort_key", sortable_tuple)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Location):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -7,26 +7,22 @@ import pytest
 from fawltydeps.types import Location
 
 testdata = {  # Test ID -> (Location args, expected string representation, sort order)
-    # The sort order below reveals that "None" sorts before "PosixPath(...)",
-    # but after ASCII digits. In practice this does not matter, as we expect
-    # Location objects in the same process to have the ~same members specified.
-    #
     # First arg must be a Path, or "<stdin>"
     "nothing": (("<stdin>",), "<stdin>", 111),
     "abs_path": ((Path("/foo/bar"),), "/foo/bar", 211),
     "rel_path": ((Path("foo"),), "foo", 311),
     # Second arg refers to notebook cell, and is rendered in [square brackets]
-    "no_path_cell": (("<stdin>", 1), "<stdin>[1]", 101),
-    "abs_path_cell": ((Path("/foo/bar"), 2), "/foo/bar[2]", 201),
-    "rel_path_cell": ((Path("foo"), 3), "foo[3]", 301),
+    "no_path_cell": (("<stdin>", 1), "<stdin>[1]", 121),
+    "abs_path_cell": ((Path("/foo/bar"), 2), "/foo/bar[2]", 221),
+    "rel_path_cell": ((Path("foo"), 3), "foo[3]", 321),
     # Third arg is line number, and is prefixed by colon
-    "no_path_cell_line": (("<stdin>", 1, 2), "<stdin>[1]:2", 100),
-    "abs_path_cell_line": ((Path("/foo/bar"), 2, 3), "/foo/bar[2]:3", 200),
-    "rel_path_cell_line": ((Path("foo"), 3, 4), "foo[3]:4", 300),
+    "no_path_cell_line": (("<stdin>", 1, 2), "<stdin>[1]:2", 122),
+    "abs_path_cell_line": ((Path("/foo/bar"), 2, 3), "/foo/bar[2]:3", 222),
+    "rel_path_cell_line": ((Path("foo"), 3, 4), "foo[3]:4", 322),
     # Cell number is omitted for non-notebooks.
-    "no_path_line": (("<stdin>", None, 2), "<stdin>:2", 110),
-    "abs_path_line": ((Path("/foo/bar"), None, 3), "/foo/bar:3", 210),
-    "rel_path_line": ((Path("foo"), None, 4), "foo:4", 310),
+    "no_path_line": (("<stdin>", None, 2), "<stdin>:2", 112),
+    "abs_path_line": ((Path("/foo/bar"), None, 3), "/foo/bar:3", 212),
+    "rel_path_line": ((Path("foo"), None, 4), "foo:4", 312),
 }
 
 
@@ -46,6 +42,17 @@ def test_location__sorting():
     actual = sorted([Location(*args) for args, *_ in testdata.values()])
 
     assert actual == expect
+
+
+def test_location__numbers_are_sorted_numerically():
+    pre_sorted = [
+        Location(Path("foo"), 9, 5),
+        Location(Path("foo"), 9, 22),
+        Location(Path("foo"), 11, 5),
+        Location(Path("foo"), 11, 22),
+    ]
+    post_sorted = sorted(pre_sorted)
+    assert pre_sorted == post_sorted
 
 
 def test_location__hashable_and_unique():


### PR DESCRIPTION
The docstring for Location.__post_init__() states:

    Paths sort alphabetically, the other members sort numerically

However, we did not follow this in practice: e.g. "foo.py:123" would
sort before "foo.py:7" because we used the string representation from
repr() in our sort key, and "123" sorts alphabetically before "7".

Fix this by changing the sort key to a tuple where our numerical members
_remain_ numerical. We map the None cases to the integer -1, which

 (a) is not a valid cell number or line number, and
 (b) sorts before any valid number.

Add a test to verify that the numerical order is obeyed when sorting.
