### PR TITLE
noxfile.py + pyproject.toml: Install our main deps when running Mypy

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -76,7 +76,7 @@ def integration_tests(session):
 
 @nox.session(python=python_versions)
 def lint(session):
-    install_groups(session, include=["lint"], include_self=False)
+    install_groups(session, include=["lint"])
     session.run("mypy")
     session.run("pylint", "fawltydeps")
     session.run(

--- a/poetry.lock
+++ b/poetry.lock
@@ -440,7 +440,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "a4f2d1af4030c992db990af6d33127f8cba91e3198b784b3fd4516fd51357b81"
+content-hash = "6a7745b0960d287ae57d74728af60b1ef1d8acf9c4114b61f56199ef10949db8"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ pytest = "^7.1.0"
 optional = true
 
 [tool.poetry.group.lint.dependencies]
-isort = "^5.10"
 mypy = "^0.991"
 nox = "^2022.11.21"
 pylint = "^2.15.8"


### PR DESCRIPTION
Mypy (and the other linters) is run on the FawltyDeps code in the
current work tree, and as such there is no need to _install_ FawltyDeps
itself into the virtualenv where the linters are running.

However, Mypy in particular needs to be able to access 3rd-party modules
that are imported by FawltyDeps code in order to verify our
type-correctness.

The result of this, has been that when we add a new main dependency to
FawltyDeps we often also need to add it to the `lint` dependency group,
so that it's also available to Mypy.

This is getting tiresome, especially since a missing module in the
`lint` group manifest as type checking errors that might easily be
misattributed to the 3rd-party module lacking type annotations, and we
as a result end up inserting unnecessary type-ignore or similar
workarounds in our code.

Fix this once and for all by auto-installing FawltyDeps and its
dependencies into the `lint` dependency group. This will make all of
FD's deps always available to Mypy.
