### PR TITLE
check: Add function for parsing import names for local packages

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -455,7 +455,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "b6162b2f7e92ef8f772cf9de22f2c9e5be07ca8b028bb8b5d1ae91fe33ab7ca6"
+content-hash = "79367c7b65d588e38b7017c220a775bf37e16b524bbd9f9132bddc9adb059744"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ fawltydeps = "fawltydeps.main:main"
 # These are the main dependencies for fawltydeps at runtime.
 # Do not add anything here that is only needed by CI/tests/linters/developers
 python = "^3.7.2"
-importlib_metadata = {version = "^5.0.0", python = "<3.8"}
+importlib_metadata = {version = "^5.0.0", python = "<3.11"}
 isort = "^5.10"
 pydantic = "^1.10.4"
 tomli = {version = "^2.0.1", python = "<3.11"}

--- a/tests/test_map_dep_name_to_import_names.py
+++ b/tests/test_map_dep_name_to_import_names.py
@@ -1,0 +1,41 @@
+"""Test the mapping of dependency names to import names."""
+
+import pytest
+
+from fawltydeps.check import find_import_names_from_package_name
+
+# TODO: These tests are not fully isolated, i.e. they do not control the
+# virtualenv in which they run. For now, we assume that we are running in an
+# environment where at least these packages are available:
+# - setuptools (exposes multiple import names, including pkg_resources)
+# - pip (exposes a single import name: pip)
+# - isort (exposes no top_level.txt, but 'isort' import name can be inferred)
+
+
+@pytest.mark.parametrize(
+    "dep_name,expect_import_names",
+    [
+        pytest.param(
+            "NOT_A_PACKAGE",
+            None,
+            id="missing_package__returns_None",
+        ),
+        pytest.param(
+            "isort",
+            ["isort"],
+            id="package_exposes_nothing__can_still_infer_import_name",
+        ),
+        pytest.param(
+            "pip",
+            ["pip"],
+            id="package_exposes_one_entry__returns_entry",
+        ),
+        pytest.param(
+            "setuptools",
+            ["_distutils_hack", "pkg_resources", "setuptools"],
+            id="package_exposes_many_entries__returns_all_entries",
+        ),
+    ],
+)
+def test_find_import_names_from_package_name(dep_name, expect_import_names):
+    assert find_import_names_from_package_name(dep_name) == expect_import_names


### PR DESCRIPTION
This adds find_import_names_from_dep() which will look up a dependency
name in the current Python environment, parse its top_level.txt file (if
it exists), and return the resulting import names made available by this
package.

If the package does not exist in the local environment, or if the
top_level.txt file does not exist for this package, we fall back to the
identity mapping, that is, returning the dependency name itself as an
import name.
