### PR TITLE
Add `--version` to the `Options` category in the CLI

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -180,13 +180,6 @@ def main() -> int:
         const={Action.REPORT_UNDECLARED, Action.REPORT_UNUSED},
         help="Report both undeclared and unused dependencies",
     )
-    parser.add_argument(
-        "-V",
-        "--version",
-        action="version",
-        version=f"FawltyDeps v{version()}",
-        help=("Print the version number of FawltyDeps"),
-    )
     select_action.add_argument(
         "--check-undeclared",
         dest="actions",
@@ -217,6 +210,13 @@ def main() -> int:
     )
 
     options = parser.add_argument_group(title="Options")
+    options.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"FawltyDeps v{version()}",
+        help=("Print the version number of FawltyDeps"),
+    )
     options.add_argument(
         "--code",
         type=parse_path_or_stdin,


### PR DESCRIPTION
This must have slipped through the cracks of a rebase.
Before:
![image](https://user-images.githubusercontent.com/4823755/218954670-ce7b19f6-0197-44a1-aebe-8e95603a2844.png)
After:
![image](https://user-images.githubusercontent.com/4823755/218954764-93968a47-a0ab-4d33-bba8-a6f164ecf70c.png)
