### PR TITLE
tests: Always call caplog.set_level(...) before using caplog.text

### DIFF
--- a/tests/test_extract_declared_dependencies_pyproject_toml.py
+++ b/tests/test_extract_declared_dependencies_pyproject_toml.py
@@ -299,6 +299,7 @@ def test_parse_pyproject_content__malformatted_poetry_dependencies__yields_no_de
     caplog, pyproject_toml, expected, metadata_standard, field_types
 ):
     source = Location(Path("pyproject.toml"))
+    caplog.set_level(logging.ERROR)
     result = list(parse_pyproject_contents(pyproject_toml, source))
     assert result == expected
     for field_type in field_types:

--- a/tests/test_extract_imports_errors.py
+++ b/tests/test_extract_imports_errors.py
@@ -1,5 +1,6 @@
 """Verify graceful failure when we cannot extract imports from Python code."""
 
+import logging
 from textwrap import dedent
 
 from fawltydeps.extract_imports import (
@@ -24,6 +25,7 @@ def test_parse_notebook_file__on_invalid_json__logs_error(tmp_path, caplog):
     script = tmp_path / "test.ipynb"
     script.write_text(code)
     expected = []
+    caplog.set_level(logging.ERROR)
     assert list(parse_notebook_file(script)) == expected
     assert f"Could not parse code from {script}" in caplog.text
 
@@ -55,6 +57,7 @@ def test_parse_notebook_file__on_parse_error_one_cell__logs_error_and_continues(
     script.write_text(code)
 
     expected = [ParsedImport("pandas", Location(script, lineno=1, cellno=2))]
+    caplog.set_level(logging.ERROR)
     assert list(parse_notebook_file(script)) == expected
     assert f"Could not parse code from {script}[1]" in caplog.text
 
@@ -68,6 +71,7 @@ def test_parse_code__on_parse_error__logs_error(caplog):
     )
     source = Location("<stdin>")
     expect = []
+    caplog.set_level(logging.ERROR)
     assert list(parse_code(code, source=source)) == expect
     assert f"Could not parse code from {source}" in caplog.text
 
@@ -78,6 +82,7 @@ def test_parse_file__on_syntax_error__logs_error(tmp_path, caplog):
     script.write_text(code)
 
     expect = []
+    caplog.set_level(logging.ERROR)
     assert list(parse_python_file(script)) == expect
     assert f"Could not parse code from {script}" in caplog.text
 
@@ -93,6 +98,7 @@ def test_parse_dir__on_parse_error__error_log_contains_filename(tmp_path, caplog
     script.write_text(code)
 
     expect = []
+    caplog.set_level(logging.ERROR)
     assert list(parse_dir(tmp_path)) == expect
     assert f"Could not parse code from {script}" in caplog.text
 
@@ -128,6 +134,7 @@ def test_parse_notebook_file__on_invalid_python_one_cell__logs_error_and_continu
     script = tmp_path / "test.ipynb"
     script.write_text(code)
 
+    caplog.set_level(logging.ERROR)
     assert list(parse_notebook_file(script)) == [
         ParsedImport("pandas", Location(script, lineno=1, cellno=2))
     ]

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -307,6 +307,7 @@ def test_parse_notebook_file__with_magic_commands__ignores_magic_commands(
 
     expect = imports_w_linenos_cellnos([("pandas", 3, 1)], script)
 
+    caplog.set_level(logging.INFO)
     assert set(parse_notebook_file(script)) == set(expect)
     for lineno, line in enumerate([exclamation_line, percent_line], start=1):
         source = Location(script, 1, lineno)
@@ -335,6 +336,7 @@ def test_parse_notebook_file__with_magic_commands__ignores__multilines_magic_com
 
     expect = imports_w_linenos_cellnos([("pandas", 4, 1)], script)
 
+    caplog.set_level(logging.INFO)
     assert set(parse_notebook_file(script)) == set(expect)
     for lineno, line in [(1, exclamation_line), (3, percent_line)]:
         source = Location(script, 1, lineno)
@@ -361,6 +363,7 @@ def test_parse_notebook_file__with_magic_commands__ignores__shell_magic_commands
 
     expect = imports_w_linenos_cellnos([("pandas", 3, 1)], script)
 
+    caplog.set_level(logging.INFO)
     assert set(parse_notebook_file(script)) == set(expect)
     source = Location(script, 1, 1)
     assert f"Found magic command {exclamation_line!r} at {source}" in caplog.text


### PR DESCRIPTION
We had a few tests that passed when running the test suite with `nox`,
but failed when running `pytest` directly in the dev shell. The failing
tests were unable to find expected log messages within caplog.text.

It turns out that the log level that caplog is configured with is not
stable/the same in the two different scenarios. Instead of digging
further to get to the bottom of this, we rather make user to call
caplog.set_level() with an appropriate log level in _every_ test that
uses caplog.text.
