### PR TITLE
Add --generate-toml-config to output current settings in TOML format

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -27,7 +27,13 @@ from pydantic.json import custom_pydantic_encoder  # pylint: disable=no-name-in-
 from fawltydeps import extract_imports
 from fawltydeps.check import compare_imports_to_dependencies
 from fawltydeps.extract_declared_dependencies import extract_declared_dependencies
-from fawltydeps.settings import Action, OutputFormat, Settings, setup_cmdline_parser
+from fawltydeps.settings import (
+    Action,
+    OutputFormat,
+    Settings,
+    print_toml_config,
+    setup_cmdline_parser,
+)
 from fawltydeps.types import (
     DeclaredDependency,
     ParsedImport,
@@ -171,11 +177,21 @@ def main() -> int:
         default=Path("./pyproject.toml"),
         help="Where to find FawltyDeps config (default: ./pyproject.toml)",
     )
+    option_group.add_argument(
+        "--generate-toml-config",
+        action="store_true",
+        default=False,
+        help="Print a TOML config section with the current settings, and exit",
+    )
 
     args = parser.parse_args()
     settings = Settings.config(config_file=args.config_file).create(args)
 
     logging.basicConfig(level=logging.WARNING - 10 * settings.verbosity)
+
+    if args.generate_toml_config:
+        print_toml_config(settings, sys.stdout)
+        return 0
 
     try:
         analysis = Analysis.create(settings)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -834,6 +834,26 @@ def test_cmdline_on_ignored_undeclared_option(
             ],
             id="override_output_format_from_config_with_command_line_option",
         ),
+        pytest.param(
+            {"actions": ["list_imports"], "output_format": "json"},
+            ["--detailed", "--deps=foobar", "--generate-toml-config"],
+            dedent(
+                """\
+                # Copy this TOML section into your pyproject.toml to configure FawltyDeps
+                # (default values are commented)
+                [tool.fawltydeps]
+                actions = ['list_imports']
+                # code = '.'
+                deps = 'foobar'
+                output_format = 'human_detailed'
+                # ignore_undeclared = []
+                # ignore_unused = []
+                # deps_parser_choice = None
+                # verbosity = 0
+                """
+            ).splitlines(),
+            id="generate_toml_config_with_combo_of_config_and_cmdline_options",
+        ),
     ],
 )
 def test_cmdline_args_in_combination_with_config_file(


### PR DESCRIPTION
This allows a user to easily configure FawltyDeps by:
- iteratively tweaking the command-line options until they are happy
  with the output the FawltyDeps produces.
- then running with --generate-toml-config to print out an equivalent
  TOML-formatted [tool.fawltydeps] section.
- finally pasting this section into their pyproject.toml

There is no TOML-writing capability built in to the Python stdlib (or
tomli), but for the simple data we currently store in our
[tool.fawltydeps] section, we can get away with cheating a little bit:

- The JSON encoding of our Settings object is identical in structure to
  the TOML encoding we expect to read from [tool.fawltydeps], all we
  need to do is convert it to TOML _formatting_.
- As it happens, the TOML formatting (for our simple value types) are
  compatible with Python's own repr() encoding, AFAICS.
- Therefore we can go via the JSON representation and manually generate
  the relevant lines of TOML config, using repr() (aka the "{value!r}"
  placeholder in a format string).
- In addition, we can also keep track of which of the Settings members
  have their hardcoded default values, and which have been customized.
  We print the former as TOML comments, to communicate that setting
  these in the pyproject.toml will have no effect.

Also include a test that verifies the expected TOML output given a
combinations of config file settings and command-line arguments.
