### PR TITLE
Fix integration_tests-3.7 within nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
   pkgs ? import (builtins.fetchGit {
     url = "https://github.com/NixOS/nixpkgs/";
     ref = "nixos-22.11";
+    rev = "96e18717904dfedcd884541e5a92bf9ff632cf39";
   }) {}
 }:
 let


### PR DESCRIPTION
- `shell.nix`: Fix venv creation on python3.7
- `shell.nix`: Use same Python to provide Poetry and inside Poetry's venv
- `shell.nix`: Pin our nixpkgs version
