### PR TITLE
test_real_projects: Use context manager instead of autouse fixure

### DIFF
--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -193,7 +193,7 @@ class Experiment(NamedTuple):
         return venv_dir
 
     @contextmanager
-    def venv_dir_w_fawltydeps(self, cache: pytest.Cache) -> Iterator[Path]:
+    def venv_with_fawltydeps(self, cache: pytest.Cache) -> Iterator[Path]:
         """Provide this experiments's venv with FawltyDeps installed within.
 
         Provide a context in which the FawltyDeps version located in the current
@@ -364,7 +364,7 @@ class ThirdPartyProject(NamedTuple):
 )
 def test_real_project(request, project, experiment):
     project_dir = project.get_project_dir(request.config.cache)
-    with experiment.venv_dir_w_fawltydeps(request.config.cache) as venv_dir:
+    with experiment.venv_with_fawltydeps(request.config.cache) as venv_dir:
         analysis = run_fawltydeps_json(
             *experiment.args,
             venv_dir=venv_dir,


### PR DESCRIPTION
As part of each real_projects experiment, we need to install FD in
editable mode just before running the test, and uninstall it afterwards.
Until now this has been accomplished with an autouse fixture, but those
are a little too magic, IMHO, and it's clearer what is happening if we
instead use an explicit context manager to both do the setup/teardown of
the venv_dir-with-editable-install, as well as as the communication of
the actual venv_dir into the test case.

Fixes: #199
