### PR TITLE
Teach `packages.LocalPackageLookup` to look at other venvs

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -20,6 +20,7 @@ from operator import attrgetter
 from pathlib import Path
 from typing import Dict, List, Optional, TextIO, no_type_check
 
+import importlib_metadata
 from pydantic.json import custom_pydantic_encoder  # pylint: disable=no-name-in-module
 
 from fawltydeps import extract_imports
@@ -40,12 +41,6 @@ from fawltydeps.types import (
     UnparseablePathException,
     UnusedDependency,
 )
-
-if sys.version_info >= (3, 8):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
-
 
 logger = logging.getLogger(__name__)
 

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -4,6 +4,7 @@ import logging
 import sys
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import Dict, Iterable, Optional, Set
 
 # importlib_metadata is gradually graduating into the importlib.metadata stdlib
@@ -11,7 +12,13 @@ from typing import Dict, Iterable, Optional, Set
 # bugfixes that will first be available in the stdlib version in Python v3.12
 # (or even later). For now, it is safer for us to _pin_ the 3rd-party dependency
 # and use that across all of our supported Python versions.
-from importlib_metadata import packages_distributions
+from importlib_metadata import (
+    DistributionFinder,
+    MetadataPathFinder,
+    _top_level_declared,
+    _top_level_inferred,
+    packages_distributions,
+)
 
 from fawltydeps.utils import hide_dataclass_fields
 
@@ -98,25 +105,75 @@ class Package:
 class LocalPackageLookup:
     """Lookup import names exposed by packages installed in the current venv."""
 
-    def __init__(self) -> None:
-        """Collect packages installed in the current python environment.
+    def __init__(self, venv_path: Optional[Path] = None) -> None:
+        """Lookup packages installed in the given virtualenv.
 
-        Use importlib.metadata to look up the mapping between packages and their
-        provided import names. This obviously depends on the Python environment
-        (e.g. virtualenv) that we're calling from.
+        Default to the current python environment if `venv_path` is not given
+        (or None).
+
+        Use importlib_metadata to look up the mapping between packages and their
+        provided import names.
         """
-        # We call packages_distributions() only _once here, and build a cache of
-        # Package objects from the information extracted.
-        self.packages: Dict[str, Package] = {}
-        for import_name, package_names in packages_distributions().items():
-            for package_name in package_names:
-                package = self.packages.setdefault(
-                    Package.normalize_name(package_name),
-                    Package(package_name),
-                )
-                package.add_import_names(
-                    import_name, mapping=DependenciesMapping.LOCAL_ENV
-                )
+        if venv_path is not None and not (venv_path / "pyvenv.cfg").is_file():
+            raise ValueError(f"Not a virtualenv: {venv_path}/pyvenv.cfg missing!")
+
+        self.venv_path = venv_path
+        # We enumerate packages for venv_path _once_ and cache the result here:
+        self._packages: Optional[Dict[str, Package]] = None
+
+    @property
+    def packages(self) -> Dict[str, Package]:
+        """Return mapping of package names to Package objects for this venv.
+
+        This enumerates the available packages in the given virtualenv (or the
+        current Python environment) _once_, and caches the result for the
+        remainder of this object's life.
+        """
+        if self._packages is None:  # need to build cache
+            if self.venv_path is None:
+                paths = sys.path
+            else:
+                # Construct faux sys.path for the given venv_path. This must
+                # handle whatever supported Python version is used by the venv
+                paths = [
+                    str(p) for p in self.venv_path.glob("lib/python?.*/site-packages")
+                ]
+
+            self._packages = {}
+            # We're reaching into the internals of importlib_metadata here,
+            # which Mypy is not overly fond of. Roughly what we're doing here
+            # is calling packages_distributions(), but on a different venv.
+            # Note that packages_distributions() is not able to return packages
+            # that map to zero import names.
+            context = DistributionFinder.Context(path=paths)  # type: ignore
+            for dist in MetadataPathFinder().find_distributions(context):  # type: ignore
+                imports = set(_top_level_declared(dist) or _top_level_inferred(dist))  # type: ignore
+                package = Package(dist.name, {DependenciesMapping.LOCAL_ENV: imports})
+                self._packages[Package.normalize_name(dist.name)] = package
+
+            # Double-check against packages_distributions()
+            if self.venv_path is None:
+                verify: Dict[str, Package] = {}
+                for import_name, package_names in packages_distributions().items():
+                    for package_name in package_names:
+                        package = verify.setdefault(
+                            Package.normalize_name(package_name),
+                            Package(package_name),
+                        )
+                        package.add_import_names(
+                            import_name, mapping=DependenciesMapping.LOCAL_ENV
+                        )
+
+                # Note that packages_distributions() is not able to return packages
+                # that map to zero import names.
+                for name, package in self._packages.items():
+                    if name not in verify:
+                        assert not package.import_names  # No import names!
+                        verify[name] = package
+
+                assert self._packages == verify
+
+        return self._packages
 
     def lookup_package(self, package_name: str) -> Optional[Package]:
         """Convert a package name to a locally available Package object.

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -6,15 +6,14 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Iterable, Optional, Set
 
-from fawltydeps.utils import hide_dataclass_fields
+# importlib_metadata is gradually graduating into the importlib.metadata stdlib
+# module, however we rely on internal functions and recent (and upcoming)
+# bugfixes that will first be available in the stdlib version in Python v3.12
+# (or even later). For now, it is safer for us to _pin_ the 3rd-party dependency
+# and use that across all of our supported Python versions.
+from importlib_metadata import packages_distributions
 
-# importlib.metadata.packages_distributions() was introduced in v3.10, but it
-# is not able to infer import names for modules lacking a top_level.txt until
-# v3.11. Hence we prefer importlib_metadata in v3.10 as well as pre-v3.10.
-if sys.version_info >= (3, 11):
-    from importlib.metadata import packages_distributions
-else:
-    from importlib_metadata import packages_distributions
+from fawltydeps.utils import hide_dataclass_fields
 
 logger = logging.getLogger(__name__)
 

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -147,7 +147,10 @@ class LocalPackageLookup:
             # that map to zero import names.
             context = DistributionFinder.Context(path=paths)  # type: ignore
             for dist in MetadataPathFinder().find_distributions(context):  # type: ignore
-                imports = set(_top_level_declared(dist) or _top_level_inferred(dist))  # type: ignore
+                imports = set(
+                    _top_level_declared(dist)  # type: ignore
+                    or _top_level_inferred(dist)  # type: ignore
+                )
                 package = Package(dist.name, {DependenciesMapping.LOCAL_ENV: imports})
                 self._packages[Package.normalize_name(dist.name)] = package
 

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -17,7 +17,6 @@ from importlib_metadata import (
     MetadataPathFinder,
     _top_level_declared,
     _top_level_inferred,
-    packages_distributions,
 )
 
 from fawltydeps.utils import hide_dataclass_fields
@@ -153,28 +152,6 @@ class LocalPackageLookup:
                 )
                 package = Package(dist.name, {DependenciesMapping.LOCAL_ENV: imports})
                 self._packages[Package.normalize_name(dist.name)] = package
-
-            # Double-check against packages_distributions()
-            if self.venv_path is None:
-                verify: Dict[str, Package] = {}
-                for import_name, package_names in packages_distributions().items():
-                    for package_name in package_names:
-                        package = verify.setdefault(
-                            Package.normalize_name(package_name),
-                            Package(package_name),
-                        )
-                        package.add_import_names(
-                            import_name, mapping=DependenciesMapping.LOCAL_ENV
-                        )
-
-                # Note that packages_distributions() is not able to return packages
-                # that map to zero import names.
-                for name, package in self._packages.items():
-                    if name not in verify:
-                        assert not package.import_names  # No import names!
-                        verify[name] = package
-
-                assert self._packages == verify
 
         return self._packages
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -184,7 +184,7 @@ zoneinfo = ["backports.zoneinfo (>=0.2.1)", "tzdata (>=2022.7)"]
 
 [[package]]
 name = "importlib-metadata"
-version = "5.2.0"
+version = "6.0.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -492,7 +492,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "d36edd5fc860adac0655639c67425e6a0447643fe3eb3f6dd4949a379b490ea4"
+content-hash = "4da0eb19ae7cde47836dc6301cf257e6b061419a17faca54af4d118ddf2a0ae9"
 
 [metadata.files]
 argcomplete = [
@@ -558,8 +558,8 @@ hypothesis = [
     {file = "hypothesis-6.68.2.tar.gz", hash = "sha256:a7eb2b0c9a18560d8197fe35047ceb58e7e8ab7623a3e5a82613f6a2cd71cffa"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-5.2.0-py3-none-any.whl", hash = "sha256:0eafa39ba42bf225fc00e67f701d71f85aead9f878569caf13c3724f704b970f"},
-    {file = "importlib_metadata-5.2.0.tar.gz", hash = "sha256:404d48d62bba0b7a77ff9d405efd91501bef2e67ff4ace0bed40a0cf28c3c7cd"},
+    {file = "importlib_metadata-6.0.0-py3-none-any.whl", hash = "sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad"},
+    {file = "importlib_metadata-6.0.0.tar.gz", hash = "sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d"},
 ]
 iniconfig = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ fawltydeps = "fawltydeps.main:main"
 # These are the main dependencies for fawltydeps at runtime.
 # Do not add anything here that is only needed by CI/tests/linters/developers
 python = "^3.7.2"
-importlib_metadata = {version = "^5.0.0", python = "<3.11"}
+importlib_metadata = "^6.0.0"
 isort = "^5.10"
 pydantic = "^1.10.4"
 tomli = {version = "^2.0.1", python = "<3.11"}

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -1,0 +1,47 @@
+"""Verify behavior of LocalPackageLookup looking at a given venv."""
+
+import venv
+
+from fawltydeps.packages import DependenciesMapping, LocalPackageLookup
+
+
+def test_local_env__empty_venv__has_no_packages(tmp_path):
+    venv.create(tmp_path, with_pip=False)
+    lpl = LocalPackageLookup(tmp_path)
+    assert lpl.packages == {}
+
+
+def test_local_env__default_venv__contains_pip_and_setuptools(tmp_path):
+    venv.create(tmp_path, with_pip=True)
+    lpl = LocalPackageLookup(tmp_path)
+    # We cannot do a direct comparison, as different Python/pip/setuptools
+    # versions differ in exactly which packages are provided. The following
+    # is a subset that we can expect across all of our supported versions.
+    expect = {  # package name -> (subset of) provided import names
+        "pip": {"pip"},
+        "setuptools": {"setuptools", "pkg_resources"},
+    }
+    for package_name, import_names in expect.items():
+        assert package_name in lpl.packages
+        p = lpl.packages[package_name]
+        assert package_name == p.package_name
+        assert len(p.mappings) == 1
+        assert DependenciesMapping.LOCAL_ENV in p.mappings
+        assert import_names.issubset(p.mappings[DependenciesMapping.LOCAL_ENV])
+
+
+def test_local_env__current_venv__contains_our_test_dependencies():
+    lpl = LocalPackageLookup()
+    expect_package_names = [
+        # Present in all venvs:
+        "pip",
+        "setuptools",
+        # FawltyDeps main deps
+        "isort",
+        "pydantic",
+        # Test dependencies
+        "hypothesis",
+        "pytest",
+    ]
+    for package_name in expect_package_names:
+        assert package_name in lpl.packages


### PR DESCRIPTION
This is the most basic building block towards decoupling the venv that FawltyDeps is installed in, from the venv that FawltyDeps is run against. From this we can work towards several goals in future PRs:
- No longer require `pip install fawltydeps` into your project's venv, but instead e.g. `pipx install fawltydeps` to make FD available to all your projects.
- Pass `--venv` as a command line option
- Passing more than one venv
- Auto-detecting and adding venvs under `basepath` (i.e. make `--venv` somewhat similar to `--code` and `--deps`)
- Supporting a first approximation to using PyPI, by downloading/installing packages from PyPI into a temporary venv, and then pointing FD at that venv.
- Changing our `real_projects` tests to no longer have to install/uninstall FD in the experiment's venv.

This PR is directly relevant to #161, and as such is also related to task 2 in the roadmap: #195. As far as #142 is still relevant, I suspect this might go a way towards fixing that as well. Furthermore, revisiting https://github.com/tweag/FawltyDeps/issues/187 is probably warranted after this PR is merged.

Commits:
- `pyproject.toml`: Use latest `importlib_metadata` across all Python versions
- Use `importlib_metadata` instead of `importlib.metadata` everywhere
- `packages`: Teach `LocalPackageLookup` to start looking at other venvs
- `test_real_projects`: Verify that all requirements are present
- `packages.LocalPackageLookup`: Remove redundant sanity check