### PR TITLE
Fix reference to GIF when this document is rendered elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A dependency checker for Python.
 
 Find _undeclared_ and/or _unused_ 3rd-party dependencies in your Python project.
 
-![FawltyDeps demo](./docs/fawltydeps_demo_tqdm.gif)
+![FawltyDeps demo](https://github.com/tweag/FawltyDeps/raw/main/docs/fawltydeps_demo_tqdm.gif)
 
 ## Table of contents
 


### PR DESCRIPTION
The GIF shows up nicely on the repo page, but does not render from e.g. our PyPI page: https://pypi.org/project/fawltydeps/

Try to fix that with an absolute URL reference