### PR TITLE
Add `--venv` option to CLI

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -107,7 +107,8 @@ class Analysis:
             assert ret.imports is not None  # convince Mypy that these cannot
             assert ret.declared_deps is not None  # be None at this time.
             ret.resolved_deps = resolve_dependencies(
-                dep.name for dep in ret.declared_deps
+                (dep.name for dep in ret.declared_deps),
+                venv_path=settings.venv,
             )
 
         if ret.is_enabled(Action.REPORT_UNDECLARED):

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -173,18 +173,24 @@ class LocalPackageLookup:
         return self.packages.get(Package.normalize_name(package_name))
 
 
-def resolve_dependencies(dep_names: Iterable[str]) -> Dict[str, Package]:
+def resolve_dependencies(
+    dep_names: Iterable[str], venv_path: Optional[Path] = None
+) -> Dict[str, Package]:
     """Associate dependencies with corresponding Package objects.
 
     Use LocalPackageLookup to find Package objects for each of the given
-    dependencies. For dependencies that cannot be found with LocalPackageLookup,
+    dependencies inside the virtualenv given by 'venv_path'. When 'venv_path' is
+    None (the default), look for packages in the current Python environment
+    (i.e. equivalent to sys.path).
+
+    For dependencies that cannot be found with LocalPackageLookup,
     fabricate an identity mapping (a pseudo-package making available an import
     of the same name as the package, modulo normalization).
 
     Return a dict mapping dependency names to the resolved Package objects.
     """
     ret = {}
-    local_packages = LocalPackageLookup()
+    local_packages = LocalPackageLookup(venv_path)
     for name in dep_names:
         if name not in ret:
             package = local_packages.lookup_package(name)

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -120,6 +120,7 @@ class Settings(BaseSettings):  # type: ignore
     actions: Set[Action] = {Action.REPORT_UNDECLARED, Action.REPORT_UNUSED}
     code: Set[PathOrSpecial] = {Path(".")}
     deps: Set[Path] = {Path(".")}
+    venv: Optional[Path] = None
     output_format: OutputFormat = OutputFormat.HUMAN_SUMMARY
     ignore_undeclared: Set[str] = set()
     ignore_unused: Set[str] = set()
@@ -323,6 +324,16 @@ def populate_parser_options(parser: argparse._ActionsContainer) -> None:
         help=(
             "Where to find dependency declarations (file or directory, defaults"
             " to looking for supported files in the current directory)"
+        ),
+    )
+    parser.add_argument(
+        "--venv",
+        type=Path,
+        metavar="VENV_DIR",
+        help=(
+            "Where to find a virtualenv that has the project dependencies"
+            " installed, defaults to the Python environment where FawltyDeps is"
+            " installed."
         ),
     )
     parser.add_argument(

--- a/noxfile.py
+++ b/noxfile.py
@@ -81,7 +81,7 @@ def lint(session):
     session.run("pylint", "fawltydeps")
     session.run(
         "pylint",
-        "--disable=missing-function-docstring,invalid-name,redefined-outer-name",
+        "--disable=missing-function-docstring,invalid-name,redefined-outer-name,too-many-lines",
         "tests",
     )
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -121,6 +121,7 @@ def test_list_imports_json__from_py_file__prints_imports_from_file(write_tmp_fil
             "actions": ["list_imports"],
             "code": [f"{tmp_path}/myfile.py"],
             "deps": ["."],
+            "venv": None,
             "output_format": "json",
             "ignore_undeclared": [],
             "ignore_unused": [],
@@ -307,6 +308,7 @@ def test_list_deps_json__dir__prints_deps_from_requirements_txt(
             "actions": ["list_deps"],
             "code": ["."],
             "deps": [f"{tmp_path}"],
+            "venv": None,
             "output_format": "json",
             "ignore_undeclared": [],
             "ignore_unused": [],
@@ -570,6 +572,7 @@ def test_check_json__simple_project__can_report_both_undeclared_and_unused(
             "actions": ["check_undeclared", "check_unused"],
             "code": [f"{tmp_path}"],
             "deps": [f"{tmp_path}"],
+            "venv": None,
             "output_format": "json",
             "ignore_undeclared": [],
             "ignore_unused": [],
@@ -758,6 +761,25 @@ def test__quiet_check__writes_only_names_of_unused_and_undeclared(
     assert returncode == 3
 
 
+def test_check__simple_project_in_fake_venv__resolves_imports_vs_deps(
+    fake_venv, project_with_code_and_requirements_txt
+):
+    tmp_path = project_with_code_and_requirements_txt(
+        imports=["requests"],
+        declares=["pandas"],
+    )
+    # A venv where the "pandas" package provides a "requests" import name
+    # should satisfy our comparison
+    venv_dir = fake_venv({"pandas": {"requests"}})
+
+    output, errors, returncode = run_fawltydeps(
+        "--detailed", f"--code={tmp_path}", f"--deps={tmp_path}", f"--venv={venv_dir}"
+    )
+    assert output.splitlines() == [SUCCESS_MESSAGE]
+    assert errors == ""
+    assert returncode == 0
+
+
 @pytest.mark.parametrize(
     "args,imports,dependencies,expected",
     [
@@ -897,6 +919,7 @@ def test_cmdline_on_ignored_undeclared_option(
                 actions = ['list_imports']
                 # code = ['.']
                 deps = ['foobar']
+                # venv = None
                 output_format = 'human_detailed'
                 # ignore_undeclared = []
                 # ignore_unused = []

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -23,6 +23,7 @@ EXPECT_DEFAULTS = dict(
     actions={Action.REPORT_UNDECLARED, Action.REPORT_UNUSED},
     code={Path(".")},
     deps={Path(".")},
+    venv=None,
     output_format=OutputFormat.HUMAN_SUMMARY,
     ignore_undeclared=set(),
     ignore_unused=set(),


### PR DESCRIPTION
Depends on #215.

- `packages`: Add `venv_path` argument to `resolve_dependencies()`
- Add `venv` setting and `--venv` command-line option
- `test_real_projects`: Use `--venv` instead of editable install of FD
