### PR TITLE
Leverage existing requirements.txt parsing logic to close #225

### DIFF
--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -6,12 +6,11 @@ import logging
 import re
 import sys
 from dataclasses import replace
-from functools import partial
-from itertools import takewhile
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Callable, Iterable, Iterator, NamedTuple, Optional, Set, Tuple
 
+from pip_requirements_parser import RequirementsFile  # type: ignore
 from pkg_resources import Requirement
 
 from fawltydeps.limited_eval import CannotResolve, VariableTracker
@@ -32,13 +31,6 @@ else:
 logger = logging.getLogger(__name__)
 
 ERROR_MESSAGE_TEMPLATE = "Failed to %s %s %s dependencies in %s: %s"
-# https://pip.pypa.io/en/stable/reference/requirements-file-format/#per-requirement-options
-PER_REQUIREMENT_OPTIONS = [
-    "--install-option",
-    "--global-option",
-    "--config-setting",
-    "--hash",
-]
 
 NamedLocations = Iterator[Tuple[str, Location]]
 
@@ -66,30 +58,9 @@ def parse_requirements_txt(path: Path) -> Iterator[DeclaredDependency]:
     https://pip.pypa.io/en/stable/reference/requirements-file-format/.
     """
     source = Location(path)
-    parse_one = partial(parse_one_req, source=source)
-    for line in path.read_text().splitlines():
-        cleaned = line.lstrip()
-        if (
-            not cleaned  # skip empty lines
-            or cleaned.startswith(("-", "#"))  # skip options and comments
-            or ("://" in line.split()[0])  # skip bare URLs at the start of line
-        ):
-            continue
-        try:
-            yield parse_one(line)
-        except ValueError:
-            # Try again with the initial part of the line preceding any of the
-            # PER_REQUIREMENT_OPTIONS
-            pre_opt_words = takewhile(
-                lambda word: not any(
-                    word.startswith(opt) for opt in PER_REQUIREMENT_OPTIONS
-                ),
-                cleaned.split(),
-            )
-            try:
-                yield parse_one(" ".join(pre_opt_words))
-            except ValueError as exc:
-                logger.warning(f"Could not parse {source} line {line!r}: {exc}")
+    for dep in RequirementsFile.from_file(path).requirements:
+        if dep.name:
+            yield DeclaredDependency(dep.name, source)
 
 
 def parse_setup_py(path: Path) -> Iterator[DeclaredDependency]:

--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -143,7 +143,10 @@ def parse_setup_cfg(path: Path) -> Iterator[DeclaredDependency]:
         return
 
     def parse_value(value: str) -> Iterator[DeclaredDependency]:
-        # Ugly hack since parse_requirements_txt() accepts only a path:
+        # Ugly hack since parse_requirements_txt() accepts only a path.
+        # TODO: try leveraging RequirementsFile.from_string once
+        #       pip-requirements-parser updates.
+        # See:  https://github.com/nexB/pip-requirements-parser/pull/17
         with NamedTemporaryFile(mode="wt") as tmp:
             tmp.write(value)
             tmp.flush()

--- a/poetry.lock
+++ b/poetry.lock
@@ -288,7 +288,7 @@ tox-to-nox = ["jinja2", "tox"]
 name = "packaging"
 version = "23.0"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -299,6 +299,22 @@ description = "Utility library for gitignore style pattern matching of file path
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+description = "pip requirements parser - a mostly correct pip requirements parsing library because it uses pip's own code."
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.dependencies]
+packaging = "*"
+pyparsing = "*"
+
+[package.extras]
+docs = ["Sphinx (>=3.3.1)", "doc8 (>=0.8.1)", "sphinx-rtd-theme (>=0.5.0)"]
+testing = ["aboutcode-toolkit (>=6.0.0)", "black", "pytest (>=6,!=7.0.0)", "pytest-xdist (>=2)"]
 
 [[package]]
 name = "platformdirs"
@@ -370,6 +386,17 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 [package.extras]
 spelling = ["pyenchant (>=3.2,<4.0)"]
 testutils = ["gitpython (>3)"]
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "main"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -492,7 +519,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "4da0eb19ae7cde47836dc6301cf257e6b061419a17faca54af4d118ddf2a0ae9"
+content-hash = "dc229546d6dc7dc532137acd8ad3f71920fd90853f7eeb65a1aba96ce9383054"
 
 [metadata.files]
 argcomplete = [
@@ -659,6 +686,10 @@ pathspec = [
     {file = "pathspec-0.11.0-py3-none-any.whl", hash = "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229"},
     {file = "pathspec-0.11.0.tar.gz", hash = "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"},
 ]
+pip-requirements-parser = [
+    {file = "pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3"},
+    {file = "pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526"},
+]
 platformdirs = [
     {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
     {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
@@ -708,6 +739,10 @@ pydantic = [
 pylint = [
     {file = "pylint-2.15.10-py3-none-any.whl", hash = "sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e"},
     {file = "pylint-2.15.10.tar.gz", hash = "sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pytest = [
     {file = "pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ fawltydeps = "fawltydeps.main:main"
 python = "^3.7.2"
 importlib_metadata = "^6.0.0"
 isort = "^5.10"
+pip-requirements-parser = "^32.0.1"
 pydantic = "^1.10.4"
 tomli = {version = "^2.0.1", python = "<3.11"}
 typing-extensions = {version = "^4.4.0", python = "<3.8"}

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -71,6 +71,14 @@ def dependency_factory(data: List[str], path: str) -> List[DeclaredDependency]:
             ["click"],
             id="requirements_with_option__ignores_option_Issue200",
         ),
+        pytest.param(
+            """\
+            black == 23.1.0 \
+                --hash=sha256:0052dba51dec07ed029ed61b18183942043e00008ec65d5028814afaab9a22fd
+            """,
+            ["black"],
+            id="per_req_option_not_on_same_line__parses_properly_Issue225",
+        ),
     ],
 )
 def test_parse_requirements_txt(write_tmp_files, file_content, expect_deps):


### PR DESCRIPTION
Once https://github.com/nexB/pip-requirements-parser/pull/17 is merged, we could more directly use `pip-requirements-parser` (namely, the `RequirementsParser.from_string` method). Until then, this works around a `NameError` that comes up when using the less common `from_string` method in the `RequirementsFile` class in that project.