### PR TITLE
Refactor `extract_declared_dependencies` parser APIs in preparation for #227

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -81,7 +81,7 @@ def lint(session):
     session.run("pylint", "fawltydeps")
     session.run(
         "pylint",
-        "--disable=missing-function-docstring,invalid-name,redefined-outer-name,too-many-lines",
+        "--disable=missing-function-docstring,invalid-name,redefined-outer-name,too-many-lines,too-many-arguments",
         "tests",
     )
 

--- a/tests/test_extract_declared_dependencies_errors.py
+++ b/tests/test_extract_declared_dependencies_errors.py
@@ -6,8 +6,8 @@ import pytest
 
 from fawltydeps.extract_declared_dependencies import (
     extract_declared_dependencies,
-    parse_setup_cfg_contents,
-    parse_setup_contents,
+    parse_setup_cfg,
+    parse_setup_py,
 )
 from fawltydeps.types import Location, UnparseablePathException
 
@@ -23,7 +23,7 @@ def test_extract_declared_dependencies__unsupported_file__raises_error(
         )
 
 
-def test_parse_setup_cfg_contents__malformed__logs_error(write_tmp_files, caplog):
+def test_parse_setup_cfg__malformed__logs_error(write_tmp_files, caplog):
     tmp_path = write_tmp_files(
         {
             "setup.cfg": """\
@@ -37,7 +37,7 @@ def test_parse_setup_cfg_contents__malformed__logs_error(write_tmp_files, caplog
     caplog.set_level(logging.ERROR)
 
     path = tmp_path / "setup.cfg"
-    result = list(parse_setup_cfg_contents(path))
+    result = list(parse_setup_cfg(path))
     assert f"Could not parse contents of `{Location(path)}`" in caplog.text
     assert expected == result
 
@@ -124,14 +124,14 @@ def test_parse_setup_cfg_contents__malformed__logs_error(write_tmp_files, caplog
         ),
     ],
 )
-def test_parse_setup_contents__cannot_parse__logs_warning(
+def test_parse_setup_py__cannot_parse__logs_warning(
     write_tmp_files, caplog, code, expect, fail_arg
 ):
     tmp_path = write_tmp_files({"setup.py": code})
     path = tmp_path / "setup.py"
 
     caplog.set_level(logging.WARNING)
-    result = list(parse_setup_contents(path))
+    result = list(parse_setup_py(path))
     assert f"Could not parse contents of `{fail_arg}`" in caplog.text
     assert str(path) in caplog.text
     assert expect == result

--- a/tests/test_extract_declared_dependencies_errors.py
+++ b/tests/test_extract_declared_dependencies_errors.py
@@ -1,8 +1,6 @@
 """Test unhappy path, where parsing of dependencies fails"""
 
 import logging
-from pathlib import Path
-from textwrap import dedent
 
 import pytest
 
@@ -25,20 +23,22 @@ def test_extract_declared_dependencies__unsupported_file__raises_error(
         )
 
 
-def test_parse_setup_cfg_contents__malformed__logs_error(caplog):
-    setup_contents = dedent(
-        """\
-        [options
-        install_requires =
-            pandas
-        """
+def test_parse_setup_cfg_contents__malformed__logs_error(write_tmp_files, caplog):
+    tmp_path = write_tmp_files(
+        {
+            "setup.cfg": """\
+                [options
+                install_requires =
+                    pandas
+                """,
+        }
     )
     expected = []
     caplog.set_level(logging.ERROR)
 
-    source = Location(Path("setup.cfg"))
-    result = list(parse_setup_cfg_contents(setup_contents, source))
-    assert f"Could not parse contents of `{source}`" in caplog.text
+    path = tmp_path / "setup.cfg"
+    result = list(parse_setup_cfg_contents(path))
+    assert f"Could not parse contents of `{Location(path)}`" in caplog.text
     assert expected == result
 
 
@@ -125,10 +125,13 @@ def test_parse_setup_cfg_contents__malformed__logs_error(caplog):
     ],
 )
 def test_parse_setup_contents__cannot_parse__logs_warning(
-    caplog, code, expect, fail_arg
+    write_tmp_files, caplog, code, expect, fail_arg
 ):
+    tmp_path = write_tmp_files({"setup.py": code})
+    path = tmp_path / "setup.py"
+
     caplog.set_level(logging.WARNING)
-    result = list(parse_setup_contents(dedent(code), Location(Path("setup.py"))))
+    result = list(parse_setup_contents(path))
     assert f"Could not parse contents of `{fail_arg}`" in caplog.text
-    assert "setup.py" in caplog.text
+    assert str(path) in caplog.text
     assert expect == result

--- a/tests/test_extract_declared_dependencies_pyproject_toml.py
+++ b/tests/test_extract_declared_dependencies_pyproject_toml.py
@@ -3,7 +3,7 @@ import logging
 
 import pytest
 
-from fawltydeps.extract_declared_dependencies import parse_pyproject_contents
+from fawltydeps.extract_declared_dependencies import parse_pyproject_toml
 from fawltydeps.types import DeclaredDependency, Location
 
 
@@ -158,13 +158,13 @@ from fawltydeps.types import DeclaredDependency, Location
         ),
     ],
 )
-def test_parse_pyproject_content__pep621_or_poetry_dependencies__yields_dependencies(
+def test_parse_pyproject_toml__pep621_or_poetry_dependencies__yields_dependencies(
     write_tmp_files, pyproject_toml, expected_deps
 ):
     tmp_path = write_tmp_files({"pyproject.toml": pyproject_toml})
     path = tmp_path / "pyproject.toml"
 
-    result = list(parse_pyproject_contents(path))
+    result = list(parse_pyproject_toml(path))
     expected = [DeclaredDependency(dep, Location(path)) for dep in expected_deps]
     assert result == expected
 
@@ -270,7 +270,7 @@ def test_parse_pyproject_content__malformatted_poetry_dependencies__yields_no_de
     path = tmp_path / "pyproject.toml"
 
     caplog.set_level(logging.ERROR)
-    result = list(parse_pyproject_contents(path))
+    result = list(parse_pyproject_toml(path))
     assert result == expected
     for field_type in field_types:
         assert (
@@ -308,14 +308,14 @@ def test_parse_pyproject_content__malformatted_poetry_dependencies__yields_no_de
         ),
     ],
 )
-def test_parse_pyproject_contents__missing_dependencies__logs_debug_message(
+def test_parse_pyproject_toml__missing_dependencies__logs_debug_message(
     write_tmp_files, caplog, tmp_path, pyproject_toml, expected, expected_logs
 ):
     tmp_path = write_tmp_files({"pyproject.toml": pyproject_toml})
     path = tmp_path / "pyproject.toml"
 
     caplog.set_level(logging.DEBUG)
-    result = list(parse_pyproject_contents(path))
+    result = list(parse_pyproject_toml(path))
     assert expected == result
     for metadata_standard, field_type in expected_logs:
         assert (

--- a/tests/test_extract_declared_dependencies_pyproject_toml.py
+++ b/tests/test_extract_declared_dependencies_pyproject_toml.py
@@ -1,6 +1,5 @@
 """Test extracting dependencies from pyproject.toml"""
 import logging
-from textwrap import dedent
 
 import pytest
 
@@ -12,70 +11,62 @@ from fawltydeps.types import DeclaredDependency, Location
     "pyproject_toml,expected_deps",
     [
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
+            """\
+            [tool.poetry]
 
-                [tool.poetry.dependencies]
-                python = "^3.8"
-                isort = "^5.10"
-                tomli = "^2.0.1"
-                """
-            ),
+            [tool.poetry.dependencies]
+            python = "^3.8"
+            isort = "^5.10"
+            tomli = "^2.0.1"
+            """,
             ["isort", "tomli"],
             id="poetry_main_dependencies",
         ),
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
+            """\
+            [tool.poetry]
 
-                [tool.poetry.group.dev.dependencies]
-                black = "^22"
-                mypy = "^0.991"
+            [tool.poetry.group.dev.dependencies]
+            black = "^22"
+            mypy = "^0.991"
 
-                [tool.poetry.group.test.dependencies]
-                pytest = "^5.0.0"
-                """
-            ),
+            [tool.poetry.group.test.dependencies]
+            pytest = "^5.0.0"
+            """,
             ["black", "mypy", "pytest"],
             id="poetry_group_dependencies",
         ),
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
+            """\
+            [tool.poetry]
 
-                [tool.poetry.extras]
-                test = ["pytest < 5.0.0", "pytest-cov[all]"]
-                dev = ["pylint >= 2.15.8"]
-                """
-            ),
+            [tool.poetry.extras]
+            test = ["pytest < 5.0.0", "pytest-cov[all]"]
+            dev = ["pylint >= 2.15.8"]
+            """,
             ["pytest", "pytest-cov", "pylint"],
             id="poetry_extra_dependencies",
         ),
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
+            """\
+            [tool.poetry]
 
-                [tool.poetry.dependencies]
-                python = "^3.8"
-                isort = "^5.10"
-                tomli = "^2.0.1"
+            [tool.poetry.dependencies]
+            python = "^3.8"
+            isort = "^5.10"
+            tomli = "^2.0.1"
 
-                [tool.poetry.group.dev.dependencies]
-                black = "^22"
-                mypy = "^0.991"
+            [tool.poetry.group.dev.dependencies]
+            black = "^22"
+            mypy = "^0.991"
 
-                [tool.poetry.group.experimental.dependencies]
-                django = "^2.1"
+            [tool.poetry.group.experimental.dependencies]
+            django = "^2.1"
 
-                [tool.poetry.extras]
-                test = ["pytest < 5.0.0", "pytest-cov[all]"]
-                dev = ["pylint >= 2.15.8"]
-                """
-            ),
+            [tool.poetry.extras]
+            test = ["pytest < 5.0.0", "pytest-cov[all]"]
+            dev = ["pylint >= 2.15.8"]
+            """,
             [
                 "isort",
                 "tomli",
@@ -89,75 +80,67 @@ from fawltydeps.types import DeclaredDependency, Location
             id="poetry_main_group_and_extra_dependencies",
         ),
         pytest.param(
-            dedent(
-                """\
-                [project]
-                name = "fawltydeps"
+            """\
+            [project]
+            name = "fawltydeps"
 
-                dependencies = ["isort", "django>2.1; os_name != 'nt'"]
-                """
-            ),
+            dependencies = ["isort", "django>2.1; os_name != 'nt'"]
+            """,
             ["isort", "django"],
             id="pep621_main_dependencies",
         ),
         pytest.param(
-            dedent(
-                """\
-                [project]
+            """\
+            [project]
 
-                [project.optional-dependencies]
-                test = ["pytest < 5.0.0", "pytest-cov[all]"]
-                dev = ["pylint >= 2.15.8"]
-                """
-            ),
+            [project.optional-dependencies]
+            test = ["pytest < 5.0.0", "pytest-cov[all]"]
+            dev = ["pylint >= 2.15.8"]
+            """,
             ["pytest", "pytest-cov", "pylint"],
             id="pep621_optional_dependencies",
         ),
         pytest.param(
-            dedent(
-                """\
-                [project]
-                name = "fawltydeps"
+            """\
+            [project]
+            name = "fawltydeps"
 
-                dependencies = ["isort", "django>2.1; os_name != 'nt'"]
+            dependencies = ["isort", "django>2.1; os_name != 'nt'"]
 
-                [project.optional-dependencies]
-                test = ["pytest < 5.0.0", "pytest-cov[all]"]
-                dev = ["pylint >= 2.15.8"]
-                """
-            ),
+            [project.optional-dependencies]
+            test = ["pytest < 5.0.0", "pytest-cov[all]"]
+            dev = ["pylint >= 2.15.8"]
+            """,
             ["isort", "django", "pytest", "pytest-cov", "pylint"],
             id="pep_621_main_and_optional_dependencies",
         ),
         pytest.param(
-            dedent(
-                """\
-                [project]
-                name = "fawltydeps"
+            """\
+            [project]
+            name = "fawltydeps"
 
-                dependencies = ["pandas", "pydantic>1.10.4"]
+            dependencies = ["pandas", "pydantic>1.10.4"]
 
-                [project.optional-dependencies]
-                dev = ["pylint >= 2.15.8"]
+            [project.optional-dependencies]
+            dev = ["pylint >= 2.15.8"]
 
-                [tool.poetry]
-                [tool.poetry.dependencies]
-                python = "^3.8"
-                isort = "^5.10"
-                tomli = "^2.0.1"
+            [tool.poetry]
+            [tool.poetry.dependencies]
+            python = "^3.8"
+            isort = "^5.10"
+            tomli = "^2.0.1"
 
-                [tool.poetry.group.dev.dependencies]
-                black = "^22"
-                mypy = "^0.991"
+            [tool.poetry.group.dev.dependencies]
+            black = "^22"
+            mypy = "^0.991"
 
-                [tool.poetry.group.experimental.dependencies]
-                django = "^2.1"
+            [tool.poetry.group.experimental.dependencies]
+            django = "^2.1"
 
-                [tool.poetry.extras]
-                alpha = ["pytorch < 1.12.1", "numpy >= 1.17.2"]
-                dev = ["flake >= 5.0.1"]
-                """
-            ),
+            [tool.poetry.extras]
+            alpha = ["pytorch < 1.12.1", "numpy >= 1.17.2"]
+            dev = ["flake >= 5.0.1"]
+            """,
             [
                 "pandas",
                 "pydantic",
@@ -190,105 +173,89 @@ def test_parse_pyproject_content__pep621_or_poetry_dependencies__yields_dependen
     "pyproject_toml,expected,metadata_standard,field_types",
     [
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
-                dependencies = ["pylint"]
-                """
-            ),
+            """\
+            [tool.poetry]
+            dependencies = ["pylint"]
+            """,
             [],
             "Poetry",
             ["main"],
             id="poetry_dependencies_as_one_element_list",
         ),
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
-                dependencies = "pylint"
-                """
-            ),
+            """\
+            [tool.poetry]
+            dependencies = "pylint"
+            """,
             [],
             "Poetry",
             ["main"],
             id="poetry_dependencies_as_str",
         ),
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
-                [tool.poetry.group.dev]
-                dependencies = ["black > 22", "mypy"]
-                """
-            ),
+            """\
+            [tool.poetry]
+            [tool.poetry.group.dev]
+            dependencies = ["black > 22", "mypy"]
+            """,
             [],
             "Poetry",
             ["group"],
             id="poetry_dependencies_as_list",
         ),
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
-                [tool.poetry.extras]
-                test = "pytest"
-                """
-            ),
+            """\
+            [tool.poetry]
+            [tool.poetry.extras]
+            test = "pytest"
+            """,
             [],
             "Poetry",
             ["extra"],
             id="poetry_extra_requirements_as_str_instead_of_list",
         ),
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
-                extras = ["pytest"]
-                """
-            ),
+            """\
+            [tool.poetry]
+            extras = ["pytest"]
+            """,
             [],
             "Poetry",
             ["extra"],
             id="poetry_extra_requirements_as_list_instead_of_dict",
         ),
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
+            """\
+            [tool.poetry]
 
-                dependencies = ["pylint"]
+            dependencies = ["pylint"]
 
-                [tool.poetry.group.dev]
-                dependencies = ["black > 22", "mypy"]
+            [tool.poetry.group.dev]
+            dependencies = ["black > 22", "mypy"]
 
-                [tool.poetry.extras]
-                black = "^22"
-                """
-            ),
+            [tool.poetry.extras]
+            black = "^22"
+            """,
             [],
             "Poetry",
             ["main", "group", "extra"],
             id="poetry_all_dependencies_malformatted",
         ),
         pytest.param(
-            dedent(
-                """\
-                [project.dependencies]
-                pylint = ""
-                """
-            ),
+            """\
+            [project.dependencies]
+            pylint = ""
+            """,
             [],
             "PEP621",
             ["main"],
             id="pep621_dependencies_as_dict_instead_of_list",
         ),
         pytest.param(
-            dedent(
-                """\
-                [project]
-                optional-dependencies = ["pylint"]
-                """
-            ),
+            """\
+            [project]
+            optional-dependencies = ["pylint"]
+            """,
             [],
             "PEP621",
             ["optional"],
@@ -316,23 +283,19 @@ def test_parse_pyproject_content__malformatted_poetry_dependencies__yields_no_de
     "pyproject_toml,expected,expected_logs",
     [
         pytest.param(
-            dedent(
-                """\
-                [project]
-                name = "fawltydeps"
-                """
-            ),
+            """\
+            [project]
+            name = "fawltydeps"
+            """,
             [],
             [("PEP621", "main"), ("PEP621", "optional")],
             id="missing_pep621_fields",
         ),
         pytest.param(
-            dedent(
-                """\
-                [tool.poetry]
-                name = "fawltydeps"
-                """
-            ),
+            """\
+            [tool.poetry]
+            name = "fawltydeps"
+            """,
             [],
             [
                 ("PEP621", "main"),

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -21,18 +21,15 @@ def dependency_factory(data: List[str], path: str) -> List[DeclaredDependency]:
 
 
 @pytest.mark.parametrize(
-    "file_content,expected",
+    "file_content,expect_deps",
     [
         pytest.param(
             """\
             pandas
             click
             """,
-            dependency_factory(
-                ["pandas", "click"],
-                "requirements.txt",
-            ),
-            id="__simple_requirements_success",
+            ["pandas", "click"],
+            id="simple_requirements_success",
         ),
         pytest.param(
             """\
@@ -40,73 +37,52 @@ def dependency_factory(data: List[str], path: str) -> List[DeclaredDependency]:
 
             click >=1.2
             """,
-            dependency_factory(
-                ["pandas", "click"],
-                "requirements.txt",
-            ),
-            id="__requirements_with_versions__yields_names",
+            ["pandas", "click"],
+            id="requirements_with_versions__yields_names",
         ),
         pytest.param(
-            dedent(
-                """\
-                requests [security] @ https://github.com/psf/requests/archive/refs/heads/main.zip
-                """
-            ),
-            dependency_factory(
-                ["requests"],
-                "requirements.txt",
-            ),
-            id="__requirements_with_url_based_specifier__yields_names",
+            """\
+            requests [security] @ https://github.com/psf/requests/archive/refs/heads/main.zip
+            """,
+            ["requests"],
+            id="requirements_with_url_based_specifier__yields_names",
         ),
         pytest.param(
-            dedent(
-                """\
-                # this is a comment
-                click >=1.2
-                """
-            ),
-            dependency_factory(
-                ["click"],
-                "requirements.txt",
-            ),
-            id="__requirements_with_comment__ignores_comment",
+            """\
+            # this is a comment
+            click >=1.2
+            """,
+            ["click"],
+            id="requirements_with_comment__ignores_comment",
         ),
         pytest.param(
-            dedent(
-                """\
-                -e .
-                click >=1.2
-                """
-            ),
-            dependency_factory(
-                ["click"],
-                "requirements.txt",
-            ),
-            id="__requirements_with_option__ignores_option",
+            """\
+            -e .
+            click >=1.2
+            """,
+            ["click"],
+            id="requirements_with_option__ignores_option",
         ),
         pytest.param(
-            dedent(
-                """\
-                . # for running tests
-                click >=1.2
-                """
-            ),
-            dependency_factory(
-                ["click"],
-                "requirements.txt",
-            ),
-            id="__requirements_with_option__ignores_option_Issue200",
+            """\
+            . # for running tests
+            click >=1.2
+            """,
+            ["click"],
+            id="requirements_with_option__ignores_option_Issue200",
         ),
     ],
 )
-def test_parse_requirements_contents(file_content, expected):
+def test_parse_requirements_contents(file_content, expect_deps):
     source = Location(Path("requirements.txt"))
+
+    expected = dependency_factory(expect_deps, source.path)
     result = list(parse_requirements_contents(dedent(file_content), source))
     assert_unordered_equivalence(result, expected)
 
 
 @pytest.mark.parametrize(
-    "file_content,expected",
+    "file_content,expect_deps",
     [
         pytest.param(
             """\
@@ -117,8 +93,8 @@ def test_parse_requirements_contents(file_content, expected):
                 install_requires=["pandas", "click"]
             )
             """,
-            dependency_factory(["pandas", "click"], "setup.py"),
-            id="__simple_requirements_in_setup_py__succeeds",
+            ["pandas", "click"],
+            id="simple_requirements_in_setup_py__succeeds",
         ),
         pytest.param(
             """\
@@ -129,8 +105,8 @@ def test_parse_requirements_contents(file_content, expected):
                 install_requires=["pandas", "click>=1.2"]
             )
             """,
-            dependency_factory(["pandas", "click"], "setup.py"),
-            id="__requirements_with_versions__yields_names",
+            ["pandas", "click"],
+            id="requirements_with_versions__yields_names",
         ),
         pytest.param(
             """\
@@ -141,7 +117,7 @@ def test_parse_requirements_contents(file_content, expected):
             )
             """,
             [],
-            id="__no_requirements__yields_nothing",
+            id="no_requirements__yields_nothing",
         ),
         pytest.param(
             """\
@@ -156,8 +132,8 @@ def test_parse_requirements_contents(file_content, expected):
                 install_requires=["pandas", "click>=1.2"]
             )
             """,
-            dependency_factory(["pandas", "click"], "setup.py"),
-            id="__handles_nested_functions__yields_names",
+            ["pandas", "click"],
+            id="handles_nested_functions__yields_names",
         ),
         pytest.param(
             """\
@@ -177,8 +153,8 @@ def test_parse_requirements_contents(file_content, expected):
                 install_requires=["pandas", "click>=1.2"]
             )
             """,
-            dependency_factory(["pandas", "click"], "setup.py"),
-            id="__two_setup_calls__uses_only_top_level",
+            ["pandas", "click"],
+            id="two_setup_calls__uses_only_top_level",
         ),
         pytest.param(
             """\
@@ -192,8 +168,8 @@ def test_parse_requirements_contents(file_content, expected):
                     }
             )
             """,
-            dependency_factory(["annoy", "jieba"], "setup.py"),
-            id="__extras_present__yields_names",
+            ["annoy", "jieba"],
+            id="extras_present__yields_names",
         ),
         pytest.param(
             """\
@@ -208,8 +184,8 @@ def test_parse_requirements_contents(file_content, expected):
                     }
             )
             """,
-            dependency_factory(["pandas", "click", "annoy", "jieba"], "setup.py"),
-            id="__extras_and_regular_dependencies__yields_all_names",
+            ["pandas", "click", "annoy", "jieba"],
+            id="extras_and_regular_dependencies__yields_all_names",
         ),
         pytest.param(
             """\
@@ -222,8 +198,8 @@ def test_parse_requirements_contents(file_content, expected):
                 install_requires=my_deps,
             )
             """,
-            dependency_factory(["pandas", "click"], "setup.py"),
-            id="__direct_list_variable_reference__succeeds",
+            ["pandas", "click"],
+            id="direct_list_variable_reference__succeeds",
         ),
         pytest.param(
             """\
@@ -239,8 +215,8 @@ def test_parse_requirements_contents(file_content, expected):
                 extras_require=my_extra_deps,
             )
             """,
-            dependency_factory(["annoy", "jieba"], "setup.py"),
-            id="__direct_dict_variable_reference__succeeds",
+            ["annoy", "jieba"],
+            id="direct_dict_variable_reference__succeeds",
         ),
         pytest.param(
             """\
@@ -254,8 +230,8 @@ def test_parse_requirements_contents(file_content, expected):
                 install_requires=[pandas, click],
             )
             """,
-            dependency_factory(["pandas", "click"], "setup.py"),
-            id="__variable_reference_inside_list__succeeds",
+            ["pandas", "click"],
+            id="variable_reference_inside_list__succeeds",
         ),
         pytest.param(
             """\
@@ -273,8 +249,8 @@ def test_parse_requirements_contents(file_content, expected):
                 },
             )
             """,
-            dependency_factory(["annoy", "foobar"], "setup.py"),
-            id="__variable_reference_inside_dict__succeeds",
+            ["annoy", "foobar"],
+            id="variable_reference_inside_dict__succeeds",
         ),
         pytest.param(
             """\
@@ -296,19 +272,21 @@ def test_parse_requirements_contents(file_content, expected):
                 extras_require=my_extra_deps,
             )
             """,
-            dependency_factory(["pandas", "click", "annoy", "foobar"], "setup.py"),
-            id="__nested_variable_reference__succeeds",
+            ["pandas", "click", "annoy", "foobar"],
+            id="nested_variable_reference__succeeds",
         ),
     ],
 )
-def test_parse_setup_contents(file_content, expected):
+def test_parse_setup_contents(write_tmp_files, file_content, expect_deps):
     source = Location(Path("setup.py"))
+
+    expected = dependency_factory(expect_deps, source.path)
     result = list(parse_setup_contents(dedent(file_content), source))
     assert_unordered_equivalence(result, expected)
 
 
 @pytest.mark.parametrize(
-    "file_content,expected",
+    "file_content,expect_deps",
     [
         pytest.param(
             """\
@@ -317,8 +295,8 @@ def test_parse_setup_contents(file_content, expected):
                 pandas
                 click
             """,
-            dependency_factory(["pandas", "click"], "setup.cfg"),
-            id="__simple_requirements_in_setup_cfg__succeeds",
+            ["pandas", "click"],
+            id="simple_requirements_in_setup_cfg__succeeds",
         ),
         pytest.param(
             """\
@@ -326,23 +304,23 @@ def test_parse_setup_contents(file_content, expected):
             license_files = LICENSE
             """,
             [],
-            id="__no_requirements_in_setup_cfg__returns_none",
+            id="no_requirements_in_setup_cfg__returns_none",
         ),
         pytest.param(
             """\
             [options.extras_require]
             test = pytest
             """,
-            [DeclaredDependency("pytest", Location(Path("setup.cfg")))],
-            id="__extra_requirements_section_in_setup_cfg__succeeds",
+            ["pytest"],
+            id="extra_requirements_section_in_setup_cfg__succeeds",
         ),
         pytest.param(
             """\
             [options.tests_require]
             test = pytest
             """,
-            [DeclaredDependency("pytest", Location(Path("setup.cfg")))],
-            id="__tests_requirements_section_in_setup_cfg__succeeds",
+            ["pytest"],
+            id="tests_requirements_section_in_setup_cfg__succeeds",
         ),
         pytest.param(
             """\
@@ -351,8 +329,8 @@ def test_parse_setup_contents(file_content, expected):
                 hypothesis
                 tox
             """,
-            dependency_factory(["hypothesis", "tox"], "setup.cfg"),
-            id="__tests_requirements_in_setup_cfg__succeeds",
+            ["hypothesis", "tox"],
+            id="tests_requirements_in_setup_cfg__succeeds",
         ),
         pytest.param(
             """\
@@ -361,8 +339,8 @@ def test_parse_setup_contents(file_content, expected):
                 hypothesis
                 tox
             """,
-            dependency_factory(["hypothesis", "tox"], "setup.cfg"),
-            id="__extras_requirements_in_setup_cfg__succeeds",
+            ["hypothesis", "tox"],
+            id="extras_requirements_in_setup_cfg__succeeds",
         ),
         pytest.param(
             """\
@@ -381,15 +359,15 @@ def test_parse_setup_contents(file_content, expected):
             [options.tests_require]
             test = hypothesis
             """,
-            dependency_factory(
-                ["pandas", "click", "tox", "scipy", "pytest", "hypothesis"], "setup.cfg"
-            ),
-            id="__all_requirements_types_in_setup_cfg__succeeds",
+            ["pandas", "click", "tox", "scipy", "pytest", "hypothesis"],
+            id="all_requirements_types_in_setup_cfg__succeeds",
         ),
     ],
 )
-def test_parse_setup_cfg_contents(file_content, expected):
+def test_parse_setup_cfg_contents(write_tmp_files, file_content, expect_deps):
     source = Location(Path("setup.cfg"))
+
+    expected = dependency_factory(expect_deps, source.path)
     result = list(parse_setup_cfg_contents(dedent(file_content), source))
     assert_unordered_equivalence(result, expected)
 

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -7,9 +7,9 @@ import pytest
 
 from fawltydeps.extract_declared_dependencies import (
     extract_declared_dependencies,
-    parse_requirements_contents,
-    parse_setup_cfg_contents,
-    parse_setup_contents,
+    parse_requirements_txt,
+    parse_setup_cfg,
+    parse_setup_py,
 )
 from fawltydeps.types import DeclaredDependency, Location
 
@@ -73,12 +73,12 @@ def dependency_factory(data: List[str], path: str) -> List[DeclaredDependency]:
         ),
     ],
 )
-def test_parse_requirements_contents(write_tmp_files, file_content, expect_deps):
+def test_parse_requirements_txt(write_tmp_files, file_content, expect_deps):
     tmp_path = write_tmp_files({"requirements.txt": file_content})
     path = tmp_path / "requirements.txt"
 
     expected = dependency_factory(expect_deps, path)
-    result = list(parse_requirements_contents(path))
+    result = list(parse_requirements_txt(path))
     assert_unordered_equivalence(result, expected)
 
 
@@ -278,12 +278,12 @@ def test_parse_requirements_contents(write_tmp_files, file_content, expect_deps)
         ),
     ],
 )
-def test_parse_setup_contents(write_tmp_files, file_content, expect_deps):
+def test_parse_setup_py(write_tmp_files, file_content, expect_deps):
     tmp_path = write_tmp_files({"setup.py": file_content})
     path = tmp_path / "setup.py"
 
     expected = dependency_factory(expect_deps, path)
-    result = list(parse_setup_contents(path))
+    result = list(parse_setup_py(path))
     assert_unordered_equivalence(result, expected)
 
 
@@ -366,16 +366,16 @@ def test_parse_setup_contents(write_tmp_files, file_content, expect_deps):
         ),
     ],
 )
-def test_parse_setup_cfg_contents(write_tmp_files, file_content, expect_deps):
+def test_parse_setup_cfg(write_tmp_files, file_content, expect_deps):
     tmp_path = write_tmp_files({"setup.cfg": file_content})
     path = tmp_path / "setup.cfg"
 
     expected = dependency_factory(expect_deps, path)
-    result = list(parse_setup_cfg_contents(path))
+    result = list(parse_setup_cfg(path))
     assert_unordered_equivalence(result, expected)
 
 
-def test_parse_setup_contents__multiple_entries_in_extras_require__returns_list(
+def test_parse_setup_py__multiple_entries_in_extras_require__returns_list(
     write_tmp_files,
 ):
     tmp_path = write_tmp_files(
@@ -410,7 +410,7 @@ def test_parse_setup_contents__multiple_entries_in_extras_require__returns_list(
         ],
         path,
     )
-    result = list(parse_setup_contents(path))
+    result = list(parse_setup_py(path))
     assert_unordered_equivalence(result, expected)
 
 

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -73,11 +73,12 @@ def dependency_factory(data: List[str], path: str) -> List[DeclaredDependency]:
         ),
     ],
 )
-def test_parse_requirements_contents(file_content, expect_deps):
-    source = Location(Path("requirements.txt"))
+def test_parse_requirements_contents(write_tmp_files, file_content, expect_deps):
+    tmp_path = write_tmp_files({"requirements.txt": file_content})
+    path = tmp_path / "requirements.txt"
 
-    expected = dependency_factory(expect_deps, source.path)
-    result = list(parse_requirements_contents(dedent(file_content), source))
+    expected = dependency_factory(expect_deps, path)
+    result = list(parse_requirements_contents(path))
     assert_unordered_equivalence(result, expected)
 
 
@@ -278,10 +279,11 @@ def test_parse_requirements_contents(file_content, expect_deps):
     ],
 )
 def test_parse_setup_contents(write_tmp_files, file_content, expect_deps):
-    source = Location(Path("setup.py"))
+    tmp_path = write_tmp_files({"setup.py": file_content})
+    path = tmp_path / "setup.py"
 
-    expected = dependency_factory(expect_deps, source.path)
-    result = list(parse_setup_contents(dedent(file_content), source))
+    expected = dependency_factory(expect_deps, path)
+    result = list(parse_setup_contents(path))
     assert_unordered_equivalence(result, expected)
 
 
@@ -365,32 +367,39 @@ def test_parse_setup_contents(write_tmp_files, file_content, expect_deps):
     ],
 )
 def test_parse_setup_cfg_contents(write_tmp_files, file_content, expect_deps):
-    source = Location(Path("setup.cfg"))
+    tmp_path = write_tmp_files({"setup.cfg": file_content})
+    path = tmp_path / "setup.cfg"
 
-    expected = dependency_factory(expect_deps, source.path)
-    result = list(parse_setup_cfg_contents(dedent(file_content), source))
+    expected = dependency_factory(expect_deps, path)
+    result = list(parse_setup_cfg_contents(path))
     assert_unordered_equivalence(result, expected)
 
 
-def test_parse_setup_contents__multiple_entries_in_extras_require__returns_list():
-    setup_contents = dedent(
-        """\
-        from setuptools import setup
+def test_parse_setup_contents__multiple_entries_in_extras_require__returns_list(
+    write_tmp_files,
+):
+    tmp_path = write_tmp_files(
+        {
+            "setup.py": """\
+                from setuptools import setup
 
-        setup(
-            name="MyLib",
-            extras_require={
-                "simple_parsing":["abc"],
-                "bert": [
-                    "bert-serving-server>=1.8.6",
-                    "bert-serving-client>=1.8.6",
-                    "pytorch-transformer",
-                    "flair"
-                    ],
-                }
-        )
-        """
+                setup(
+                    name="MyLib",
+                    extras_require={
+                        "simple_parsing":["abc"],
+                        "bert": [
+                            "bert-serving-server>=1.8.6",
+                            "bert-serving-client>=1.8.6",
+                            "pytorch-transformer",
+                            "flair"
+                            ],
+                        }
+                )
+                """,
+        }
     )
+    path = tmp_path / "setup.py"
+
     expected = dependency_factory(
         [
             "abc",
@@ -399,9 +408,9 @@ def test_parse_setup_contents__multiple_entries_in_extras_require__returns_list(
             "pytorch-transformer",
             "flair",
         ],
-        Path(""),
+        path,
     )
-    result = list(parse_setup_contents(setup_contents, Location(Path(""))))
+    result = list(parse_setup_contents(path))
     assert_unordered_equivalence(result, expected)
 
 


### PR DESCRIPTION
This should enable @vreuter's rewrite of our requirements.txt parser to avoid creating a temporary copy of each requirements.txt file while parsing it.

We do however need to find a better way to parse our setup.cfg files...

- `test_extract_declared_dependencies_succes`: Harmless test refactoring
- `extract_declared_dependencies`: Refactor API of parser functions
- `test_extract_declared_dependencies_pyproject_toml`: Remove unnecessary `dedent()`
- `extract_declared_dependencies`: Rename parser functions
