### PR TITLE
Add a shield for CI to the top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![PyPI Latest Release](https://img.shields.io/pypi/v/fawltydeps.svg)](https://pypi.org/project/fawltydeps/) [![Supported Python versions](https://img.shields.io/pypi/pyversions/fawltydeps.svg)](https://pypi.org/project/fawltydeps/) [![Licence](https://img.shields.io/pypi/l/fawltydeps.svg)](https://pypi.org/project/fawltydeps/)
-
+[![PyPI Latest Release](https://img.shields.io/pypi/v/fawltydeps.svg)](https://pypi.org/project/fawltydeps/) [![Supported Python versions](https://img.shields.io/pypi/pyversions/fawltydeps.svg)](https://pypi.org/project/fawltydeps/) ![Build](https://img.shields.io/github/actions/workflow/status/tweag/fawltydeps/ci.yaml) [![Licence](https://img.shields.io/pypi/l/fawltydeps.svg)](https://pypi.org/project/fawltydeps/)
 # FawltyDeps
 
 FawltyDeps is a dependency checker for Python that finds _undeclared_ and/or


### PR DESCRIPTION
To faster detect the failing CI.

If you have any other suggestions on a useful shield, feel free to pick from: https://shields.io

I did a minimal change, because, I do not want to clutter the README with those shields too much. (There are _many_ of them)