### PR TITLE
doc: fix configurattion example in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ default behavior of FawltyDeps. Here's a fairly comprehensive example:
 
 ```toml
 [tool.fawltydeps]
-code = "myproject"  # Only search for imports under ./myproject
-deps = "pyproject.toml"  # Only look for declared dependencies here
+code = ["myproject"]  # Only search for imports under ./myproject
+deps = ["pyproject.toml"]  # Only look for declared dependencies here
 ignore_unused = ["black"]  # We use `black`, but we don't intend to import it
 output_format = "human_detailed"  # Detailed report by default
 ```
@@ -227,10 +227,10 @@ Here is a complete list of configuration directives we support:
 - `actions`: A list of one or more of these actions to perform: `list_imports`,
   `list_deps`, `check_undeclared`, `check_unused`. The default behavior
   corresponds to `actions = ["check_undeclared", "check_unused"]`.
-- `code`: A file or directory containing the code to parse for import statements.
-  Defaults to the current directory, i.e. like `code = .`.
-- `deps`: A file or directory containing the declared dependencies.
-  Defaults to the current directory, i.e. like `deps = .`.
+- `code`: Files or directories containing the code to parse for import statements.
+  Defaults to the current directory, i.e. like `code = ["."]`.
+- `deps`: Files or directories containing the declared dependencies.
+  Defaults to the current directory, i.e. like `deps = ["."]`.
 - `output_format`: Which output format to use by default. One of `human_summary`,
   `human_detailed`, or `json`.
   The default corresponds to `output_format = "human_summary"`.


### PR DESCRIPTION
Thanks for the great project!
With current example I have the following error.

```
➜ fawltydeps                                                                                                                                                                                                                                                                                                                                              nix-shell-env
Traceback (most recent call last):
  File "/nix/store/r6d17z5j0ydcvk7dpbbifrxrs6h8w4c7-python3.9-fawltydeps-0.6.1/bin/.fawltydeps-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/r6d17z5j0ydcvk7dpbbifrxrs6h8w4c7-python3.9-fawltydeps-0.6.1/lib/python3.9/site-packages/fawltydeps/main.py", line 204, in main
    settings = Settings.config(config_file=args.config_file).create(args)
  File "/nix/store/r6d17z5j0ydcvk7dpbbifrxrs6h8w4c7-python3.9-fawltydeps-0.6.1/lib/python3.9/site-packages/fawltydeps/settings.py", line 213, in create
    return cls(**ret)
  File "pydantic/env_settings.py", line 39, in pydantic.env_settings.BaseSettings.__init__
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 2 validation errors for Settings
code
  value is not a valid set (type=type_error.set)
deps
  value is not a valid set (type=type_error.set)
```

This PR fixes this issue.