### PR TITLE
Develop sample_projects to support multiple experiments and cached venvs

### DIFF
--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -128,7 +128,7 @@ class AnalysisExpectations:
     unused_deps: Optional[Set[str]] = None
 
     @classmethod
-    def parse_from_toml(cls, data: TomlData) -> "AnalysisExpectations":
+    def from_toml(cls, data: TomlData) -> "AnalysisExpectations":
         """Read expectations from the given TOML table."""
 
         def set_or_none(data: Optional[Iterable[str]]) -> Optional[Set[str]]:
@@ -187,11 +187,11 @@ class BaseExperiment:
             name=name,
             description=data.get("description"),
             requirements=data.get("requirements", []),
-            expectations=AnalysisExpectations.parse_from_toml(data),
+            expectations=AnalysisExpectations.from_toml(data),
         )
 
     @classmethod
-    def parse_from_toml(cls, name: str, data: TomlData) -> "BaseExperiment":
+    def from_toml(cls, name: str, data: TomlData) -> "BaseExperiment":
         raise NotImplementedError
 
     def get_venv_dir(self, cache: pytest.Cache) -> Path:
@@ -233,7 +233,7 @@ class BaseProject:
             name=project_name,
             description=toml_data["project"].get("description"),
             experiments=[
-                ExperimentClass.parse_from_toml(f"{project_name}:{name}", data)
+                ExperimentClass.from_toml(f"{project_name}:{name}", data)
                 for name, data in toml_data["experiments"].items()
             ],
         )

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -4,6 +4,7 @@ import logging
 import shlex
 import subprocess
 import sys
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from dataclasses import fields as dataclass_fields
 from pathlib import Path
@@ -153,7 +154,7 @@ class AnalysisExpectations:
 
 
 @dataclass
-class BaseExperiment:
+class BaseExperiment(ABC):
     """A single experiment, running FawltyDeps on a test project.
 
     An experiment is part of a bigger project (see BaseProject below) and has:
@@ -181,6 +182,7 @@ class BaseExperiment:
         )
 
     @classmethod
+    @abstractmethod
     def from_toml(cls, name: str, data: TomlData) -> "BaseExperiment":
         """Create an instance from TOML data."""
         raise NotImplementedError
@@ -191,7 +193,7 @@ class BaseExperiment:
 
 
 @dataclass
-class BaseProject:
+class BaseProject(ABC):
     """Encapsulate a Python project to be tested with FawltyDeps.
 
     This represents a project on which we want to run FawltyDeps in one or more
@@ -224,6 +226,7 @@ class BaseProject:
         )
 
     @classmethod
+    @abstractmethod
     def collect(cls) -> Iterator["BaseProject"]:
         """Find and generate all projects in this test suite."""
         raise NotImplementedError

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -1,0 +1,86 @@
+"""Common helpers shared between test_real_project and test_sample_projects."""
+import hashlib
+import logging
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CachedExperimentVenv:
+    """A virtualenv used in a sample or real-world experiment.
+
+    This is a test helper to create and reuse virtualenvs that contain real
+    packages used in our integration tests. The goal is that venvs are created
+    _once_ and reused as long as the commands used to create them and install
+    packages into them remain unchanged. These use pytest's caching
+    infrastructure meaning that the venvs typically end up living under
+    ~/.cache/pytest/d/...
+    """
+
+    requirements: List[str]  # PEP 508 requirements, passed to 'pip install'
+
+    def venv_script_lines(self, venv_path: Path) -> List[str]:
+        return (
+            [
+                f"rm -rf {venv_path}",
+                f"python3 -m venv {venv_path}",
+                f"{venv_path}/bin/pip install --upgrade pip",
+            ]
+            + [
+                f"{venv_path}/bin/pip install {shlex.quote(req)}"
+                for req in self.requirements
+            ]
+            + [
+                f"touch {venv_path}/.installed",
+            ]
+        )
+
+    def venv_hash(self) -> str:
+        """Returns a hash that depends on the venv script and python version.
+
+        The installation script will change if the code to setup the venv in
+        venv_script_lines() changes, or if the requirements of the experiment
+        changes. It will also be different for different Python versions.
+        The Python version currently used to run the tests is used to compute
+        the hash and create the venv.
+        """
+        dummy_script = self.venv_script_lines(Path("/dev/null"))
+        py_version = f"{sys.version_info.major},{sys.version_info.major}"
+        script_and_version_bytes = ("".join(dummy_script) + py_version).encode()
+        return hashlib.sha256(script_and_version_bytes).hexdigest()
+
+    def __call__(self, cache: pytest.Cache) -> Path:
+        """Get this venv's dir and create it if necessary.
+
+        The venv_dir is where we install the dependencies of the current
+        experiment. It is keyed by the sha256 checksum of the requirements
+        file and the script we use for setting up the venv. This way, we
+        don't risk using a previously cached venv for a different if the
+        script or the requirements to create that venv change.
+        """
+        # We cache venv dirs using the hash from create_venv_hash
+        cached_str = cache.get(f"fawltydeps/{self.venv_hash()}", None)
+        if cached_str is not None and Path(cached_str, ".installed").is_file():
+            return Path(cached_str)  # already cached
+
+        # Must run the script to set up the venv
+        venv_dir = Path(cache.mkdir(f"fawltydeps_venv_{self.venv_hash()}"))
+        logger.info(f"Creating venv at {venv_dir}...")
+        venv_script = self.venv_script_lines(venv_dir)
+        subprocess.run(
+            " && ".join(venv_script),
+            check=True,  # fail if any of the commands fail
+            shell=True,  # pass multiple shell commands to the subprocess
+        )
+        # Make sure the venv has been installed
+        assert (venv_dir / ".installed").is_file()
+        cache.set(f"fawltydeps/{self.venv_hash()}", str(venv_dir))
+        return venv_dir

--- a/tests/sample_projects/beautifulsoup_and_html5lib/expected.toml
+++ b/tests/sample_projects/beautifulsoup_and_html5lib/expected.toml
@@ -1,0 +1,46 @@
+[project]
+# General information about a simplified project: Its name, why we test it,
+# its relation to real world projects
+name = "beautifulsoup_and_html5lib"
+description = """
+  (taken from issue #246: https://github.com/tweag/FawltyDeps/issues/246)
+  A project depends on beautifulsoup4, and - following its documentation
+  (https://beautiful-soup-4.readthedocs.io/en/latest/#installing-a-parser) -
+  also adds a dependency on html5lib. However, the project itself does not
+  directly import html5lib, only beautifulsoup4 does so (after being told so by
+  the project with a `BeautifulSoup(..., "html5lib")` call.
+
+  This is a special case of a more general problem of packages that have
+  supplemental/optional dependencies, and ask their users to install these
+  transitive dependencies as if they were direct dependencies.
+
+  As it happens, the beautifulsoup4 project has provided an "extra" since
+  v4.4.0 (July 2015) called "html5lib" that does indeed bring in html5lib as
+  an extra dependency of beautifulsoup4. As such, this problem can be side-
+  stepped for beautifulsoup4 by depending on "beautifulsoup4[html5lib]" instead
+  of just "beautifulsoup4". However, this solution is not documented by BS4
+  itself.
+
+  Furthermore, the general problem of how FawltyDeps should better deal with
+  supplemental packages remains.
+"""
+
+[experiments.original]
+description = "Use the original requirements.txt"
+deps = ["requirements.txt"]
+requirements = ["beautifulsoup4", "html5lib"]
+
+imports = ["bs4"]
+declared_deps = ["beautifulsoup4", "html5lib"]
+undeclared_deps = []
+unused_deps = ["html5lib"]
+
+[experiments.workaround]
+description = "Use the modified requirements.txt that uses the provided extra"
+deps = ["requirements.workaround.txt"]
+requirements = ["beautifulsoup4[html5lib]"]
+
+imports = ["bs4"]
+declared_deps = ["beautifulsoup4"]
+undeclared_deps = []
+unused_deps = []

--- a/tests/sample_projects/beautifulsoup_and_html5lib/main.py
+++ b/tests/sample_projects/beautifulsoup_and_html5lib/main.py
@@ -1,0 +1,4 @@
+from bs4 import BeautifulSoup
+
+soup = BeautifulSoup("<html>data</html>", "html5lib")
+print(soup)

--- a/tests/sample_projects/beautifulsoup_and_html5lib/requirements.txt
+++ b/tests/sample_projects/beautifulsoup_and_html5lib/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+html5lib

--- a/tests/sample_projects/beautifulsoup_and_html5lib/requirements.workaround.txt
+++ b/tests/sample_projects/beautifulsoup_and_html5lib/requirements.workaround.txt
@@ -1,0 +1,1 @@
+beautifulsoup4[html5lib]

--- a/tests/sample_projects/blog_post_example/expected.toml
+++ b/tests/sample_projects/blog_post_example/expected.toml
@@ -19,7 +19,10 @@ description = '''
     to look the other way.
 '''
 
-[analysis_result]
+[experiments.default]
+description = "Run fawltydeps as shown in the blog post"
+requirements = []  # rely on identity mapping
+
 # 3rd-party imports found in the code:
 imports = [
     "requests",

--- a/tests/sample_projects/file__requirements_undeclared/expected.toml
+++ b/tests/sample_projects/file__requirements_undeclared/expected.toml
@@ -9,7 +9,10 @@ description = '''
   Identity mapping between import and dependencies is sufficient.
 '''
 
-[analysis_result]
+[experiments.default]
+description = "Default run"
+requirements = []  # rely on identity mapping
+
 # Names of imports found in the code which 
 # do not have a matching dependency declared.
 # What we expect the analysis to return.

--- a/tests/sample_projects/file__requirements_unused/expected.toml
+++ b/tests/sample_projects/file__requirements_unused/expected.toml
@@ -9,7 +9,10 @@ description = '''
   Identity mapping between import and dependencies is sufficient.
 '''
 
-[analysis_result]
+[experiments.default]
+description = "Default run"
+requirements = []  # rely on identity mapping
+
 # Names of imports found in the code which 
 # do not have a matching dependency declared.
 # What we expect the analysis to return.

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -86,7 +86,7 @@ class Experiment(BaseExperiment):
     args: List[str]
 
     @classmethod
-    def parse_from_toml(cls, name: str, data: TomlData) -> "Experiment":
+    def from_toml(cls, name: str, data: TomlData) -> "Experiment":
         return cls(args=data["args"], **cls.init_args_from_toml(name, data))
 
 

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -22,7 +22,7 @@ from pkg_resources import Requirement
 from fawltydeps.packages import LocalPackageLookup
 from fawltydeps.types import TomlData
 
-from .project_helpers import BaseExperiment, BaseProject, JsonData
+from .project_helpers import BaseExperiment, BaseProject, JsonData, parse_toml
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ class Experiment(BaseExperiment):
 
     @classmethod
     def from_toml(cls, name: str, data: TomlData) -> "Experiment":
-        return cls(args=data["args"], **cls.init_args_from_toml(name, data))
+        return cls(args=data["args"], **cls._init_args_from_toml(name, data))
 
 
 @dataclass
@@ -110,12 +110,12 @@ class ThirdPartyProject(BaseProject):
     @classmethod
     def collect(cls) -> Iterator["ThirdPartyProject"]:
         for path in filter(lambda p: p.suffix == ".toml", REAL_PROJECTS_DIR.iterdir()):
-            init_args, toml_data = cls.parse_toml(path, Experiment)
+            toml_data = parse_toml(path)
             yield cls(
                 toml_path=path,
                 url=toml_data["project"]["url"],
                 sha256=toml_data["project"]["sha256"],
-                **init_args,
+                **cls._init_args_from_toml(toml_data, Experiment),
             )
 
     def tarball_name(self) -> str:

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -1,10 +1,9 @@
-"""
-Integration tests for the FawltyDeps project
+"""Verify behavior of FawltyDeps on sample projects.
 
-Check for given a simple project that following workflows work:
+Check for a given simple project that the following workflows work:
 - discover all imports and dependencies
   and correctly identify unused and missing dependencies
-- TODO given only part of the project to search in
+- given only part of the project to search in
   correctly identify unused and missing dependencies
 
 Sample projects are subdirectories of `tests/sample_projects`. These are
@@ -20,48 +19,95 @@ tests/sample_projects
     ├── expected.toml (mandatory)
     └── ... (regular Python project)
 """
-import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterator, List
 
 import pytest
 
 from fawltydeps.main import Analysis
 from fawltydeps.settings import Action, Settings
+from fawltydeps.types import TomlData
 
-from .project_helpers import AnalysisExpectations
-
-if sys.version_info >= (3, 11):
-    import tomllib  # pylint: disable=E1101
-else:
-    import tomli as tomllib
+from .project_helpers import BaseExperiment, BaseProject
 
 # These are (slow) integration tests that are disabled by default.
 pytestmark = pytest.mark.integration
 
 SAMPLE_PROJECTS_DIR = Path(__file__).with_name("sample_projects")
 
-sample_projects_params = [
-    pytest.param(sample_project, id=sample_project.name)
-    for sample_project in SAMPLE_PROJECTS_DIR.iterdir()
-    if sample_project.is_dir()
-]
+
+@dataclass
+class Experiment(BaseExperiment):
+    """A single experiment to run FawltyDeps on a sample project.
+
+    Input to the experiment consists of the following members:
+    - code: Settings.code paths relative to the sample project root
+    - deps: Settings.deps paths relative to the sample project root
+
+    See BaseExperiment for details on the inherited members.
+    """
+
+    code: List[str]
+    deps: List[str]
+
+    @classmethod
+    def parse_from_toml(cls, name: str, data: TomlData) -> "Experiment":
+        return cls(
+            code=data.get("code", [""]),
+            deps=data.get("deps", [""]),
+            **cls.init_args_from_toml(name, data),
+        )
+
+    def build_settings(self, project_path: Path, cache: pytest.Cache) -> Settings:
+        """Construct a Settings object appropriate for this experiment."""
+        return Settings(
+            actions={Action.REPORT_UNDECLARED, Action.REPORT_UNUSED},
+            code=[(project_path / path) for path in self.code],
+            deps=[(project_path / path) for path in self.deps],
+            pyenv=self.get_venv_dir(cache),
+        )
 
 
-@pytest.mark.parametrize("project_path", sample_projects_params)
-def test_integration_analysis_on_sample_projects__(project_path):
-    settings = Settings(
-        actions={Action.REPORT_UNDECLARED, Action.REPORT_UNUSED},
-        code=[project_path],
-        deps=[project_path],
-    )
+@dataclass
+class SampleProject(BaseProject):
+    """Encapsulate a sample project to be tested with FawltyDeps.
+
+    This represents a sample Python project living in a subdirectory under
+    tests/sample_projects/, and the things we expect FawltyDeps to find when
+    run on this project.
+
+    The actual data populating these objects is read from TOML files under
+    SAMPLE_PROJECTS_DIR.
+    """
+
+    path: Path  # Directory containing expected.toml, and rest of sample project
+
+    @classmethod
+    def collect(cls) -> Iterator["SampleProject"]:
+        for subdir in SAMPLE_PROJECTS_DIR.iterdir():
+            toml_path = subdir / "expected.toml"
+            if not toml_path.is_file():
+                continue
+            init_args, _ = cls.parse_toml(toml_path, Experiment)
+            yield cls(path=subdir, **init_args)
+
+
+@pytest.mark.parametrize(
+    "project, experiment",
+    [
+        pytest.param(project, experiment, id=experiment.name)
+        for project in SampleProject.collect()
+        for experiment in project.experiments
+    ],
+)
+def test_integration_analysis_on_sample_projects__(request, project, experiment):
+    print(f"Testing sample project: {project.name} under {project.path}")
+    print(f"Project description: {project.description}")
+    print()
+    print(f"Running sample project experiment: {experiment.name}")
+    print(f"Experiment description: {experiment.description}")
+    print()
+    settings = experiment.build_settings(project.path, request.config.cache)
     analysis = Analysis.create(settings)
-
-    with (project_path / "expected.toml").open("rb") as f:
-        experiment = tomllib.load(f)
-
-    print(experiment["project"].get("name"))
-    print(experiment["project"].get("description"))
-    expectation = AnalysisExpectations.parse_from_toml(
-        experiment.get("analysis_result", {})
-    )
-    expectation.verify_analysis(analysis)
+    experiment.expectations.verify_analysis(analysis)

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -28,6 +28,8 @@ import pytest
 from fawltydeps.main import Analysis
 from fawltydeps.settings import Action, Settings
 
+from .project_helpers import AnalysisExpectations
+
 if sys.version_info >= (3, 11):
     import tomllib  # pylint: disable=E1101
 else:
@@ -59,26 +61,7 @@ def test_integration_analysis_on_sample_projects__(project_path):
 
     print(experiment["project"].get("name"))
     print(experiment["project"].get("description"))
-    expected = experiment.get("analysis_result", {})
-
-    if "imports" in expected:
-        print("Verifying 'imports'...")
-        actual_imports = {i.name for i in analysis.imports}
-        expect_imports = set(expected["imports"])
-        assert actual_imports == expect_imports
-
-    if "declared_deps" in expected:
-        print("Verifying 'declared_deps'...")
-        actual_declared = {d.name for d in analysis.declared_deps}
-        expect_declared = set(expected["declared_deps"])
-        assert actual_declared == expect_declared
-
-    print("Verifying 'undeclared_deps'...")
-    actual_undeclared = {u.name for u in analysis.undeclared_deps}
-    expect_undeclared = set(expected.get("undeclared_deps", []))
-    assert actual_undeclared == expect_undeclared
-
-    print("Verifying 'unused_deps'...")
-    actual_unused = {u.name for u in analysis.unused_deps}
-    expect_unused = set(expected.get("unused_deps", []))
-    assert actual_unused == expect_unused
+    expectation = AnalysisExpectations.parse_from_toml(
+        experiment.get("analysis_result", {})
+    )
+    expectation.verify_analysis(analysis)

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -52,7 +52,7 @@ class Experiment(BaseExperiment):
     deps: List[str]
 
     @classmethod
-    def parse_from_toml(cls, name: str, data: TomlData) -> "Experiment":
+    def from_toml(cls, name: str, data: TomlData) -> "Experiment":
         return cls(
             code=data.get("code", [""]),
             deps=data.get("deps", [""]),

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -29,7 +29,7 @@ from fawltydeps.main import Analysis
 from fawltydeps.settings import Action, Settings
 from fawltydeps.types import TomlData
 
-from .project_helpers import BaseExperiment, BaseProject
+from .project_helpers import BaseExperiment, BaseProject, parse_toml
 
 # These are (slow) integration tests that are disabled by default.
 pytestmark = pytest.mark.integration
@@ -56,7 +56,7 @@ class Experiment(BaseExperiment):
         return cls(
             code=data.get("code", [""]),
             deps=data.get("deps", [""]),
-            **cls.init_args_from_toml(name, data),
+            **cls._init_args_from_toml(name, data),
         )
 
     def build_settings(self, project_path: Path, cache: pytest.Cache) -> Settings:
@@ -89,8 +89,8 @@ class SampleProject(BaseProject):
             toml_path = subdir / "expected.toml"
             if not toml_path.is_file():
                 continue
-            init_args, _ = cls.parse_toml(toml_path, Experiment)
-            yield cls(path=subdir, **init_args)
+            toml_data = parse_toml(toml_path)
+            yield cls(path=subdir, **cls._init_args_from_toml(toml_data, Experiment))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This started as a simple wish to add the problem described in issue #246 as a sample project in our test suite.

However, I quickly discovered that our `sample_projects` did not support installing comples dependencies (such as `beautifulsoup4`, much less `beautifulsoup4[html5lib]`. Furthermore, it also did not support running multiple experiments inside a single `sample_project`.

Both of these features are already available in our `real_projects`, so I took this as an opportunity to do some extensive refactoring on `real_projects` and `sample_projects`, and bring these two parts of our test suite as close together as possible:

The common parts are refactored into a new `project_helpers` module (unders `tests/`), and the remaining differences are expressed in the `Experiment` and `*Project` subclasses that now remain in both `test_real_projects` and `test_sample_projects`.

The test suite is kept unchanged and working throughout the refactoring, save for some light refactoring of `sample_projects` TOML files in the second-last commit, and the addition of the new `beautifulsoup_and_html5lib` test (that triggered all of this) in the last commit.

Commits:
- `test_real_projects`: Refactor cached venv code into separate module
- `test_real_projects`: Refactor verification of expected analysis report
- `test_sample_projects`: Minimal rewrite to use `AnalysisExpectations`
- `test_real_project`: Refactor common project/experiment details
- `test_sample_projects`: Refactor to use `BaseProject`/`BaseExperiment`
- `test_sample_projects`: Add new project: `beautifulsoup_and_html5lib`
