### PR TITLE
package: Introduce a list of package resolvers

### DIFF
--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -442,7 +442,7 @@ def setup_cmdline_parser(
     return parser, option_group
 
 
-def print_toml_config(settings: Settings, out: TextIO) -> None:
+def print_toml_config(settings: Settings, out: TextIO = sys.stdout) -> None:
     """Serialize the given Settings object into a TOML config section."""
     # Use JSON serialization as a basis for TOML output. Load that back into
     # Python and then use Python's repr() representation below

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -430,8 +430,8 @@ def test_check__simple_project_with_missing_deps__reports_undeclared(
     ]
     expect_logs = [
         f"INFO:fawltydeps.extract_imports:Parsing Python files under {tmp_path}",
-        "INFO:fawltydeps.packages:Could not find 'pandas' in the current environment."
-        " Assuming it can be imported as pandas",
+        "INFO:fawltydeps.packages:'pandas' was not resolved."
+        " Assuming it can be imported as 'pandas'.",
     ]
     output, errors, returncode = run_fawltydeps(
         "--check", "--detailed", "-v", f"--code={tmp_path}", f"--deps={tmp_path}"
@@ -456,10 +456,10 @@ def test_check__simple_project_with_extra_deps__reports_unused(
     ]
     expect_logs = [
         f"INFO:fawltydeps.extract_imports:Parsing Python files under {tmp_path}",
-        "INFO:fawltydeps.packages:Could not find 'requests' in the current environment."
-        " Assuming it can be imported as requests",
-        "INFO:fawltydeps.packages:Could not find 'pandas' in the current environment."
-        " Assuming it can be imported as pandas",
+        "INFO:fawltydeps.packages:'requests' was not resolved."
+        " Assuming it can be imported as 'requests'.",
+        "INFO:fawltydeps.packages:'pandas' was not resolved."
+        " Assuming it can be imported as 'pandas'.",
     ]
     output, errors, returncode = run_fawltydeps(
         "--check", "--detailed", "-v", f"--code={tmp_path}", f"--deps={tmp_path}"
@@ -488,8 +488,8 @@ def test_check__simple_project__can_report_both_undeclared_and_unused(
     ]
     expect_logs = [
         f"INFO:fawltydeps.extract_imports:Parsing Python files under {tmp_path}",
-        "INFO:fawltydeps.packages:Could not find 'pandas' in the current environment."
-        " Assuming it can be imported as pandas",
+        "INFO:fawltydeps.packages:'pandas' was not resolved."
+        " Assuming it can be imported as 'pandas'.",
     ]
     output, errors, returncode = run_fawltydeps(
         "--check", "--detailed", "-v", f"--code={tmp_path}", f"--deps={tmp_path}"
@@ -518,8 +518,8 @@ def test_check__simple_project__summary_report_with_verbose_logging(
     ]
     expect_logs = [
         f"INFO:fawltydeps.extract_imports:Parsing Python files under {tmp_path}",
-        "INFO:fawltydeps.packages:Could not find 'pandas' in the current environment."
-        " Assuming it can be imported as pandas",
+        "INFO:fawltydeps.packages:'pandas' was not resolved."
+        " Assuming it can be imported as 'pandas'.",
     ]
     output, errors, returncode = run_fawltydeps(
         "--check",
@@ -626,8 +626,8 @@ def test_check_undeclared__simple_project__reports_only_undeclared(
     ]
     expect_logs = [
         f"INFO:fawltydeps.extract_imports:Parsing Python files under {tmp_path}",
-        "INFO:fawltydeps.packages:Could not find 'pandas' in the current environment."
-        " Assuming it can be imported as pandas",
+        "INFO:fawltydeps.packages:'pandas' was not resolved."
+        " Assuming it can be imported as 'pandas'.",
     ]
     output, errors, returncode = run_fawltydeps(
         "--check-undeclared",
@@ -657,8 +657,8 @@ def test_check_unused__simple_project__reports_only_unused(
     ]
     expect_logs = [
         f"INFO:fawltydeps.extract_imports:Parsing Python files under {tmp_path}",
-        "INFO:fawltydeps.packages:Could not find 'pandas' in the current environment."
-        " Assuming it can be imported as pandas",
+        "INFO:fawltydeps.packages:'pandas' was not resolved."
+        " Assuming it can be imported as 'pandas'.",
     ]
     output, errors, returncode = run_fawltydeps(
         "--check-unused",
@@ -692,8 +692,8 @@ def test__no_action__defaults_to_check_action(
     ]
     expect_logs = [
         f"INFO:fawltydeps.extract_imports:Parsing Python files under {tmp_path}",
-        "INFO:fawltydeps.packages:Could not find 'pandas' in the current environment."
-        " Assuming it can be imported as pandas",
+        "INFO:fawltydeps.packages:'pandas' was not resolved."
+        " Assuming it can be imported as 'pandas'.",
     ]
     output, errors, returncode = run_fawltydeps(
         f"--code={tmp_path}", "--detailed", "-v", f"--deps={tmp_path}"
@@ -722,8 +722,8 @@ def test__no_options__defaults_to_check_action_in_current_dir(
     ]
     expect_logs = [
         "INFO:fawltydeps.extract_imports:Parsing Python files under .",
-        "INFO:fawltydeps.packages:Could not find 'pandas' in the current environment."
-        " Assuming it can be imported as pandas",
+        "INFO:fawltydeps.packages:'pandas' was not resolved."
+        " Assuming it can be imported as 'pandas'.",
     ]
     output, errors, returncode = run_fawltydeps("--detailed", "-v", cwd=tmp_path)
     assert output.splitlines() == expect

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -465,7 +465,7 @@ def test_check__simple_project_with_extra_deps__reports_unused(
         "--check", "--detailed", "-v", f"--code={tmp_path}", f"--deps={tmp_path}"
     )
     assert output.splitlines() == expect
-    assert errors == "\n".join(expect_logs)
+    assert_unordered_equivalence(errors.splitlines(), expect_logs)
     assert returncode == 4
 
 

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -99,10 +99,7 @@ def test_resolve_dependencies__in_empty_venv__reverts_to_id_mapping(tmp_path):
     venv.create(tmp_path, with_pip=False)
     id_mapping = IdentityMapping()
     actual = resolve_dependencies(["pip", "setuptools"], pyenv_path=tmp_path)
-    assert actual == {
-        "pip": id_mapping.lookup_package("pip"),
-        "setuptools": id_mapping.lookup_package("setuptools"),
-    }
+    assert actual == id_mapping.lookup_packages({"pip", "setuptools"})
 
 
 def test_resolve_dependencies__in_fake_venv__returns_local_and_id_deps(fake_venv):

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -6,7 +6,7 @@ import pytest
 
 from fawltydeps.packages import (
     DependenciesMapping,
-    LocalPackageLookup,
+    LocalPackageResolver,
     Package,
     resolve_dependencies,
 )
@@ -31,7 +31,7 @@ def test_determine_package_dir__various_paths_in_venv(tmp_path, subdir):
     venv.create(tmp_path, with_pip=False)
     path = tmp_path / subdir
     expect = tmp_path / f"lib/python{major}.{minor}/site-packages"
-    assert LocalPackageLookup.determine_package_dir(path) == expect
+    assert LocalPackageResolver.determine_package_dir(path) == expect
 
 
 @pytest.mark.parametrize(
@@ -49,18 +49,18 @@ def test_determine_package_dir__various_paths_in_poetry2nix_env(
     )
     path = tmp_path / subdir
     expect = tmp_path / f"lib/python{major}.{minor}/site-packages"
-    assert LocalPackageLookup.determine_package_dir(path) == expect
+    assert LocalPackageResolver.determine_package_dir(path) == expect
 
 
 def test_local_env__empty_venv__has_no_packages(tmp_path):
     venv.create(tmp_path, with_pip=False)
-    lpl = LocalPackageLookup(tmp_path)
+    lpl = LocalPackageResolver(tmp_path)
     assert lpl.packages == {}
 
 
 def test_local_env__default_venv__contains_pip_and_setuptools(tmp_path):
     venv.create(tmp_path, with_pip=True)
-    lpl = LocalPackageLookup(tmp_path)
+    lpl = LocalPackageResolver(tmp_path)
     # We cannot do a direct comparison, as different Python/pip/setuptools
     # versions differ in exactly which packages are provided. The following
     # is a subset that we can expect across all of our supported versions.
@@ -78,7 +78,7 @@ def test_local_env__default_venv__contains_pip_and_setuptools(tmp_path):
 
 
 def test_local_env__current_venv__contains_our_test_dependencies():
-    lpl = LocalPackageLookup()
+    lpl = LocalPackageResolver()
     expect_package_names = [
         # Present in ~all venvs:
         "pip",

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -6,6 +6,7 @@ import pytest
 
 from fawltydeps.packages import (
     DependenciesMapping,
+    IdentityMapping,
     LocalPackageResolver,
     Package,
     resolve_dependencies,
@@ -96,10 +97,11 @@ def test_local_env__current_venv__contains_our_test_dependencies():
 
 def test_resolve_dependencies__in_empty_venv__reverts_to_id_mapping(tmp_path):
     venv.create(tmp_path, with_pip=False)
+    id_mapping = IdentityMapping()
     actual = resolve_dependencies(["pip", "setuptools"], pyenv_path=tmp_path)
     assert actual == {
-        "pip": Package.identity_mapping("pip"),
-        "setuptools": Package.identity_mapping("setuptools"),
+        "pip": id_mapping.lookup_package("pip"),
+        "setuptools": id_mapping.lookup_package("setuptools"),
     }
 
 
@@ -114,7 +116,7 @@ def test_resolve_dependencies__in_fake_venv__returns_local_and_id_deps(fake_venv
     actual = resolve_dependencies(["PIP", "pandas", "empty-pkg"], pyenv_path=venv_dir)
     assert actual == {
         "PIP": Package("pip", {DependenciesMapping.LOCAL_ENV: {"pip"}}),
-        "pandas": Package.identity_mapping("pandas"),
+        "pandas": Package("pandas", {DependenciesMapping.IDENTITY: {"pandas"}}),
         "empty-pkg": Package("empty_pkg", {DependenciesMapping.LOCAL_ENV: set()}),
     }
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -6,6 +6,7 @@ import pytest
 
 from fawltydeps.packages import (
     DependenciesMapping,
+    IdentityMapping,
     LocalPackageResolver,
     Package,
     resolve_dependencies,
@@ -52,7 +53,8 @@ def test_package__empty_package__matches_nothing():
 def test_package__identity_mapping(
     package_name, matching_imports, non_matching_imports
 ):
-    p = Package.identity_mapping(package_name)
+    id_mapping = IdentityMapping()
+    p = id_mapping.lookup_package(package_name)
     assert p.package_name == package_name  # package name is not normalized
     assert p.is_used(matching_imports)
     assert not p.is_used(non_matching_imports)
@@ -123,7 +125,8 @@ def test_package__local_env_mapping(
 
 
 def test_package__both_mappings():
-    p = Package.identity_mapping("FooBar")
+    id_mapping = IdentityMapping()
+    p = id_mapping.lookup_package("FooBar")
     import_names = ["foo", "bar", "baz"]
     p.add_import_names(*import_names, mapping=DependenciesMapping.LOCAL_ENV)
     assert p.package_name == "FooBar"  # package name is not normalized
@@ -253,8 +256,7 @@ def test_resolve_dependencies__informs_once_when_id_mapping_is_used(caplog):
         (
             "fawltydeps.packages",
             logging.INFO,
-            "Could not find 'some-foo' in the current environment."
-            " Assuming it can be imported as some_foo",
+            "'some-foo' was not resolved. Assuming it can be imported as 'some_foo'.",
         )
     ]
     caplog.set_level(logging.INFO)

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -186,13 +186,14 @@ def test_package__both_mappings():
         ),
     ],
 )
-def test_LocalPackageLookup_lookup_package(dep_name, expect_import_names):
+def test_LocalPackageResolver_lookup_packages(dep_name, expect_import_names):
     lpl = LocalPackageResolver()
-    actual = lpl.lookup_package(dep_name)
+    actual = lpl.lookup_packages({dep_name})
     if expect_import_names is None:
-        assert actual is None
+        assert actual == {}
     else:
-        assert actual.import_names == expect_import_names
+        assert len(actual) == 1
+        assert actual[dep_name].import_names == expect_import_names
 
 
 @pytest.mark.parametrize(

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -6,7 +6,7 @@ import pytest
 
 from fawltydeps.packages import (
     DependenciesMapping,
-    LocalPackageLookup,
+    LocalPackageResolver,
     Package,
     resolve_dependencies,
 )
@@ -184,7 +184,7 @@ def test_package__both_mappings():
     ],
 )
 def test_LocalPackageLookup_lookup_package(dep_name, expect_import_names):
-    lpl = LocalPackageLookup()
+    lpl = LocalPackageResolver()
     actual = lpl.lookup_package(dep_name)
     if expect_import_names is None:
         assert actual is None

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -19,7 +19,7 @@ from urllib.request import urlretrieve
 import pytest
 from pkg_resources import Requirement
 
-from fawltydeps.packages import LocalPackageLookup
+from fawltydeps.packages import LocalPackageResolver
 from fawltydeps.types import TomlData
 
 from .project_helpers import BaseExperiment, BaseProject, JsonData, parse_toml
@@ -36,7 +36,7 @@ REAL_PROJECTS_DIR = Path(__file__).with_name("real_projects")
 
 
 def verify_requirements(venv_path: Path, requirements: List[str]) -> None:
-    lpl = LocalPackageLookup(venv_path)
+    lpl = LocalPackageResolver(venv_path)
     for req in requirements:
         if "python_version" in req:  # we don't know how to parse these (yet)
             continue  # skip checking this requirement

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -36,12 +36,13 @@ REAL_PROJECTS_DIR = Path(__file__).with_name("real_projects")
 
 
 def verify_requirements(venv_path: Path, requirements: List[str]) -> None:
-    lpl = LocalPackageResolver(venv_path)
-    for req in requirements:
-        if "python_version" in req:  # we don't know how to parse these (yet)
-            continue  # skip checking this requirement
-        pkg_name = Requirement.parse(req).unsafe_name
-        assert lpl.lookup_package(pkg_name) is not None
+    deps = {
+        Requirement.parse(req).unsafe_name
+        for req in requirements
+        if "python_version" not in req  # we don't know how to parse these (yet)
+    }
+    resolved = LocalPackageResolver(venv_path).lookup_packages(deps)
+    assert all(dep in resolved for dep in deps)
 
 
 def run_fawltydeps_json(

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -26,7 +26,7 @@ from typing import Iterator, List
 import pytest
 
 from fawltydeps.main import Analysis
-from fawltydeps.settings import Action, Settings
+from fawltydeps.settings import Action, Settings, print_toml_config
 from fawltydeps.types import TomlData
 from tests.utils import SAMPLE_PROJECTS_DIR
 
@@ -110,6 +110,9 @@ def test_integration_analysis_on_sample_projects__(request, project, experiment)
     print(f"Running sample project experiment: {experiment.name}")
     print(f"Experiment description: {experiment.description}")
     print()
+    print("Experiment settings:")
     settings = experiment.build_settings(project.path, request.config.cache)
+    print_toml_config(settings)
+    print()
     analysis = Analysis.create(settings)
     experiment.expectations.verify_analysis(analysis)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from fawltydeps.packages import DependenciesMapping, LocalPackageLookup, Package
+from fawltydeps.packages import DependenciesMapping, LocalPackageResolver, Package
 from fawltydeps.types import (
     DeclaredDependency,
     Location,
@@ -35,7 +35,7 @@ def collect_dep_names(deps: Iterable[DeclaredDependency]) -> Iterable[str]:
 # - pip (exposes a single import name: pip)
 # - isort (exposes no top_level.txt, but 'isort' import name can be inferred)
 
-local_env = LocalPackageLookup()
+local_env = LocalPackageResolver()
 
 
 def imports_factory(*imports: str) -> List[ParsedImport]:


### PR DESCRIPTION
This does not change current behavior, but does a preliminary
refactoring on the way towards having multiple package-to-import
resolvers as discussed in #256 and associated issues.

Introduce a `BasePackageResolver` abstract base class to define the
interface for package resolvers, and provide, for now, two subclasses:

- `LocalPackageResolver` (renamed from `LocalPackageLookup`)
- `IdentityMapping` (refactored from `resolve_dependencies()`)

Also refactor `resolved_dependencies()` to operate on a list of
`BasePackageResolver` objects: For each dependency name we go through the
list of resolvers until a resolver returns a `Package` object for this
name. We then add this `Package` to the returned mapping.

For now this list of resolvers is hardcoded to exactly two entries, the
`LocalPackageResolver` we were already using, and the `IdentityMapping` that
we were effectively falling back on for packages not found in the former.

Ideas for future work that build on this:
- Introduce more/different `BasePackageResolver` subclasses to do
  different kinds of package resolving. E.g. user-defined mapping from a
  config file. Resolving by looking up packages remotely on PyPI, etc.
- Make the list of resolvers user-configurable instead of hardcoded.
- Properly handle the case where none of the resolver find a package
  mapping, i.e. _unmapped_ depenedencies.
