### PR TITLE
Tests refactor: running fawltydeps on 'main' instead of in subprocess in command line tests

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -229,7 +229,7 @@ def print_output(
     if analysis.settings.output_format == OutputFormat.JSON:
         analysis.print_json(stdout)
     elif analysis.settings.output_format == OutputFormat.HUMAN_DETAILED:
-        analysis.print_human_readable(sys.stdout, details=True)
+        analysis.print_human_readable(stdout, details=True)
         if exit_code == 0 and success_message:
             print(f"\n{success_message}", file=stdout)
     elif analysis.settings.output_format == OutputFormat.HUMAN_SUMMARY:

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -16,7 +16,7 @@ from fawltydeps.main import UNUSED_DEPS_OUTPUT_PREFIX, VERBOSE_PROMPT, Analysis,
 from fawltydeps.types import Location, UnusedDependency
 
 from .test_extract_imports_simple import generate_notebook
-from .utils import assert_unordered_equivalence, run_fawltydeps
+from .utils import assert_unordered_equivalence, run_fawltydeps, run_fawltydeps_function
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +152,7 @@ def test_list_imports_json__from_py_file__prints_imports_from_file(write_tmp_fil
         "unused_deps": None,
         "version": version(),
     }
-    output, _errors, returncode = run_fawltydeps(
+    output, returncode = run_fawltydeps_function(
         "--list-imports", "--json", f"--code={tmp_path}/myfile.py"
     )
     assert json.loads(output) == expect
@@ -333,7 +333,7 @@ def test_list_deps_json__dir__prints_deps_from_requirements_txt(
         "unused_deps": None,
         "version": version(),
     }
-    output, _errors, returncode = run_fawltydeps(
+    output, returncode = run_fawltydeps_function(
         "--list-deps", "--json", f"--deps={tmp_path}"
     )
     assert json.loads(output) == expect
@@ -605,7 +605,7 @@ def test_check_json__simple_project__can_report_both_undeclared_and_unused(
         ],
         "version": version(),
     }
-    output, _errors, returncode = run_fawltydeps(
+    output, returncode = run_fawltydeps_function(
         "--check", "--json", f"--code={tmp_path}", f"--deps={tmp_path}"
     )
     assert json.loads(output) == expect

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -637,7 +637,6 @@ def test_check_unused__simple_project__reports_only_unused(
     )
 
     expect = [
-        "",
         "These dependencies appear to be unused (i.e. not imported):",
         "- 'pandas' declared in:",
         f"    {tmp_path / 'requirements.txt'}",
@@ -663,7 +662,6 @@ def test__no_action__defaults_to_check_action(
     )
 
     expect = [
-        "",
         "These imports appear to be undeclared dependencies:",
         "- 'requests' imported at:",
         f"    {tmp_path / 'code.py'}:1",
@@ -688,7 +686,6 @@ def test__no_options__defaults_to_check_action_in_current_dir(
     )
 
     expect = [
-        "",
         "These imports appear to be undeclared dependencies:",
         "- 'requests' imported at:",
         f"    {tmp_path / 'code.py'}:1",
@@ -697,7 +694,7 @@ def test__no_options__defaults_to_check_action_in_current_dir(
         "- 'pandas' declared in:",
         f"    {tmp_path / 'requirements.txt'}",
     ]
-    output, returncode = run_fawltydeps_function("--detailed", "-v", cwd=tmp_path)
+    output, returncode = run_fawltydeps_function("--detailed", "-v", basepath=tmp_path)
     assert output.splitlines() == expect
     assert returncode == 3
 
@@ -740,7 +737,6 @@ def test_check__simple_project_in_fake_venv__resolves_imports_vs_deps(
         "--detailed", f"--code={tmp_path}", f"--deps={tmp_path}", f"--pyenv={venv_dir}"
     )
     assert output.splitlines() == [
-        "",
         Analysis.success_message(check_undeclared=True, check_unused=True),
     ]
     assert returncode == 0

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -533,10 +533,16 @@ def test_check_undeclared_and_unused(
     output, logs, returncode = run_fawltydeps(
         *[option.format(path=tmp_path) for option in vector.options]
     )
+    # Order of output is determined, as we use alphabetical ordering.
     assert output.splitlines() == [
         v.format(path=tmp_path) for v in vector.expect_output
     ]
-    assert logs == "\n".join([v.format(path=tmp_path) for v in vector.expect_logs])
+    # We do set comparison here, as the evaluation order of
+    # input is not determined. In the process of evaluation,
+    # we use sets (like in IdentityMapping fallback).
+    assert {l for l in logs.split("\n") if l != ""} == {
+        v.format(path=tmp_path) for v in vector.expect_logs
+    }
     assert returncode == vector.expect_returncode
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -102,15 +102,15 @@ def run_fawltydeps_function(
     *args: str,
     config_file: Path = Path("/dev/null"),
     to_stdin: Optional[str] = None,
-    cwd: Optional[Path] = None,
+    basepath: Optional[Path] = None,
 ) -> Tuple[str, int]:
     """Run FawltyDeps with `main` function. Designed for unit tests.
 
-    Ignores logging output and returns stdout and the exti code
+    Ignores logging output and returns stdout and the exit code
     """
     output = io.StringIO()
     exit_code = main(
-        cmdline_args=([str(cwd)] if cwd else [])
+        cmdline_args=([str(basepath)] if basepath else [])
         + [f"--config-file={str(config_file)}"]
         + list(args),
         stdin=io.StringIO(to_stdin),
@@ -124,7 +124,7 @@ def run_fawltydeps_function(
         "    ----------------"
     )
     output.close()
-    return output_value, exit_code
+    return output_value.strip(), exit_code
 
 
 @dataclass

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+from fawltydeps.main import main
 from fawltydeps.packages import (
     DependenciesMapping,
     IdentityMapping,
@@ -20,7 +21,6 @@ from fawltydeps.types import (
     UndeclaredDependency,
     UnusedDependency,
 )
-from fawltydeps.main import main
 
 SAMPLE_PROJECTS_DIR = Path(__file__).with_name("sample_projects")
 
@@ -103,7 +103,7 @@ def run_fawltydeps_function(
     config_file: Path = Path("/dev/null"),
     to_stdin: Optional[str] = None,
     cwd: Optional[Path] = None,
-) -> Tuple[str, str, int]:
+) -> Tuple[str, int]:
     """Run FawltyDeps with `main` function. Designed for unit tests.
 
     Ignores logging output and returns stdout and the exti code
@@ -123,6 +123,7 @@ def run_fawltydeps_function(
         f"    ---- STDOUT ----\n{output_value}"
         "    ----------------"
     )
+    output.close()
     return output_value, exit_code
 
 


### PR DESCRIPTION
Tests refactor aiming at speeding up the tests and reducing some unnecessarily tested logs equalities, that may end up slowing down refactors of the code.

Things improved:
- fixed bug in `print_output` function, where one of the writers were still using `sys.stdout`.
- introduce `ProjectTestsVector` and parameterized some of the tests in `tests_cmdline`
- introduce `run_fawltydeps_function` that uses `main` function instead of subprocesses to run FawltyDeps. Tests with using this function are simpler, we do not collect `stderr` and only compare output and exit code.
- rewrite some of tests in `test_cmdine` to use the above function to reduce unnecessary checks of log messages,



## Experiments
From a simple check below, we see that there is some improvement in the execution time of tests suites. There are some more gains, if we use `run_fawltydeps_function` instead of `run_faltydeps` more extensively. But for this PR it is enough :)
**Current**
```
time nox -s tests
...
real	2m11.658s
user	1m55.989s
sys	0m7.951s

```

```
time nox -Rs tests
...
real	1m39.510s
user	1m33.693s
sys	0m5.844s
```

**Previous**
```
time nox -s tests
...
real	2m22.484s
user	2m5.909s
sys	0m8.902s
```

```
time nox -Rs tests
...
real	1m58.316s
user	1m51.029s
sys	0m7.309s

```