### PR TITLE
Refactor: reorder CLI options and add "Source paths" group

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -31,7 +31,6 @@ from fawltydeps.settings import (
     Settings,
     print_toml_config,
     setup_cmdline_parser,
-    version,
 )
 from fawltydeps.types import (
     DeclaredDependency,
@@ -40,6 +39,7 @@ from fawltydeps.types import (
     UnparseablePathException,
     UnusedDependency,
 )
+from fawltydeps.utils import version
 
 logger = logging.getLogger(__name__)
 

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -17,10 +17,8 @@ import sys
 from dataclasses import dataclass
 from functools import partial
 from operator import attrgetter
-from pathlib import Path
-from typing import Dict, List, Optional, TextIO, no_type_check
+from typing import Dict, List, Optional, TextIO
 
-import importlib_metadata
 from pydantic.json import custom_pydantic_encoder  # pylint: disable=no-name-in-module
 
 from fawltydeps import extract_imports
@@ -33,6 +31,7 @@ from fawltydeps.settings import (
     Settings,
     print_toml_config,
     setup_cmdline_parser,
+    version,
 )
 from fawltydeps.types import (
     DeclaredDependency,
@@ -46,17 +45,6 @@ logger = logging.getLogger(__name__)
 
 VERBOSE_PROMPT = "For a more verbose report re-run with the `--detailed` option."
 UNUSED_DEPS_OUTPUT_PREFIX = "These dependencies appear to be unused (i.e. not imported)"
-
-
-@no_type_check
-def version() -> str:
-    """Returns the version of fawltydeps."""
-
-    # This function is extracted to allow annotation with `@no_type_check`.
-    # Using `#type: ignore` on the line below leads to an
-    # "unused type ignore comment" MyPy error in python's version 3.8 and
-    # higher.
-    return str(importlib_metadata.version("fawltydeps"))
 
 
 @dataclass
@@ -191,23 +179,25 @@ def build_parser() -> argparse.ArgumentParser:
     """Create the CLI parser."""
     parser, option_group = setup_cmdline_parser(description=__doc__)
     option_group.add_argument(
+        "--generate-toml-config",
+        action="store_true",
+        default=False,
+        help="Print a TOML config section with the current settings, and exit",
+    )
+    option_group.add_argument(
         "-V",
         "--version",
         action="version",
         version=f"FawltyDeps v{version()}",
         help="Print the version number of FawltyDeps",
     )
+    # setup_cmdline_parser() removes the automatic `--help` option so that we
+    # can control exactly where it's added. Here we add it back:
     option_group.add_argument(
-        "--config-file",
-        type=Path,
-        default=Path("./pyproject.toml"),
-        help="Where to find FawltyDeps config (default: ./pyproject.toml)",
-    )
-    option_group.add_argument(
-        "--generate-toml-config",
-        action="store_true",
-        default=False,
-        help="Print a TOML config section with the current settings, and exit",
+        "-h",
+        "--help",
+        action="help",
+        help="Show this help message and exit",
     )
     return parser
 

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -17,10 +17,8 @@ from typing import (
     Tuple,
     Type,
     Union,
-    no_type_check,
 )
 
-import importlib_metadata
 from pydantic import BaseSettings
 from pydantic.env_settings import SettingsSourceCallable  # pylint: disable=E0611
 
@@ -32,17 +30,6 @@ else:
     import tomli as tomllib
 
 logger = logging.getLogger(__name__)
-
-
-@no_type_check
-def version() -> str:
-    """Returns the version of fawltydeps."""
-
-    # This function is extracted to allow annotation with `@no_type_check`.
-    # Using `#type: ignore` on the line below leads to an
-    # "unused type ignore comment" MyPy error in python's version 3.8 and
-    # higher.
-    return str(importlib_metadata.version("fawltydeps"))
 
 
 class PyprojectTomlSettingsSource:

--- a/fawltydeps/utils.py
+++ b/fawltydeps/utils.py
@@ -3,7 +3,20 @@
 import os
 from dataclasses import is_dataclass
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, no_type_check
+
+import importlib_metadata
+
+
+@no_type_check
+def version() -> str:
+    """Returns the version of fawltydeps."""
+
+    # This function is extracted to allow annotation with `@no_type_check`.
+    # Using `#type: ignore` on the line below leads to an
+    # "unused type ignore comment" MyPy error in python's version 3.8 and
+    # higher.
+    return str(importlib_metadata.version("fawltydeps"))
 
 
 def walk_dir(path: Path) -> Iterator[Path]:


### PR DESCRIPTION
A small refactor of CLI options order before adding a new CLi option for a user #260 

What has changed:
- `version` function moved to settings module
- all argparse options are moved to settings module
- reorder of options displayed in the help message
- add "Source paths options" as a separate group to easier identify this presumably most common use case.

### CLI help message after
```
fawltydeps --help
usage: fawltydeps [--check | --check-undeclared | --check-unused | --list-imports | --list-deps] [--summary | --detailed | --json] [--code PATH_OR_STDIN [PATH_OR_STDIN ...]] [--deps PATH [PATH ...]]
                  [--pyenv PYENV_DIR] [--ignore-undeclared IMPORT_NAME [IMPORT_NAME ...]] [--ignore-unused DEP_NAME [DEP_NAME ...]]
                  [--deps-parser-choice {requirements.txt,setup.py,setup.cfg,pyproject.toml}] [--config-file CONFIG_FILE] [--generate-toml-config] [-v] [-q] [-V] [-h]
                  [basepaths ...]

Find undeclared and/or unused 3rd-party dependencies in your Python project.

Supports finding 3rd-party imports in Python scripts (*.py) and Jupyter
notebooks (*.ipynb).

Supports finding dependency declarations in *requirements*.txt (and .in) files,
pyproject.toml (following PEP 621 or Poetry conventions), setup.cfg, as well as
limited support for setup.py files with a single, simple setup() call and
minimal computation involved in setting the install_requires and extras_require
arguments.

Actions (choose one):
  --check               Report both undeclared and unused dependencies (default)
  --check-undeclared    Report only undeclared dependencies
  --check-unused        Report only unused dependencies
  --list-imports        List third-party imports extracted from code
  --list-deps           List declared dependencies

Output format (choose one):
  --summary             Generate human-readable summary report (default)
  --detailed            Generate human-readable detailed report
  --json                Generate JSON output instead of a human-readable report

Source paths options:
  basepaths             (Optional) directory in which to search for code (imports) and/or dependency declarations
  --code PATH_OR_STDIN [PATH_OR_STDIN ...]
                        Code to parse for import statements (file or directory, use '-' to read code from stdin; defaults to the current directory)
  --deps PATH [PATH ...]
                        Where to find dependency declarations (file or directory, defaults to looking for supported files in the current directory)
  --pyenv PYENV_DIR     Where to find a Python environment that has the project dependencies installed, defaults to the Python environment where FawltyDeps is installed.

Other options:
  --ignore-undeclared IMPORT_NAME [IMPORT_NAME ...]
                        Imports to ignore when looking for undeclared dependencies, e.g. --ignore-undeclared isort pkg_resources
  --ignore-unused DEP_NAME [DEP_NAME ...]
                        Dependencies to ignore when looking for unused dependencies, e.g. --ignore-unused pylint black
  --deps-parser-choice {requirements.txt,setup.py,setup.cfg,pyproject.toml}
                        Name of the parsing strategy to use for dependency declarations, useful for when the file to parse doesn't match a standard name
  --config-file CONFIG_FILE
                        Where to find FawltyDeps config (default: ./pyproject.toml)
  --generate-toml-config
                        Print a TOML config section with the current settings, and exit
  -v, --verbose         Increase log level (WARNING by default, -v: INFO, -vv: DEBUG)
  -q, --quiet           Decrease log level (WARNING by default, -q: ERROR, -qq: FATAL)
  -V, --version         Print the version number of FawltyDeps
  -h, --help            Show this help message and exit
```

### CLI help message before
```
fawltydeps --help
usage: fawltydeps [--check | --check-undeclared | --check-unused | --list-imports | --list-deps] [--summary | --detailed | --json] [--code PATH_OR_STDIN [PATH_OR_STDIN ...]] [--deps PATH [PATH ...]]
                  [--pyenv PYENV_DIR] [--ignore-undeclared IMPORT_NAME [IMPORT_NAME ...]] [--ignore-unused DEP_NAME [DEP_NAME ...]]
                  [--deps-parser-choice {requirements.txt,setup.py,setup.cfg,pyproject.toml}] [-v] [-q] [-h] [-V] [--config-file CONFIG_FILE] [--generate-toml-config]
                  [basepaths ...]

Find undeclared and/or unused 3rd-party dependencies in your Python project.

Supports finding 3rd-party imports in Python scripts (*.py) and Jupyter
notebooks (*.ipynb).

Supports finding dependency declarations in *requirements*.txt (and .in) files,
pyproject.toml (following PEP 621 or Poetry conventions), setup.cfg, as well as
limited support for setup.py files with a single, simple setup() call and
minimal computation involved in setting the install_requires and extras_require
arguments.

Actions (choose one):
  --check               Report both undeclared and unused dependencies (default)
  --check-undeclared    Report only undeclared dependencies
  --check-unused        Report only unused dependencies
  --list-imports        List third-party imports extracted from code
  --list-deps           List declared dependencies

Output format (choose one):
  --summary             Generate human-readable summary report (default)
  --detailed            Generate human-readable detailed report
  --json                Generate JSON output instead of a human-readable report

Other options:
  basepaths             (Optional) directory in which to search for code (imports) and/or dependency declarations
  --code PATH_OR_STDIN [PATH_OR_STDIN ...]
                        Code to parse for import statements (file or directory, use '-' to read code from stdin; defaults to the current directory)
  --deps PATH [PATH ...]
                        Where to find dependency declarations (file or directory, defaults to looking for supported files in the current directory)
  --pyenv PYENV_DIR     Where to find a Python environment that has the project dependencies installed, defaults to the Python environment where FawltyDeps is installed.
  --ignore-undeclared IMPORT_NAME [IMPORT_NAME ...]
                        Imports to ignore when looking for undeclared dependencies, e.g. --ignore-undeclared isort pkg_resources
  --ignore-unused DEP_NAME [DEP_NAME ...]
                        Dependencies to ignore when looking for unused dependencies, e.g. --ignore-unused pylint black
  --deps-parser-choice {requirements.txt,setup.py,setup.cfg,pyproject.toml}
                        Name of the parsing strategy to use for dependency declarations, useful for when the file to parse doesn't match a standard name
  -v, --verbose         Increase log level (WARNING by default, -v: INFO, -vv: DEBUG)
  -q, --quiet           Decrease log level (WARNING by default, -q: ERROR, -qq: FATAL)
  -h, --help            Show this help message and exit
  -V, --version         Print the version number of FawltyDeps
  --config-file CONFIG_FILE
                        Where to find FawltyDeps config (default: ./pyproject.toml)
  --generate-toml-config
                        Print a TOML config section with the current settings, and exit
```