### PR TITLE
Preparing for the traversal refactoring

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -14,10 +14,9 @@ import argparse
 import json
 import logging
 import sys
-from dataclasses import dataclass
-from functools import partial
+from functools import partial, wraps
 from operator import attrgetter
-from typing import Dict, List, Optional, TextIO
+from typing import Callable, Dict, List, Optional, TextIO, TypeVar
 
 from pydantic.json import custom_pydantic_encoder  # pylint: disable=no-name-in-module
 
@@ -47,33 +46,97 @@ VERBOSE_PROMPT = "For a more verbose report re-run with the `--detailed` option.
 UNUSED_DEPS_OUTPUT_PREFIX = "These dependencies appear to be unused (i.e. not imported)"
 
 
-@dataclass
-class Analysis:
+Instance = TypeVar("Instance")
+T = TypeVar("T")
+
+
+def calculated_once(method: Callable[[Instance], T]) -> Callable[[Instance], T]:
+    """Emulate functools.cached_property for our simple use case.
+
+    functools.cached_property does not exist in Python v3.7, so we emulate the
+    simple things we need here:
+
+    Each method that uses this decorator will store its return value in an
+    instance attribute whose name is the method name prefixed with underscore.
+    The first time the property is referenced, the method will be called, its
+    return value stored in the corresponding instance attribute, and also
+    returned to the caller. All subsequent references (as long as the stored
+    value it not None) will return the instance attribute value directly,
+    without calling the method.
+    """
+
+    @wraps(method)
+    def wrapper(self: Instance) -> T:
+        cached_attr = f"_{method.__name__}"
+        cached_value: Optional[T] = getattr(self, cached_attr, None)
+        if cached_value is not None:
+            return cached_value
+        calculated: T = method(self)
+        setattr(self, cached_attr, calculated)
+        return calculated
+
+    return wrapper
+
+
+class Analysis:  # pylint: disable=too-many-instance-attributes
     """Result from FawltyDeps analysis, to be presented to the user."""
 
-    settings: Settings
-    imports: Optional[List[ParsedImport]] = None
-    declared_deps: Optional[List[DeclaredDependency]] = None
-    resolved_deps: Optional[Dict[str, Package]] = None
-    undeclared_deps: Optional[List[UndeclaredDependency]] = None
-    unused_deps: Optional[List[UnusedDependency]] = None
-    version: str = version()
+    def __init__(self, settings: Settings, stdin: Optional[TextIO] = None):
+        self.settings = settings
+        self.stdin = stdin
+        self.version = version()
+
+        # The following members are calculated once, on-demand, by the
+        # @property @calculated_once methods below:
+        self._imports: Optional[List[ParsedImport]] = None
+        self._declared_deps: Optional[List[DeclaredDependency]] = None
+        self._resolved_deps: Optional[Dict[str, Package]] = None
+        self._undeclared_deps: Optional[List[UndeclaredDependency]] = None
+        self._unused_deps: Optional[List[UnusedDependency]] = None
 
     def is_enabled(self, *args: Action) -> bool:
         """Return True if any of the given actions are in self.settings."""
         return len(self.settings.actions.intersection(args)) > 0
 
-    @staticmethod
-    def success_message(check_undeclared: bool, check_unused: bool) -> Optional[str]:
-        """Returns the message to print when the analysis finds no errors."""
-        checking = []
-        if check_undeclared:
-            checking.append("undeclared")
-        if check_unused:
-            checking.append("unused")
-        if checking:
-            return f"No {' or '.join(checking)} dependencies detected."
-        return None
+    @property
+    @calculated_once
+    def imports(self) -> List[ParsedImport]:
+        """The list of 3rd-party imports parsed from this project."""
+        return list(extract_imports.parse_any_args(self.settings.code, self.stdin))
+
+    @property
+    @calculated_once
+    def declared_deps(self) -> List[DeclaredDependency]:
+        """The list of declared dependencies parsed from this project."""
+        return list(
+            extract_declared_dependencies(
+                self.settings.deps, self.settings.deps_parser_choice
+            )
+        )
+
+    @property
+    @calculated_once
+    def resolved_deps(self) -> Dict[str, Package]:
+        """The resolved mapping of dependency names to provided import names."""
+        return resolve_dependencies(
+            (dep.name for dep in self.declared_deps),
+            pyenv_path=self.settings.pyenv,
+            install_deps=self.settings.install_deps,
+        )
+
+    @property
+    @calculated_once
+    def undeclared_deps(self) -> List[UndeclaredDependency]:
+        """The import statements for which no declared dependency is found."""
+        return calculate_undeclared(self.imports, self.resolved_deps, self.settings)
+
+    @property
+    @calculated_once
+    def unused_deps(self) -> List[UnusedDependency]:
+        """The declared dependencies that appear to not be in use."""
+        return calculate_unused(
+            self.imports, self.declared_deps, self.resolved_deps, self.settings
+        )
 
     @classmethod
     def create(cls, settings: Settings, stdin: Optional[TextIO] = None) -> "Analysis":
@@ -87,44 +150,17 @@ class Analysis:
         this can also be called from other Python contexts without having to go
         via the command-line.
         """
-        ret = cls(settings)
-        if ret.is_enabled(
-            Action.LIST_IMPORTS, Action.REPORT_UNDECLARED, Action.REPORT_UNUSED
-        ):
-            ret.imports = list(extract_imports.parse_any_args(settings.code, stdin))
+        ret = cls(settings, stdin)
 
-        if ret.is_enabled(
-            Action.LIST_DEPS, Action.REPORT_UNDECLARED, Action.REPORT_UNUSED
-        ):
-            ret.declared_deps = list(
-                extract_declared_dependencies(
-                    settings.deps, settings.deps_parser_choice
-                )
-            )
-
-        if ret.is_enabled(Action.REPORT_UNDECLARED, Action.REPORT_UNUSED):
-            assert ret.imports is not None  # convince Mypy that these cannot
-            assert ret.declared_deps is not None  # be None at this time.
-            ret.resolved_deps = resolve_dependencies(
-                (dep.name for dep in ret.declared_deps),
-                pyenv_path=settings.pyenv,
-                install_deps=settings.install_deps,
-            )
-
+        # Compute only the properties needed to satisfy settings.actions:
+        if ret.is_enabled(Action.LIST_IMPORTS):
+            ret.imports  # pylint: disable=pointless-statement
+        if ret.is_enabled(Action.LIST_DEPS):
+            ret.declared_deps  # pylint: disable=pointless-statement
         if ret.is_enabled(Action.REPORT_UNDECLARED):
-            assert ret.imports is not None  # convince Mypy that these cannot
-            assert ret.resolved_deps is not None  # be None at this time.
-            ret.undeclared_deps = calculate_undeclared(
-                ret.imports, ret.resolved_deps, settings
-            )
-
+            ret.undeclared_deps  # pylint: disable=pointless-statement
         if ret.is_enabled(Action.REPORT_UNUSED):
-            assert ret.imports is not None  # convince Mypy that these cannot
-            assert ret.declared_deps is not None  # be None at this time.
-            assert ret.resolved_deps is not None
-            ret.unused_deps = calculate_unused(
-                ret.imports, ret.declared_deps, ret.resolved_deps, settings
-            )
+            ret.unused_deps  # pylint: disable=pointless-statement
 
         return ret
 
@@ -137,12 +173,23 @@ class Analysis:
         # Path), so order by string representation instead:
         set_sort = partial(sorted, key=str)
         encoder = partial(custom_pydantic_encoder, {frozenset: set_sort, set: set_sort})
-        json.dump(self, out, indent=2, default=encoder)
+        json_dict = {
+            "settings": self.settings,
+            # Using properties with an underscore do not trigger computations.
+            # They are populated only if the computations were already required
+            # by settings.actions.
+            "imports": self._imports,
+            "declared_deps": self._declared_deps,
+            "resolved_deps": self._resolved_deps,
+            "undeclared_deps": self._undeclared_deps,
+            "unused_deps": self._unused_deps,
+            "version": self.version,
+        }
+        json.dump(json_dict, out, indent=2, default=encoder)
 
     def print_human_readable(self, out: TextIO, details: bool = True) -> None:
         """Print a human-readable rendering of this analysis to 'out'."""
         if self.is_enabled(Action.LIST_IMPORTS):
-            assert self.imports is not None  # sanity-check / convince Mypy
             if details:
                 # Sort imports by source, then by name
                 for imp in sorted(self.imports, key=attrgetter("source", "name")):
@@ -152,7 +199,6 @@ class Analysis:
                 print("\n".join(sorted(unique_imports)), file=out)
 
         if self.is_enabled(Action.LIST_DEPS):
-            assert self.declared_deps is not None  # sanity-check / convince Mypy
             if details:
                 # Sort dependencies by location, then by name
                 for dep in sorted(
@@ -173,6 +219,18 @@ class Analysis:
             print(f"\n{UNUSED_DEPS_OUTPUT_PREFIX}:", file=out)
             for unused in sorted(self.unused_deps, key=lambda d: d.name):
                 print(f"- {unused.render(details)}", file=out)
+
+    @staticmethod
+    def success_message(check_undeclared: bool, check_unused: bool) -> Optional[str]:
+        """Returns the message to print when the analysis finds no errors."""
+        checking = []
+        if check_undeclared:
+            checking.append("undeclared")
+        if check_unused:
+            checking.append("unused")
+        if checking:
+            return f"No {' or '.join(checking)} dependencies detected."
+        return None
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/noxfile.py
+++ b/noxfile.py
@@ -86,9 +86,17 @@ def lint(session):
     install_groups(session, include=["lint"])
     session.run("mypy")
     session.run("pylint", "fawltydeps")
+    test_extra_pylint_disable = [
+        "invalid-name",
+        "missing-function-docstring",
+        "protected-access",
+        "redefined-outer-name",
+        "too-many-arguments",
+        "too-many-lines",
+    ]
     session.run(
         "pylint",
-        "--disable=missing-function-docstring,invalid-name,redefined-outer-name,too-many-lines,too-many-arguments",
+        f"--disable={','.join(test_extra_pylint_disable)}",
         "tests",
     )
 

--- a/tests/sample_projects/empty/expected.toml
+++ b/tests/sample_projects/empty/expected.toml
@@ -1,0 +1,21 @@
+[project]
+# General information about a simplified project: Its name, why we test it,
+# its relation to real world projects
+name = "empty"
+description = "A completely empty project. No code, no deps"
+
+[experiments.default]
+description = "Run fawltydeps in an empty project"
+requirements = []  # rely on identity mapping
+
+# 3rd-party imports found in the code:
+imports = []
+
+# Declared dependencies found in the project configuration:
+declared_deps = []
+
+# Import names in the code that do not have a matching dependency declared:
+undeclared_deps = []
+
+# Declared dependencies which were never `import`ed from the code:
+unused_deps = []

--- a/tests/sample_projects/mixed_project/expected.toml
+++ b/tests/sample_projects/mixed_project/expected.toml
@@ -1,0 +1,48 @@
+[project]
+# General information about a simplified project: Its name, why we test it,
+# its relation to real world projects
+name = "mixed_project"
+description = "A project with Python code and declared deps in various formats."
+
+[experiments.default]
+description = "Run fawltydeps with no options on entire project"
+requirements = []  # rely on identity mapping
+
+# Skip: 3rd-party imports found in the code:
+# imports = []
+
+# Skip: Declared dependencies found in the project configuration:
+# declared_deps = []
+
+# Import names in the code that do not have a matching dependency declared:
+undeclared_deps = ["tomli"]
+
+# Declared dependencies which were never `import`ed from the code:
+unused_deps = ["black", "jieba", "tox"]
+
+[experiments.subdir2]
+description = "Run fawltydeps on subdir2 only"
+code = ["subdir2"]
+deps = ["subdir2"]
+requirements = []  # rely on identity mapping
+
+# 3rd-party imports found in the code:
+imports = [
+    # subdir2/notebook.ipynb
+    "pandas",
+    "numpy",
+    # subdir2/script.py
+    "requests",
+    "tomli",
+    # subdir2/setup.py
+    "setuptools",
+]
+
+# Declared dependencies found in subdir2/setup.py:
+declared_deps = ["pandas", "click", "requests", "jieba"]
+
+# Import names in the code that do not have a matching dependency declared:
+undeclared_deps = ["numpy", "setuptools", "tomli"]
+
+# Declared dependencies which were never `import`ed from the code:
+unused_deps = ["click", "jieba"]

--- a/tests/sample_projects/mixed_project/main.py
+++ b/tests/sample_projects/mixed_project/main.py
@@ -1,0 +1,1 @@
+import click

--- a/tests/sample_projects/mixed_project/pyproject.toml
+++ b/tests/sample_projects/mixed_project/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "mixed"
+
+dependencies = ["numpy", "setuptools", "black"]
+
+[tool.black]
+target-version = ["py37"]

--- a/tests/sample_projects/mixed_project/subdir1/notebook.ipynb
+++ b/tests/sample_projects/mixed_project/subdir1/notebook.ipynb
@@ -1,0 +1,42 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": ""
+      },
+      "outputs": [],
+      "source": [
+        "import pandas"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": ""
+      },
+      "outputs": [],
+      "source": [
+        "import pytorch"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.9"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/tests/sample_projects/mixed_project/subdir1/script.py
+++ b/tests/sample_projects/mixed_project/subdir1/script.py
@@ -1,0 +1,11 @@
+from requests import Request, Session
+
+pyproject_url = "https://raw.githubusercontent.com/tweag/nickel/master/Cargo.toml"
+s = Session()
+req = Request("GET", pyproject_url)
+prepped = req.prepare()
+timeout = 10
+resp = s.send(prepped, timeout=timeout)
+
+print(f"GET {pyproject_url} => {resp.status_code}")
+print(resp.text)

--- a/tests/sample_projects/mixed_project/subdir1/setup.cfg
+++ b/tests/sample_projects/mixed_project/subdir1/setup.cfg
@@ -1,0 +1,4 @@
+[options]
+install_requires = pandas
+tests_require = tox
+extras_require = pytorch

--- a/tests/sample_projects/mixed_project/subdir2/notebook.ipynb
+++ b/tests/sample_projects/mixed_project/subdir2/notebook.ipynb
@@ -1,0 +1,42 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": ""
+      },
+      "outputs": [],
+      "source": [
+        "import pandas"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": ""
+      },
+      "outputs": [],
+      "source": [
+        "import numpy"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.9"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/tests/sample_projects/mixed_project/subdir2/script.py
+++ b/tests/sample_projects/mixed_project/subdir2/script.py
@@ -1,0 +1,20 @@
+import sys
+
+from requests import Request, Session
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+pyproject_url = "https://raw.githubusercontent.com/tweag/nickel/master/Cargo.toml"
+s = Session()
+req = Request("GET", pyproject_url)
+prepped = req.prepare()
+timeout = 10
+resp = s.send(prepped, timeout=timeout)
+
+print(f"GET {pyproject_url} => {resp.status_code}")
+cargo = tomllib.loads(resp.text)
+print()
+print(f"{cargo['package']['name']} v{cargo['package']['version']}")

--- a/tests/sample_projects/mixed_project/subdir2/setup.py
+++ b/tests/sample_projects/mixed_project/subdir2/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup
+
+setup(
+    name="MyLib",
+    install_requires=["pandas", "click>=1.2"],
+    extras_require={"http": ["requests"], "chinese": ["jieba"]},
+)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,52 @@
+"""Verify behavior of the Analysis class."""
+
+from fawltydeps.main import calculated_once
+
+
+class CalculatedOnceExample:
+    """Example class using @calculated_once properties."""
+
+    def __init__(self):
+        self._memberA = None
+        self._memberB = None
+
+    @property
+    @calculated_once
+    def memberA(self) -> int:
+        """Property that changes value if it's calculated more than once."""
+        prev_value: int = 0 if self._memberA is None else self._memberA
+        return prev_value + 1
+
+    @property
+    @calculated_once
+    def memberB(self) -> int:
+        """Property that depends on another property calculated first."""
+        return self.memberA + 1
+
+
+def test_calculcated_once():
+    obj = CalculatedOnceExample()
+    assert obj._memberA is None  # not yet calculated
+    assert obj.memberA == 1  # first reference triggers calculation
+    assert obj._memberA == 1  # now it's calculated
+
+    assert obj._memberB is None  # not yet calculated
+    assert obj.memberB == 2  # first reference triggers calculation
+    assert obj._memberB == 2  # now it's calculated
+
+    assert obj.memberA == 1  # subsequent references
+    assert obj.memberB == 2
+    assert obj._memberA == 1  # do not recalculate
+    assert obj._memberB == 2
+
+    obj = CalculatedOnceExample()
+    assert obj._memberA is None  # not yet calculated
+    assert obj._memberB is None
+    assert obj.memberB == 2  # trigger calculation of both
+    assert obj._memberA == 1  # both calculated now
+    assert obj._memberB == 2
+
+    assert obj.memberA == 1  # subsequent references
+    assert obj.memberB == 2
+    assert obj._memberA == 1  # do not recalculate
+    assert obj._memberB == 2

--- a/tests/test_cmdline_options.py
+++ b/tests/test_cmdline_options.py
@@ -145,7 +145,7 @@ def cli_arguments_combinations(draw):
     # to point to a parser that we want fawltydeps to use.
     # Following code ensures that we do not encounter trying to match
     # explicit file with incorrect parser (square in the oval-shaped hole problem)
-    drawn_deps = draw(deps_option_strategy(dep_paths))
+    drawn_deps = [] if not dep_paths else draw(deps_option_strategy(dep_paths))
     deps_parser = []
     drawn_deps_parser = draw(deps_parser_choice_strategy)
     # a simple and not 100% accurate check if deps parser matches explicitly given file

--- a/tests/test_cmdline_options.py
+++ b/tests/test_cmdline_options.py
@@ -91,6 +91,8 @@ output_formats_strategy = st.lists(
 
 
 def code_option_strategy(paths: List[str]):
+    if not paths:
+        return st.just([])
     return st.lists(
         st.sampled_from(paths),
         min_size=0,
@@ -99,6 +101,8 @@ def code_option_strategy(paths: List[str]):
 
 
 def deps_option_strategy(paths: List[str]):
+    if not paths:
+        return st.just([])
     return st.lists(
         st.sampled_from(paths),
         min_size=0,
@@ -145,7 +149,7 @@ def cli_arguments_combinations(draw):
     # to point to a parser that we want fawltydeps to use.
     # Following code ensures that we do not encounter trying to match
     # explicit file with incorrect parser (square in the oval-shaped hole problem)
-    drawn_deps = [] if not dep_paths else draw(deps_option_strategy(dep_paths))
+    drawn_deps = draw(deps_option_strategy(dep_paths))
     deps_parser = []
     drawn_deps_parser = draw(deps_parser_choice_strategy)
     # a simple and not 100% accurate check if deps parser matches explicitly given file
@@ -170,10 +174,9 @@ def cli_arguments_combinations(draw):
 
     # only `code` option changes to_stdin
     code = draw(code_option_strategy(code_paths))
-    if code is not None:
-        if "-" in code:
-            to_stdin = example_python_stdin
-        args += code
+    if "-" in code:
+        to_stdin = example_python_stdin
+    args += code
 
     return (project_dir, args, to_stdin)
 

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -45,7 +45,7 @@ def generate_notebook(
     def cell_template(cell_type: str, source: List[str]):
         return {
             "cell_type": cell_type,
-            "execution_count": "null",
+            "execution_count": None,
             "metadata": {"id": ""},
             "outputs": [],
             "source": source,
@@ -238,7 +238,7 @@ def test_parse_notebook_file__two_cells__extracts_from_cell_with_imports(tmp_pat
 
 def test_parse_notebook_file__two_cells__extracts_from_code_cell(tmp_path):
     code = generate_notebook(
-        [["import pandas"], ["import pytcorch"]], ["code", "markdown"]
+        [["import pandas"], ["import pytorch"]], ["code", "markdown"]
     )
     script = tmp_path / "test.ipynb"
     script.write_text(code)


### PR DESCRIPTION
While working on the project traversal refactoring that I talked about yesterday,
these commits that do not strictly need to be part of that work has settled down
to the bottom of my branch. They deserve to be reviewed/considered separately before
the rest of the (still-ongoing) traversal work is submitted.

Commits:
- `test_extract_imports_simple`: Minor inconsequential fixes
- `sample_projects`: Add empty project
- `sample_projects`: Add mixed project
- `main`: Refactor `Analysis` object to remove annoying asserts
