### PR TITLE
noxfile.py: More stats in our test output

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -65,13 +65,20 @@ def install_groups(
 @nox.session(python=python_versions)
 def tests(session):
     install_groups(session, include=["test"])
-    session.run("pytest", "-x", "--log-level=debug", *session.posargs)
+    session.run(
+        "pytest",
+        "-x",
+        "--log-level=debug",
+        "--durations=10",
+        "--hypothesis-show-statistics",
+        *session.posargs,
+    )
 
 
 @nox.session(python=python_versions)
 def integration_tests(session):
     install_groups(session, include=["test"])
-    session.run("pytest", "-x", "-m", "integration", *session.posargs)
+    session.run("pytest", "-x", "-m", "integration", "--durations=10", *session.posargs)
 
 
 @nox.session(python=python_versions)


### PR DESCRIPTION
We want to keep track of which tests take the longest to run, both
locally, but especially in CI where we now see very long test runtimes.

Also, add --hypothesis-show-statistics to our "tests" session to print
relevant stats from Hypothesis.
