### PR TITLE
Update isort to v5.11.5, but no further

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -209,7 +209,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "isort"
-version = "5.11.4"
+version = "5.11.5"
 description = "A Python utility / library to sort Python imports."
 category = "main"
 optional = false
@@ -217,7 +217,7 @@ python-versions = ">=3.7.0"
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
 plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
@@ -593,8 +593,8 @@ iniconfig = [
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
 isort = [
-    {file = "isort-5.11.4-py3-none-any.whl", hash = "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"},
-    {file = "isort-5.11.4.tar.gz", hash = "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6"},
+    {file = "isort-5.11.5-py3-none-any.whl", hash = "sha256:ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746"},
+    {file = "isort-5.11.5.tar.gz", hash = "sha256:6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.9.0.tar.gz", hash = "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -519,7 +519,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "dc229546d6dc7dc532137acd8ad3f71920fd90853f7eeb65a1aba96ce9383054"
+content-hash = "6103f324dc2f0cfbc937ffba3d863af3c2a0b7e9366aa05fb7e47a8f04e22c2d"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ fawltydeps = "fawltydeps.main:main"
 # Do not add anything here that is only needed by CI/tests/linters/developers
 python = "^3.7.2"
 importlib_metadata = "^6.0.0"
-isort = "^5.10"
+# isort 5.12.0 drops support for Python v3.7:
+isort = ">=5.10,<5.12.0"
 pip-requirements-parser = "^32.0.1"
 pydantic = "^1.10.4"
 tomli = {version = "^2.0.1", python = "<3.11"}
@@ -70,7 +71,7 @@ optional = true
 [tool.poetry.group.format.dependencies]
 black = "^22"
 colorama = "^0.4.6"
-isort = "^5.10"
+isort = ">=5.10,<5.12.0"
 codespell = "^2.2.2"
 
 [tool.poetry.group.dev]
@@ -85,7 +86,7 @@ black = "^22"
 codespell = "^2.2.2"
 colorama = "^0.4.6"
 hypothesis = "^6.68.2"
-isort = "^5.10"
+isort = ">=5.10,<5.12.0"
 mypy = "^0.991"
 nox = "^2022.11.21"
 pylint = "^2.15.8"


### PR DESCRIPTION
This supersedes #272, to fix using FawltyDeps with newer versions of Poetry (poetry-core>=1.5.0).

Thanks to @janydoe for submitting #272. This PR rephrases their commit to only include the `poetry.lock`
changes directly associated with the `isort` upgrade, but omitting collateral changes caused by the newer
Poetry version. AFAICS, these collateral changes cause an older Poetry version (e.g. the v1.2.2 version
used by our `shell.nix`) to loop forever when running `poetry lock --no-udpate`.

I also add another commit preventing `isort` from upgrading to v5.12.0, which is the version where isort
drop support for Python v3.7.

Commits:
- `poetry.lock`: Update `isort` (5.11.4 -> 5.11.5)
- `pyproject.toml`: Don't upgrade `isort` to 5.12.0
