### PR TITLE
Traverse refactor, part 1

### DIFF
--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -173,12 +173,7 @@ def parse_source(
             logger.warning("Reading code from terminal input. Ctrl+D to stop.")
         return parse_code(stdin.read(), source=Location(src.path))
 
-    # sanity checks (CodeSource invariants given that src.path != "<stdin>")
-    assert (
-        isinstance(src.path, Path)
-        and src.path.is_file()
-        and src.path.suffix in {".py", ".ipynb"}
-    )
+    assert isinstance(src.path, Path)  # sanity check / silence mypy
 
     local_context = (
         None
@@ -195,10 +190,7 @@ def parse_source(
     if src.path.suffix == ".ipynb":
         logger.info("Parsing Notebook file %s", src.path)
         return parse_notebook_file(src.path, local_context)
-    raise UnparseablePathException(  # SHOULD NOT HAPPEN!
-        ctx="Supported formats are .py and .ipynb; Cannot parse code",
-        path=src.path,
-    )
+    raise RuntimeError("MISMATCH BETWEEN CODE PATH AND CODE PARSERS!")
 
 
 def parse_sources(
@@ -223,15 +215,7 @@ def validate_code_source(
     if path == "<stdin>":
         return CodeSource(path, base_dir)
     assert isinstance(path, Path)  # sanity check: SpecialPath handled above
-    if path.is_file():
-        if path.suffix in {".py", ".ipynb"}:
-            return CodeSource(path, base_dir)
-        raise UnparseablePathException(
-            ctx="Supported formats are .py and .ipynb; Cannot parse code", path=path
-        )
     if path.is_dir():
         logger.info("Finding Python files under %s", path)
         return None
-    raise UnparseablePathException(
-        ctx="Code path to parse is neither dir nor file", path=path
-    )
+    return CodeSource(path, base_dir)

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -99,8 +99,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
         """The list of declared dependencies parsed from this project."""
         return list(
             extract_declared_dependencies.parse_sources(
-                (src for src in self.sources if isinstance(src, DepsSource)),
-                self.settings.deps_parser_choice,
+                (src for src in self.sources if isinstance(src, DepsSource))
             )
         )
 

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -11,7 +11,7 @@ from typing import ClassVar, List, Optional, Set, TextIO, Tuple, Type, Union
 from pydantic import BaseSettings
 from pydantic.env_settings import SettingsSourceCallable  # pylint: disable=E0611
 
-from fawltydeps.types import CustomMapping, PathOrSpecial, TomlData
+from fawltydeps.types import CustomMapping, ParserChoice, PathOrSpecial, TomlData
 
 if sys.version_info >= (3, 11):
     import tomllib  # pylint: disable=no-member
@@ -74,18 +74,6 @@ class OutputFormat(OrderedEnum):
     HUMAN_SUMMARY = "human_summary"
     HUMAN_DETAILED = "human_detailed"
     JSON = "json"
-
-
-class ParserChoice(Enum):
-    """Enumerate the choices of dependency declaration parsers."""
-
-    REQUIREMENTS_TXT = "requirements.txt"
-    SETUP_PY = "setup.py"
-    SETUP_CFG = "setup.cfg"
-    PYPROJECT_TOML = "pyproject.toml"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 def read_parser_choice(filename: str) -> ParserChoice:

--- a/fawltydeps/traverse_project.py
+++ b/fawltydeps/traverse_project.py
@@ -1,0 +1,66 @@
+"""Traverse a project to identify appropriate inputs to FawltyDeps."""
+import logging
+from pathlib import Path
+from typing import AbstractSet, Dict, Iterator, Optional, Set, Type
+
+from fawltydeps.extract_declared_dependencies import validate_deps_source
+from fawltydeps.extract_imports import validate_code_source
+from fawltydeps.settings import Settings
+from fawltydeps.types import CodeSource, DepsSource, Source, UnparseablePathException
+from fawltydeps.utils import walk_dir
+
+logger = logging.getLogger(__name__)
+
+
+def find_sources(
+    settings: Settings,
+    source_types: AbstractSet[Type[Source]] = frozenset([CodeSource, DepsSource]),
+) -> Iterator[Source]:
+    """Traverse files and directories and yield Sources to be parsed.
+
+    Traverse the files and directories configured by the given Settings object,
+    and yield the corresponding *Source objects found.
+    """
+
+    # Collect any directories we will need to traverse.
+    dirs_to_traverse: Dict[Path, Set[Type[Source]]] = {}
+
+    for path_or_special in settings.code if CodeSource in source_types else []:
+        # exceptions raised by validate_code_source() are propagated here
+        validated: Optional[Source] = validate_code_source(path_or_special)
+        if validated is not None:  # parse-able file given directly
+            yield validated
+        else:  # must traverse directory
+            # sanity check: convince mypy that SpecialPath is already handled
+            assert isinstance(path_or_special, Path)
+            dirs_to_traverse.setdefault(path_or_special, set()).add(CodeSource)
+
+    for path in settings.deps if DepsSource in source_types else []:
+        # exceptions raised by validate_deps_source() are propagated here
+        validated = validate_deps_source(
+            path, settings.deps_parser_choice, filter_by_parser=False
+        )
+        if validated is not None:  # parse-able file given directly
+            yield validated
+        else:  # must traverse directory
+            dirs_to_traverse.setdefault(path, set()).add(DepsSource)
+
+    for dir_path, types in dirs_to_traverse.items():
+        assert len(types) > 0
+        for file in walk_dir(dir_path):  # traverse directories only _once_
+            if CodeSource in types:
+                try:  # catch all exceptions while traversing dirs
+                    validated = validate_code_source(file, dir_path)
+                    assert validated is not None  # sanity check
+                    yield validated
+                except UnparseablePathException:  # don't abort directory walk for this
+                    pass
+            if DepsSource in types:
+                try:  # catch all exceptions while traversing dirs
+                    validated = validate_deps_source(
+                        file, settings.deps_parser_choice, filter_by_parser=True
+                    )
+                    assert validated is not None  # sanity check
+                    yield validated
+                except UnparseablePathException:  # don't abort directory walk for this
+                    pass

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -26,6 +26,24 @@ class UnparseablePathException(Exception):
         self.msg = f"{ctx}: {path}"
 
 
+@dataclass(frozen=True, eq=True, order=True)
+class CodeSource:
+    """A Python code source to be parsed for imports statements."""
+
+    path: PathOrSpecial
+    base_dir: Optional[Path] = None
+
+
+@dataclass(frozen=True, eq=True, order=True)
+class DepsSource:
+    """A source to be parsed for declared dependencies."""
+
+    path: Path
+
+
+Source = Union[CodeSource, DepsSource]
+
+
 @total_ordering
 @dataclass(frozen=True)
 class Location:

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -33,6 +33,20 @@ class CodeSource:
     path: PathOrSpecial
     base_dir: Optional[Path] = None
 
+    def __post_init__(self) -> None:
+        if self.path != "<stdin>":
+            assert isinstance(self.path, Path)
+            if not self.path.is_file():
+                raise UnparseablePathException(
+                    ctx="Code path to parse is neither dir nor file",
+                    path=self.path,
+                )
+            if self.path.suffix not in {".py", ".ipynb"}:
+                raise UnparseablePathException(
+                    ctx="Supported formats are .py and .ipynb; Cannot parse code",
+                    path=self.path,
+                )
+
 
 @dataclass(frozen=True, eq=True, order=True)
 class DepsSource:

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -2,6 +2,7 @@
 
 import sys
 from dataclasses import asdict, dataclass, field, replace
+from enum import Enum
 from functools import total_ordering
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -24,6 +25,18 @@ class UnparseablePathException(Exception):
 
     def __init__(self, ctx: str, path: Path):
         self.msg = f"{ctx}: {path}"
+
+
+class ParserChoice(Enum):
+    """Enumerate the choices of dependency declaration parsers."""
+
+    REQUIREMENTS_TXT = "requirements.txt"
+    SETUP_PY = "setup.py"
+    SETUP_CFG = "setup.cfg"
+    PYPROJECT_TOML = "pyproject.toml"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 @dataclass(frozen=True, eq=True, order=True)

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -63,9 +63,17 @@ class CodeSource:
 
 @dataclass(frozen=True, eq=True, order=True)
 class DepsSource:
-    """A source to be parsed for declared dependencies."""
+    """A source to be parsed for declared dependencies.
+
+    Also include which declared dependencies parser we have chosen to use for
+    this file.
+    """
 
     path: Path
+    parser_choice: ParserChoice
+
+    def __post_init__(self) -> None:
+        assert self.path.is_file()  # sanity check
 
 
 Source = Union[CodeSource, DepsSource]

--- a/noxfile.py
+++ b/noxfile.py
@@ -92,6 +92,7 @@ def lint(session):
         "protected-access",
         "redefined-outer-name",
         "too-many-arguments",
+        "too-many-instance-attributes",
         "too-many-lines",
     ]
     session.run(

--- a/tests/sample_projects/no_issues/.venv/lib/python3.10/site-packages/dummy_package/code.py
+++ b/tests/sample_projects/no_issues/.venv/lib/python3.10/site-packages/dummy_package/code.py
@@ -1,0 +1,1 @@
+import requests

--- a/tests/sample_projects/no_issues/.venv/lib/python3.10/site-packages/dummy_package/setup.py
+++ b/tests/sample_projects/no_issues/.venv/lib/python3.10/site-packages/dummy_package/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup
+
+setup(
+    name="dummy_package",
+    install_requires=["requests"],
+)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -204,7 +204,9 @@ def test_list_imports__from_dir__prints_imports_from_py_and_ipynb_files_only(
         for i, n in [("my_pathlib", 1), ("pandas", 2), ("scipy", 2)]
     ] + [f"{tmp_path}/file3.ipynb[1]:1: pytorch"]
     expect_logs = [
-        f"INFO:fawltydeps.extract_imports:Parsing Python files under {tmp_path}",
+        f"INFO:fawltydeps.extract_imports:Finding Python files under {tmp_path}",
+        f"INFO:fawltydeps.extract_imports:Parsing Python file {tmp_path}/file1.py",
+        f"INFO:fawltydeps.extract_imports:Parsing Notebook file {tmp_path}/file3.ipynb",
     ]
     output, errors, returncode = run_fawltydeps_subprocess(
         "--list-imports", "--detailed", "-v", f"--code={tmp_path}"
@@ -238,7 +240,7 @@ def test_list_imports__from_missing_file__fails_with_exit_code_2(tmp_path):
 def test_list_imports__from_empty_dir__logs_but_extracts_nothing(tmp_path):
     # Enable log level INFO with -v
     expect_logs = [
-        f"INFO:fawltydeps.extract_imports:Parsing Python files under {tmp_path}",
+        f"INFO:fawltydeps.extract_imports:Finding Python files under {tmp_path}",
     ]
     output, errors, returncode = run_fawltydeps_subprocess(
         "--list-imports", f"--code={tmp_path}", "--detailed", "-v"
@@ -257,7 +259,9 @@ def test_list_imports__pick_multiple_files_dir__prints_all_imports(
         "--list-imports", "--code", f"{path_code1}", f"{path_code2}", "-v"
     )
     expect_logs = [
-        f"INFO:fawltydeps.extract_imports:Parsing Python files under {path_code1}",
+        f"INFO:fawltydeps.extract_imports:Finding Python files under {path_code1}",
+        f"INFO:fawltydeps.extract_imports:Parsing Python file {path_code1}/python_file2.py",
+        f"INFO:fawltydeps.extract_imports:Parsing Python file {path_code1}/python_file3.py",
         f"INFO:fawltydeps.extract_imports:Parsing Python file {path_code2}",
     ]
     expect = ["django", "pandas", "click"]
@@ -450,7 +454,8 @@ project_tests_samples = [
             "    {path}/code.py:1",
         ],
         expect_logs=[
-            "INFO:fawltydeps.extract_imports:Parsing Python files under {path}",
+            "INFO:fawltydeps.extract_imports:Finding Python files under {path}",
+            "INFO:fawltydeps.extract_imports:Parsing Python file {path}/code.py",
             "INFO:fawltydeps.packages:'pandas' was not resolved."
             " Assuming it can be imported as 'pandas'.",
         ],
@@ -467,7 +472,8 @@ project_tests_samples = [
             "    {path}/requirements.txt",
         ],
         expect_logs=[
-            "INFO:fawltydeps.extract_imports:Parsing Python files under {path}",
+            "INFO:fawltydeps.extract_imports:Finding Python files under {path}",
+            "INFO:fawltydeps.extract_imports:Parsing Python file {path}/code.py",
             "INFO:fawltydeps.packages:'requests' was not resolved."
             " Assuming it can be imported as 'requests'.",
             "INFO:fawltydeps.packages:'pandas' was not resolved."
@@ -490,7 +496,8 @@ project_tests_samples = [
             "    {path}/requirements.txt",
         ],
         expect_logs=[
-            "INFO:fawltydeps.extract_imports:Parsing Python files under {path}",
+            "INFO:fawltydeps.extract_imports:Finding Python files under {path}",
+            "INFO:fawltydeps.extract_imports:Parsing Python file {path}/code.py",
             "INFO:fawltydeps.packages:'pandas' was not resolved."
             " Assuming it can be imported as 'pandas'.",
         ],
@@ -511,7 +518,8 @@ project_tests_samples = [
             VERBOSE_PROMPT,
         ],
         expect_logs=[
-            "INFO:fawltydeps.extract_imports:Parsing Python files under {path}",
+            "INFO:fawltydeps.extract_imports:Finding Python files under {path}",
+            "INFO:fawltydeps.extract_imports:Parsing Python file {path}/code.py",
             "INFO:fawltydeps.packages:'pandas' was not resolved."
             " Assuming it can be imported as 'pandas'.",
         ],
@@ -627,7 +635,8 @@ def test_check_undeclared__simple_project__reports_only_undeclared(
         f"    {str(tmp_path / 'code.py')}:1",
     ]
     expect_logs = [
-        f"INFO:fawltydeps.extract_imports:Parsing Python files under {tmp_path}",
+        f"INFO:fawltydeps.extract_imports:Finding Python files under {tmp_path}",
+        f"INFO:fawltydeps.extract_imports:Parsing Python file {tmp_path}/code.py",
         "INFO:fawltydeps.packages:'pandas' was not resolved."
         " Assuming it can be imported as 'pandas'.",
     ]

--- a/tests/test_extract_declared_dependencies_errors.py
+++ b/tests/test_extract_declared_dependencies_errors.py
@@ -4,23 +4,8 @@ import logging
 
 import pytest
 
-from fawltydeps.extract_declared_dependencies import (
-    extract_declared_dependencies,
-    parse_setup_cfg,
-    parse_setup_py,
-)
-from fawltydeps.types import Location, UnparseablePathException
-
-
-def test_extract_declared_dependencies__unsupported_file__raises_error(
-    project_with_setup_and_requirements,
-):
-    with pytest.raises(UnparseablePathException):
-        list(
-            extract_declared_dependencies(
-                [project_with_setup_and_requirements / "python_file.py"]
-            )
-        )
+from fawltydeps.extract_declared_dependencies import parse_setup_cfg, parse_setup_py
+from fawltydeps.types import Location
 
 
 def test_parse_setup_cfg__malformed__logs_error(write_tmp_files, caplog):

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -8,6 +8,7 @@ from fawltydeps.extract_declared_dependencies import (
     parse_setup_cfg,
     parse_setup_py,
     parse_sources,
+    validate_deps_source,
 )
 from fawltydeps.settings import Settings
 from fawltydeps.traverse_project import find_sources
@@ -454,7 +455,7 @@ def test_parse_sources__parse_only_requirements_from_subdir__returns_list(
         "tensorflow",
     ]
     path = project_with_setup_and_requirements / "subdir/requirements.txt"
-    actual = collect_dep_names(parse_sources([DepsSource(path)]))
+    actual = collect_dep_names(parse_sources([validate_deps_source(path)]))
     assert_unordered_equivalence(actual, expect)
 
 
@@ -582,5 +583,5 @@ def test_parse_requirements_per_req_options(tmp_path, deps_file_content, exp_dep
     # originally motivated by #114 (A dep can span multiple lines.)
     deps_path = tmp_path / "requirements.txt"
     deps_path.write_text(dedent(deps_file_content))
-    obs_deps = collect_dep_names(parse_sources([DepsSource(deps_path)]))
+    obs_deps = collect_dep_names(parse_sources([validate_deps_source(deps_path)]))
     assert_unordered_equivalence(obs_deps, exp_deps)

--- a/tests/test_extract_imports_errors.py
+++ b/tests/test_extract_imports_errors.py
@@ -5,11 +5,11 @@ from textwrap import dedent
 
 from fawltydeps.extract_imports import (
     parse_code,
-    parse_dir,
     parse_notebook_file,
     parse_python_file,
+    parse_source,
 )
-from fawltydeps.types import Location, ParsedImport
+from fawltydeps.types import CodeSource, Location, ParsedImport
 
 
 def test_parse_notebook_file__on_invalid_json__logs_error(tmp_path, caplog):
@@ -87,7 +87,7 @@ def test_parse_file__on_syntax_error__logs_error(tmp_path, caplog):
     assert f"Could not parse code from {script}" in caplog.text
 
 
-def test_parse_dir__on_parse_error__error_log_contains_filename(tmp_path, caplog):
+def test_parse_source__on_parse_error__error_log_contains_filename(tmp_path, caplog):
     code = dedent(
         """\
         This file is littered with Python syntax errors...
@@ -99,7 +99,8 @@ def test_parse_dir__on_parse_error__error_log_contains_filename(tmp_path, caplog
 
     expect = []
     caplog.set_level(logging.ERROR)
-    assert list(parse_dir(tmp_path)) == expect
+    source = CodeSource(script, tmp_path)
+    assert list(parse_source(source)) == expect
     assert f"Could not parse code from {script}" in caplog.text
 
 

--- a/tests/test_traverse_project.py
+++ b/tests/test_traverse_project.py
@@ -1,0 +1,348 @@
+"""Test that we can traverse a project to find our inputs."""
+import dataclasses
+from pathlib import Path
+from typing import Optional, Set, Type
+
+import pytest
+
+from fawltydeps.settings import ParserChoice, Settings
+from fawltydeps.traverse_project import CodeSource, DepsSource, find_sources
+from fawltydeps.types import PathOrSpecial, UnparseablePathException
+
+from .test_sample_projects import SAMPLE_PROJECTS_DIR
+
+
+@dataclasses.dataclass
+class TraverseProjectVector:
+    """Test vectors for traverse_project.find_sources()."""
+
+    id: str
+    project: str  # The base path for this test, relative to SAMPLE_PROJECTS_DIR
+    # The following sets contain paths that are all relative to cwd
+    code: Set[str] = dataclasses.field(default_factory=lambda: {"."})
+    deps: Set[str] = dataclasses.field(default_factory=lambda: {"."})
+    deps_parser_choice: Optional[ParserChoice] = None
+    expect_imports_src: Set[str] = dataclasses.field(default_factory=set)
+    expect_deps_src: Set[str] = dataclasses.field(default_factory=set)
+    expect_raised: Optional[Type[Exception]] = None
+
+
+find_sources_vectors = [
+    TraverseProjectVector(
+        "default_traversal_in_empty_project_yields__nothing", "empty"
+    ),
+    TraverseProjectVector(
+        "traverse_nothing_in_non_empty_project__yields_nothing",
+        "blog_post_example",
+        code=set(),
+        deps=set(),
+    ),
+    #
+    # Testing 'code' alone:
+    #
+    TraverseProjectVector(
+        "given_code_as_nonexistent_file__raises_exception",
+        "blog_post_example",
+        code={"missing.py"},
+        deps=set(),
+        expect_raised=UnparseablePathException,
+    ),
+    TraverseProjectVector(
+        "given_code_as_non_py_file__raises_exception",
+        "blog_post_example",
+        code={"README.md"},
+        deps=set(),
+        expect_raised=UnparseablePathException,
+    ),
+    TraverseProjectVector(
+        "given_code_as_specialpath_stdin__yields_preserved_specialpath_stdin",
+        "empty",
+        code={"<stdin>"},
+        deps=set(),
+        expect_imports_src={"<stdin>"},
+    ),
+    TraverseProjectVector(
+        "given_code_as_py_file__yields_file",
+        "blog_post_example",
+        code={"my_script.py"},
+        deps=set(),
+        expect_imports_src={"my_script.py"},
+    ),
+    TraverseProjectVector(
+        "given_code_as_ipynb_file__yields_file",
+        "mixed_project",
+        code={"subdir1/notebook.ipynb"},
+        deps=set(),
+        expect_imports_src={"subdir1/notebook.ipynb"},
+    ),
+    TraverseProjectVector(
+        "given_code_as_py_and_ipynb_file__yields_both_files",
+        "mixed_project",
+        code={"subdir1/notebook.ipynb", "subdir2/script.py"},
+        deps=set(),
+        expect_imports_src={"subdir1/notebook.ipynb", "subdir2/script.py"},
+    ),
+    TraverseProjectVector(
+        "given_code_as_stdin_and_files__yields_all",
+        "mixed_project",
+        code={"<stdin>", "subdir1/notebook.ipynb", "subdir2/script.py"},
+        deps=set(),
+        expect_imports_src={"<stdin>", "subdir1/notebook.ipynb", "subdir2/script.py"},
+    ),
+    TraverseProjectVector(
+        "given_code_as_dir__yields_only_files_within",
+        "mixed_project",
+        code={"subdir1"},
+        deps=set(),
+        expect_imports_src={"subdir1/notebook.ipynb", "subdir1/script.py"},
+    ),
+    TraverseProjectVector(
+        "given_code_as_dir_and_stdin__yields_files_within_dir_and_stdin",
+        "mixed_project",
+        code={"subdir1", "<stdin>"},
+        deps=set(),
+        expect_imports_src={"subdir1/notebook.ipynb", "subdir1/script.py", "<stdin>"},
+    ),
+    TraverseProjectVector(
+        "given_code_as_multiple_dirs__yields_files_within_all_dirs",
+        "mixed_project",
+        code={"subdir1", "subdir2"},
+        deps=set(),
+        expect_imports_src={
+            "subdir1/notebook.ipynb",
+            "subdir1/script.py",
+            "subdir2/notebook.ipynb",
+            "subdir2/script.py",
+            "subdir2/setup.py",
+        },
+    ),
+    TraverseProjectVector(
+        "given_code_as_parent_and_child_dirs__yields_files_within_all_dirs",
+        "mixed_project",
+        code={".", "subdir2"},
+        deps=set(),
+        expect_imports_src={
+            "main.py",
+            "subdir1/notebook.ipynb",
+            "subdir1/script.py",
+            "subdir2/notebook.ipynb",
+            "subdir2/script.py",
+            "subdir2/setup.py",
+        },
+    ),
+    TraverseProjectVector(
+        "given_code_as_file_and_dir__yields_file_and_files_within_dir",
+        "mixed_project",
+        code={"subdir1", "subdir2/notebook.ipynb"},
+        deps=set(),
+        expect_imports_src={
+            "subdir1/notebook.ipynb",
+            "subdir1/script.py",
+            "subdir2/notebook.ipynb",
+        },
+    ),
+    #
+    # Testing 'deps' alone:
+    #
+    TraverseProjectVector(
+        "given_deps_as_nonexistent_file__raises_exception",
+        "blog_post_example",
+        code=set(),
+        deps={"missing_requirements.txt"},
+        expect_raised=UnparseablePathException,
+    ),
+    TraverseProjectVector(
+        "given_deps_as_non_deps_file__raises_exception",
+        "README.md",
+        code=set(),
+        deps={"README.md"},
+        expect_raised=UnparseablePathException,
+    ),
+    TraverseProjectVector(
+        "given_deps_as_requirements_txt__yields_file",
+        "blog_post_example",
+        code=set(),
+        deps={"requirements.txt"},
+        expect_deps_src={"requirements.txt"},
+    ),
+    TraverseProjectVector(
+        "given_deps_as_pyproject_toml__yields_file",
+        "mixed_project",
+        code=set(),
+        deps={"pyproject.toml"},
+        expect_deps_src={"pyproject.toml"},
+    ),
+    TraverseProjectVector(
+        "given_deps_as_setup_cfg_and_pyproject_toml__yields_both_files",
+        "mixed_project",
+        code=set(),
+        deps={"pyproject.toml", "subdir1/setup.cfg"},
+        expect_deps_src={"pyproject.toml", "subdir1/setup.cfg"},
+    ),
+    TraverseProjectVector(
+        "given_deps_as_dir__yields_only_files_within",
+        "mixed_project",
+        code=set(),
+        deps={"subdir1"},
+        expect_deps_src={"subdir1/setup.cfg"},
+    ),
+    TraverseProjectVector(
+        "given_deps_as_multiple_dirs__yields_files_within_all_dirs",
+        "mixed_project",
+        code=set(),
+        deps={"subdir1", "subdir2"},
+        expect_deps_src={"subdir1/setup.cfg", "subdir2/setup.py"},
+    ),
+    TraverseProjectVector(
+        "given_deps_as_parent_and_child_dirs__yields_files_within_all_dirs",
+        "mixed_project",
+        code=set(),
+        deps={".", "subdir2"},
+        expect_deps_src={"pyproject.toml", "subdir1/setup.cfg", "subdir2/setup.py"},
+    ),
+    TraverseProjectVector(
+        "given_deps_as_file_and_dir__yields_file_and_files_within_dir",
+        "mixed_project",
+        code=set(),
+        deps={"subdir1", "subdir2/setup.py"},
+        expect_deps_src={"subdir1/setup.cfg", "subdir2/setup.py"},
+    ),
+    #
+    # Test interaction of 'deps_parser_choice' and 'deps' as file vs dir
+    #
+    TraverseProjectVector(
+        "given_deps_as_files_with_parser_choice__yields_all_files",
+        "mixed_project",
+        code=set(),
+        deps={"pyproject.toml", "subdir1/setup.cfg"},
+        deps_parser_choice=ParserChoice.REQUIREMENTS_TXT,
+        expect_deps_src={"pyproject.toml", "subdir1/setup.cfg"},
+    ),
+    TraverseProjectVector(
+        "given_deps_as_dir_with_parser_choice__yields_only_matching_files",
+        "mixed_project",
+        code=set(),
+        deps={"."},
+        deps_parser_choice=ParserChoice.SETUP_CFG,
+        expect_deps_src={"subdir1/setup.cfg"},
+    ),
+    TraverseProjectVector(
+        "given_deps_as_dir_with_wrong_parser_choice__yields_no_matching_files",
+        "mixed_project",
+        code=set(),
+        deps={"subdir2"},
+        deps_parser_choice=ParserChoice.REQUIREMENTS_TXT,
+        expect_deps_src=set(),
+    ),
+    #
+    # Testing 'code' and 'deps' together
+    #
+    TraverseProjectVector(
+        "default_traversal_in_blog_post_example__yields_one_py_two_deps",
+        "blog_post_example",
+        expect_imports_src={"my_script.py"},
+        expect_deps_src={"requirements.txt", "dev-requirements.txt"},
+    ),
+    TraverseProjectVector(
+        "given_explicit_files_in_blog_post_example__yields_one_py_two_deps",
+        "blog_post_example",
+        code={"my_script.py"},
+        deps={"requirements.txt", "dev-requirements.txt"},
+        expect_imports_src={"my_script.py"},
+        expect_deps_src={"requirements.txt", "dev-requirements.txt"},
+    ),
+    TraverseProjectVector(
+        "given_code_and_deps_as_same_dir__yields_files_within",
+        "mixed_project",
+        code={"subdir1"},
+        deps={"subdir1"},
+        expect_imports_src={"subdir1/notebook.ipynb", "subdir1/script.py"},
+        expect_deps_src={"subdir1/setup.cfg"},
+    ),
+    TraverseProjectVector(
+        "given_code_and_deps_as_same_dir_with_file_both_dep_and_import__yields_files_within",
+        "mixed_project",
+        code={"subdir2"},
+        deps={"subdir2"},
+        expect_imports_src={
+            "subdir2/notebook.ipynb",
+            "subdir2/script.py",
+            "subdir2/setup.py",
+        },
+        expect_deps_src={"subdir2/setup.py"},
+    ),
+    TraverseProjectVector(
+        "given_code_and_deps_as_separate_dirs__yields_expected_files",
+        "mixed_project",
+        code={"subdir1"},
+        deps={"subdir2"},
+        expect_imports_src={"subdir1/notebook.ipynb", "subdir1/script.py"},
+        expect_deps_src={"subdir2/setup.py"},
+    ),
+    TraverseProjectVector(
+        "given_code_and_deps_as_parent_and_child_dirs__yields_expected_files",
+        "mixed_project",
+        code={"subdir1"},
+        deps={"."},
+        expect_imports_src={"subdir1/notebook.ipynb", "subdir1/script.py"},
+        expect_deps_src={"pyproject.toml", "subdir1/setup.cfg", "subdir2/setup.py"},
+    ),
+    #
+    # We should not traverse into dot dirs (e.g. .git or .venv) by default
+    #
+    TraverseProjectVector(
+        "default_traversal_in_no_issues__does_not_traverse_into_dot_venv",
+        "no_issues",
+        expect_imports_src={"python_file.py"},
+        expect_deps_src={"requirements.txt", "subdir/requirements.txt"},
+    ),
+    TraverseProjectVector(
+        "passing_dot_dir_explicitly__does_traverse_into_it",
+        "no_issues",
+        code={".venv"},
+        deps={".venv"},
+        expect_imports_src={
+            ".venv/lib/python3.10/site-packages/dummy_package/setup.py",
+            ".venv/lib/python3.10/site-packages/dummy_package/code.py",
+        },
+        expect_deps_src={".venv/lib/python3.10/site-packages/dummy_package/setup.py"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "vector", [pytest.param(v, id=v.id) for v in find_sources_vectors]
+)
+def test_find_sources(vector: TraverseProjectVector):
+    project_dir = SAMPLE_PROJECTS_DIR / vector.project
+    settings = Settings(
+        code={
+            path if path == "<stdin>" else project_dir / path for path in vector.code
+        },
+        deps={project_dir / path for path in vector.deps},
+        deps_parser_choice=vector.deps_parser_choice,
+    )
+    expect_imports_src = {
+        path if path == "<stdin>" else project_dir / path
+        for path in vector.expect_imports_src
+    }
+    expect_deps_src = {project_dir / path for path in vector.expect_deps_src}
+
+    actual_imports_src: Set[PathOrSpecial] = set()
+    actual_deps_src: Set[Path] = set()
+
+    if vector.expect_raised is not None:
+        with pytest.raises(vector.expect_raised):
+            list(find_sources(settings))
+        return
+
+    for src in find_sources(settings):
+        if isinstance(src, CodeSource):
+            actual_imports_src.add(src.path)
+        elif isinstance(src, DepsSource):
+            actual_deps_src.add(src.path)
+        else:
+            raise TypeError(src)
+
+    assert actual_imports_src == expect_imports_src
+    assert actual_deps_src == expect_deps_src


### PR DESCRIPTION
This is the first part of several with the ultimate goal to:
- Support ignore patterns to skip various parts of a project's directory structure (#226).
- Supporting multiple --pyenv options (#249).
- Allowing auto-discovery of venvs within the project dirs (also issue 249).
- Have the discovery of such venvs ignore code/deps otherwise found inside those venvs (barely mentioned in a footnote to issue 249).
- Adding actions to list code sources and deps sources (`--list-code-sources` and `--list-deps-sources`, not yet tracked in any issue, I believe)

**This part** of the bigger refactoring, however, does not do any of that.

There should in fact be ~zero observable difference before and after this PR (modulo some changed INFO log messages). This PR is all about providing a single traversal structure that will more easily enable the goals above to be done in future PRs.

In graphical terms, this PR tries to implement this restructuring:
![traverse_refactor_step1](https://user-images.githubusercontent.com/547031/229246514-f6801e3f-34d3-4e44-9b18-e442c08aa5e8.png)


Probably best viewed on a per-commit basis.

Commits:
- `sample_project/no_issues`: Add a dummy package inside the bundled venv
- Introduce `traverse_project` module
- `extract_imports`: Add new parse functions
- `extract_declared_dependencies`: Add new parse functions
- `test_cmdline`: Unify testing of log messages
- `main`: Use new traversal logic and new parsers
- `test_cmdline`: Remove unnecessary asserts for log messages
- `extract_imports`: Remove obsolete API for traversing files/dirs
- `extract_declared_dependencies`: Remove obsolete API
