### PR TITLE
User-defined mapping: add option to read mapping from configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ fawltydeps --custom-mapping-file my_mapping.toml
 
 FawltyDeps will parse `my_mapping.toml` file and use extracted mapping for matching dependencies to imports.
 
-You may also use put the custom mapping in the configuration file of your project, like `pyproject.toml` with the same toml structure like for `my_mapping.toml` above. Just add a section:
+You may also place the custom mapping in the `pyproject.toml` file of your project, inside a `[tool.fawltydeps.custom_mapping]` section, like this:
 
 ```toml
-[tools.fawltydeps.custom_mapping]
+[tool.fawltydeps.custom_mapping]
 my-package = ["mpkg"]
 scikit-learn = ["sklearn"]
 multiple-modules = ["module1", "module2"]

--- a/README.md
+++ b/README.md
@@ -194,10 +194,19 @@ multiple-modules = ["module1", "module2"]
 To use your mapping, run:
 
 ```sh
-fawltydeps --mapping my_mapping.toml
+fawltydeps --custom-mapping-file my_mapping.toml
 ```
 
 FawltyDeps will parse `my_mapping.toml` file and use extracted mapping for matching dependencies to imports.
+
+You may also use put the custom mapping in the configuration file of your project, like `pyproject.toml` with the same toml structure like for `my_mapping.toml` above. Just add a section:
+
+```toml
+[tools.fawltydeps.custom_mapping]
+my-package = ["mpkg"]
+scikit-learn = ["sklearn"]
+multiple-modules = ["module1", "module2"]
+```
 
 Caution when using your mapping is advised. The user-defined mapping takes precedence over all other resolving strategies.
 If the mapping file has some stale mapping entries, they will not be resolved by

--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -165,7 +165,7 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         ),
     )
     parser.add_argument(
-        "--custom-mapping",
+        "--custom-mapping-file",
         type=Path,
         metavar="PATH",
         help=(

--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -167,7 +167,7 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
     parser.add_argument(
         "--custom-mapping-file",
         type=Path,
-        metavar="PATH",
+        metavar="FILE_PATH",
         help=(
             "Path to toml file containing mapping of dependencies to imports defined by the user."
         ),

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -82,7 +82,8 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
         """The resolved mapping of dependency names to provided import names."""
         return resolve_dependencies(
             (dep.name for dep in self.declared_deps),
-            custom_mapping_path=self.settings.custom_mapping,
+            custom_mapping_path=self.settings.custom_mapping_file,
+            custom_mapping=self.settings.custom_mapping,
             pyenv_path=self.settings.pyenv,
             install_deps=self.settings.install_deps,
         )

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -82,7 +82,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
         """The resolved mapping of dependency names to provided import names."""
         return resolve_dependencies(
             (dep.name for dep in self.declared_deps),
-            custom_mapping_path=self.settings.custom_mapping_file,
+            custom_mapping_file=self.settings.custom_mapping_file,
             custom_mapping=self.settings.custom_mapping,
             pyenv_path=self.settings.pyenv,
             install_deps=self.settings.install_deps,

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -131,7 +131,11 @@ class UserDefinedMapping(BasePackageResolver):
     @property
     @calculated_once
     def packages(self) -> Dict[str, Package]:
-        """Gather mapping from a mapping file in a given path.
+        """Gather a custom mapping given by a user.
+
+        Mapping may come from two sources:
+        * _mapping_path_ which is a file in a given path, which is parsed to a ditionary
+        * _custom_mapping_ which is a dictionary of package to imports mapping.
 
         This enumerates the available packages  _once_, and caches the result for
         the remainder of this object's life in _packages.

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -332,7 +332,7 @@ class IdentityMapping(BasePackageResolver):
 
 def resolve_dependencies(
     dep_names: Iterable[str],
-    custom_mapping_path: Optional[Path] = None,
+    custom_mapping_file: Optional[Path] = None,
     custom_mapping: Optional[Dict[str, List[str]]] = None,
     pyenv_path: Optional[Path] = None,
     install_deps: bool = False,
@@ -353,10 +353,10 @@ def resolve_dependencies(
     # each resolver in order until one of them returns a Package object. At
     # that point we are happy, and don't consult any of the later resolvers.
     resolvers: List[BasePackageResolver] = []
-    if custom_mapping_path or custom_mapping:
+    if custom_mapping_file or custom_mapping:
         resolvers.append(
             UserDefinedMapping(
-                mapping_path=custom_mapping_path, custom_mapping=custom_mapping
+                mapping_path=custom_mapping_file, custom_mapping=custom_mapping
             )
         )
 

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -24,7 +24,7 @@ from importlib_metadata import (
     _top_level_inferred,
 )
 
-from fawltydeps.types import TomlData, UnparseablePathException
+from fawltydeps.types import CustomMapping, UnparseablePathException
 from fawltydeps.utils import calculated_once, hide_dataclass_fields
 
 if sys.version_info >= (3, 11):
@@ -117,7 +117,7 @@ class UserDefinedMapping(BasePackageResolver):
     def __init__(
         self,
         mapping_path: Optional[Path] = None,
-        custom_mapping: Optional[TomlData] = None,
+        custom_mapping: Optional[CustomMapping] = None,
     ) -> None:
         self.mapping_path = mapping_path
         if self.mapping_path and not self.mapping_path.is_file():
@@ -156,7 +156,7 @@ class UserDefinedMapping(BasePackageResolver):
         }
 
         if self.custom_mapping is not None:
-            logger.debug("Loading user-defined mapping from custom mapping.")
+            logger.debug("Applying user-defined mapping from settings.")
 
             for name, imports in self.custom_mapping.items():
                 normalised_name = Package.normalize_name(name)
@@ -355,7 +355,7 @@ class IdentityMapping(BasePackageResolver):
 def resolve_dependencies(
     dep_names: Iterable[str],
     custom_mapping_file: Optional[Path] = None,
-    custom_mapping: Optional[Dict[str, List[str]]] = None,
+    custom_mapping: Optional[CustomMapping] = None,
     pyenv_path: Optional[Path] = None,
     install_deps: bool = False,
 ) -> Dict[str, Package]:

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -6,7 +6,7 @@ import sys
 from enum import Enum
 from functools import total_ordering
 from pathlib import Path
-from typing import ClassVar, Dict, List, Optional, Set, TextIO, Tuple, Type, Union
+from typing import ClassVar, List, Optional, Set, TextIO, Tuple, Type, Union
 
 from pydantic import BaseSettings
 from pydantic.env_settings import SettingsSourceCallable  # pylint: disable=E0611
@@ -123,7 +123,7 @@ class Settings(BaseSettings):  # type: ignore
     deps: Set[Path] = {Path(".")}
     pyenv: Optional[Path] = None
     custom_mapping_file: Optional[Path] = None
-    custom_mapping: Optional[Dict[str, List[str]]] = None
+    custom_mapping: Optional[TomlData] = None
     ignore_undeclared: Set[str] = set()
     ignore_unused: Set[str] = set()
     deps_parser_choice: Optional[ParserChoice] = None

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -6,7 +6,7 @@ import sys
 from enum import Enum
 from functools import total_ordering
 from pathlib import Path
-from typing import ClassVar, List, Optional, Set, TextIO, Tuple, Type, Union
+from typing import ClassVar, Dict, List, Optional, Set, TextIO, Tuple, Type, Union
 
 from pydantic import BaseSettings
 from pydantic.env_settings import SettingsSourceCallable  # pylint: disable=E0611
@@ -123,7 +123,7 @@ class Settings(BaseSettings):  # type: ignore
     deps: Set[Path] = {Path(".")}
     pyenv: Optional[Path] = None
     custom_mapping_file: Optional[Path] = None
-    custom_mapping: Optional[TomlData] = None
+    custom_mapping: Optional[Dict[str, List[str]]] = None
     ignore_undeclared: Set[str] = set()
     ignore_unused: Set[str] = set()
     deps_parser_choice: Optional[ParserChoice] = None

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -6,7 +6,7 @@ import sys
 from enum import Enum
 from functools import total_ordering
 from pathlib import Path
-from typing import ClassVar, List, Optional, Set, TextIO, Tuple, Type, Union
+from typing import ClassVar, Dict, List, Optional, Set, TextIO, Tuple, Type, Union
 
 from pydantic import BaseSettings
 from pydantic.env_settings import SettingsSourceCallable  # pylint: disable=E0611
@@ -122,7 +122,8 @@ class Settings(BaseSettings):  # type: ignore
     code: Set[PathOrSpecial] = {Path(".")}
     deps: Set[Path] = {Path(".")}
     pyenv: Optional[Path] = None
-    custom_mapping: Optional[Path] = None
+    custom_mapping_file: Optional[Path] = None
+    custom_mapping: Optional[Dict[str, List[str]]] = None
     ignore_undeclared: Set[str] = set()
     ignore_unused: Set[str] = set()
     deps_parser_choice: Optional[ParserChoice] = None
@@ -214,9 +215,6 @@ class Settings(BaseSettings):  # type: ignore
         # any pre-configured verbosity value
         if {"verbose", "quiet"}.intersection(args_dict.keys()):
             ret["verbosity"] = args_dict.get("verbose", 0) - args_dict.get("quiet", 0)
-
-        if "custom_mapping" in args_dict.keys():
-            ret["custom_mapping"] = args_dict.get("custom_mapping")
 
         return cls(**ret)
 

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -16,6 +16,7 @@ else:
 SpecialPath = Literal["<stdin>"]
 PathOrSpecial = Union[SpecialPath, Path]
 TomlData = Dict[str, Any]  # type: ignore
+CustomMapping = Dict[str, List[str]]
 
 
 class UnparseablePathException(Exception):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,10 +273,16 @@ def setup_fawltydeps_config(write_tmp_files):
 
     def _inner(contents: Union[str, TomlData]):
         if isinstance(contents, dict):
-            contents = "".join(
-                ["[tool.fawltydeps]\n"]
-                + [f"{k} = {v!r}\n" for k, v in contents.items()]
-            )
+            header = ["[tool.fawltydeps]\n"]
+            entries = []
+            for k, v in contents.items():
+                if isinstance(v, dict):
+                    entries += [f"[tool.fawltydeps.{k}]\n"] + [
+                        f"{kk} = {vv!r}\n" for kk, vv in v.items()
+                    ]
+                else:
+                    entries += [f"{k} = {v!r}\n"]
+            contents = "".join(header + entries)
         tmp_path = write_tmp_files({"pyproject.toml": contents})
         return tmp_path / "pyproject.toml"
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -897,12 +897,12 @@ def test_cmdline_on_ignored_undeclared_option(
                 deps = ['foobar']
                 # pyenv = None
                 # custom_mapping_file = None
-                # [tool.fawltydeps.custom_mapping]
                 # ignore_undeclared = []
                 # ignore_unused = []
                 # deps_parser_choice = None
                 # install_deps = False
                 # verbosity = 0
+                # [tool.fawltydeps.custom_mapping]
                 """
             ).splitlines(),
             id="generate_toml_config_with_combo_of_config_and_cmdline_options",

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -36,6 +36,7 @@ def make_json_settings_dict(**kwargs):
         "code": ["."],
         "deps": ["."],
         "pyenv": None,
+        "custom_mapping_file": None,
         "custom_mapping": None,
         "output_format": "human_summary",
         "ignore_undeclared": [],
@@ -895,6 +896,7 @@ def test_cmdline_on_ignored_undeclared_option(
                 # code = ['.']
                 deps = ['foobar']
                 # pyenv = None
+                # custom_mapping_file = None
                 # custom_mapping = None
                 # ignore_undeclared = []
                 # ignore_unused = []

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -897,7 +897,7 @@ def test_cmdline_on_ignored_undeclared_option(
                 deps = ['foobar']
                 # pyenv = None
                 # custom_mapping_file = None
-                # custom_mapping = None
+                # [tool.fawltydeps.custom_mapping]
                 # ignore_undeclared = []
                 # ignore_unused = []
                 # deps_parser_choice = None

--- a/tests/test_configured_run.py
+++ b/tests/test_configured_run.py
@@ -1,6 +1,8 @@
-"""Test configuration-based run of FawltyDeps tool.
+"""Test configuration-based run of FawltyDeps (i.e. without command-line args).
 
-Use only pyproject.toml contents to determine setting of the run.
+Run FawltyDeps in a subprocess, using only pyproject.toml to determine its
+settings. Specify imports and declared dependencies that occur in the relevant
+project, and verify that we get the expected exit code.
 """
 
 from dataclasses import dataclass, field
@@ -9,7 +11,9 @@ from typing import List
 
 import pytest
 
-from .utils import run_fawltydeps
+from .utils import run_fawltydeps_subprocess
+
+pytestmark = pytest.mark.integration
 
 
 @dataclass
@@ -70,5 +74,5 @@ def test_run_with_pyproject_toml_settings(
     path = tmp_path / "pyproject.toml"
     path.write_text(dedent(vector.toml_contents))
 
-    _, _, exit_code = run_fawltydeps(config_file=str(path), cwd=tmp_path)
+    _, _, exit_code = run_fawltydeps_subprocess(config_file=str(path), cwd=tmp_path)
     assert exit_code == vector.expect

--- a/tests/test_configured_run.py
+++ b/tests/test_configured_run.py
@@ -1,0 +1,74 @@
+"""Test configuration-based run of FawltyDeps tool.
+
+Use only pyproject.toml contents to determine setting of the run.
+"""
+
+from dataclasses import dataclass, field
+from textwrap import dedent
+from typing import List
+
+import pytest
+
+from .utils import run_fawltydeps
+
+
+@dataclass
+class ConfiguredRunTestVector:
+    """Test vectors for FawltyDeps Settings configuration."""
+
+    id: str
+    toml_contents: str = ""
+    imports: List[str] = field(default_factory=list)
+    dependencies: List[str] = field(default_factory=list)
+    expect: int = 0  # exit code
+
+
+configured_run_tests_samples = [
+    ConfiguredRunTestVector(id="empty_pyproject_toml__no_problem_detected"),
+    ConfiguredRunTestVector(
+        id="with_ignored__no_problem_detected",
+        toml_contents="""
+            [tool.fawltydeps]
+            ignore_undeclared=["foo"]
+            ignore_unused=["bar"]
+        """,
+        imports=["foo"],
+        dependencies=["bar"],
+    ),
+    ConfiguredRunTestVector(
+        id="with_ignored_unused__undeclared_detected",
+        toml_contents="""
+            [tool.fawltydeps]
+            ignore_unused=["bar"]
+        """,
+        imports=["foo"],
+        dependencies=["bar"],
+        expect=3,
+    ),
+    ConfiguredRunTestVector(
+        id="with_custom_mapping__no_problem_detected",
+        toml_contents="""
+            [tool.fawltydeps.custom_mapping]
+            bar=["foo"]
+        """,
+        imports=["foo"],
+        dependencies=["bar"],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "vector", [pytest.param(v, id=v.id) for v in configured_run_tests_samples]
+)
+def test_run_with_pyproject_toml_settings(
+    vector, project_with_code_and_requirements_txt
+):
+    tmp_path = project_with_code_and_requirements_txt(
+        imports=vector.imports,
+        declares=vector.dependencies,
+    )
+    path = tmp_path / "pyproject.toml"
+    path.write_text(dedent(vector.toml_contents))
+
+    _, _, exit_code = run_fawltydeps(config_file=str(path), cwd=tmp_path)
+    assert exit_code == vector.expect

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -303,7 +303,7 @@ def test_resolve_dependencies__focus_on_mappings(
         user_mapping_path = tmp_path / "mapping.toml"
 
     assert (
-        resolve_dependencies(dep_names, custom_mapping_path=user_mapping_path)
+        resolve_dependencies(dep_names, custom_mapping_file=user_mapping_path)
         == expected
     )
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -167,6 +167,11 @@ def test_user_defined_mapping__input_is_no_file__raises_unparsable_path_exeption
         UserDefinedMapping(SAMPLE_PROJECTS_DIR)
 
 
+def test_ser_defined_mapping__no_input__returns_empty_mapping():
+    udm = UserDefinedMapping()
+    assert len(udm.packages) == 0
+
+
 # TODO: These tests are not fully isolated, i.e. they do not control the
 # virtualenv in which they run. For now, we assume that we are running in an
 # environment where at least these packages are available:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 from pydantic.env_settings import SettingsError  # pylint: disable=no-name-in-module
 
 from fawltydeps.main import build_parser
-from fawltydeps.settings import Action, OutputFormat, Settings, print_toml_config
+from fawltydeps.settings import Action, OutputFormat, Settings
 from fawltydeps.types import TomlData
 
 if sys.version_info >= (3, 11):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 from pydantic.env_settings import SettingsError  # pylint: disable=no-name-in-module
 
 from fawltydeps.main import build_parser
-from fawltydeps.settings import Action, OutputFormat, Settings
+from fawltydeps.settings import Action, OutputFormat, Settings, print_toml_config
 from fawltydeps.types import TomlData
 
 if sys.version_info >= (3, 11):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -259,7 +259,7 @@ settings_tests_samples = [
             deps=["my_requirements.txt"],
             custom_mapping={"package": ["foo", "bar"]},
         ),
-        cmdline=dict(custom_mapping_file="mapping.toml"),  # should be list/set, not str
+        cmdline=dict(custom_mapping_file="mapping.toml"),
         expect=make_settings_dict(
             actions={Action.LIST_DEPS},
             deps={Path("my_requirements.txt")},

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -268,6 +268,14 @@ settings_tests_samples = [
         ),
     ),
     SettingsTestVector(
+        "config_file_with_mapping_and_cli__cli_mapping_overrides_config",
+        config=dict(custom_mapping_file="foo.toml"),
+        cmdline=dict(custom_mapping_file="mapping.toml"),
+        expect=make_settings_dict(
+            custom_mapping_file=Path("mapping.toml"),
+        ),
+    ),
+    SettingsTestVector(
         "env_var_with_wrong_type__raises_SettingsError",
         env=dict(actions="list_imports"),  # actions is not a list
         expect=SettingsError,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -240,6 +240,34 @@ settings_tests_samples = [
         ),
     ),
     SettingsTestVector(
+        "config_file_with_mapping__overrides_some_defaults",
+        config=dict(
+            actions=["list_deps"],
+            deps=["my_requirements.txt"],
+            custom_mapping={"package": ["foo", "bar"]},
+        ),
+        expect=make_settings_dict(
+            actions={Action.LIST_DEPS},
+            deps={Path("my_requirements.txt")},
+            custom_mapping={"package": ["foo", "bar"]},
+        ),
+    ),
+    SettingsTestVector(
+        "config_file_with_mapping_and_cli__overrides_some_defaults",
+        config=dict(
+            actions=["list_deps"],
+            deps=["my_requirements.txt"],
+            custom_mapping={"package": ["foo", "bar"]},
+        ),
+        cmdline=dict(custom_mapping_file="mapping.toml"),  # should be list/set, not str
+        expect=make_settings_dict(
+            actions={Action.LIST_DEPS},
+            deps={Path("my_requirements.txt")},
+            custom_mapping={"package": ["foo", "bar"]},
+            custom_mapping_file=Path("mapping.toml"),
+        ),
+    ),
+    SettingsTestVector(
         "env_var_with_wrong_type__raises_SettingsError",
         env=dict(actions="list_imports"),  # actions is not a list
         expect=SettingsError,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,6 +28,7 @@ EXPECT_DEFAULTS = dict(
     code={Path(".")},
     deps={Path(".")},
     pyenv=None,
+    custom_mapping_file=None,
     custom_mapping=None,
     output_format=OutputFormat.HUMAN_SUMMARY,
     ignore_undeclared=set(),
@@ -226,16 +227,16 @@ settings_tests_samples = [
         ),
     ),
     SettingsTestVector(
-        "config_file_with_mapping__overrides_some_defaults",
+        "config_file_with_mapping_file__overrides_some_defaults",
         config=dict(
             actions=["list_deps"],
             deps=["my_requirements.txt"],
-            custom_mapping="mapping.toml",
+            custom_mapping_file="mapping.toml",
         ),
         expect=make_settings_dict(
             actions={Action.LIST_DEPS},
             deps={Path("my_requirements.txt")},
-            custom_mapping=Path("mapping.toml"),
+            custom_mapping_file=Path("mapping.toml"),
         ),
     ),
     SettingsTestVector(


### PR DESCRIPTION
Follow-up on #287 .

In this PR an option to read the mapping directly from the configuration file (pyproject.toml). This is a useful option when we have only a few mapping entries we want to adjust.

What changed:
- in `Settings`, field `custom_mapping` was renamed to `custom_mapping_file` (and the related elements accordingly). This field keeps a path to mapping file
- in `Settings` a new field `custom_mapping` was added, which is a dictionary of packages and list of modules they export.
- `UserDefinedMapping` is using now both, the file and the custom mapping in form of a dictionary. If both the mapping from file, and the custom mapping contain the same key (package), the mapping from pyproject.toml is taken. This is because  pyproject.toml is usually better maintained, with smaller chance of getting stale.
- refactored `setup_fawltydeps_config` to be able to add a subsection of fawltydeps configuration
- added `test_configured_run.py` to the test suite to have a place where we test how fawltydeps runs on configuration files only.
