### PR TITLE
Fix boolean representation and skip null values in generated toml config

### DIFF
--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -251,12 +251,12 @@ def print_toml_config(settings: Settings, out: TextIO = sys.stdout) -> None:
             if value is not None:
                 toml_option += "".join(
                     [
-                        f"\n{prefix}{k} = {toml_value_map.get(str(v), repr(v))}"
+                        f"\n{prefix}{k} = {toml_value_map.get(repr(v), repr(v))}"
                         for k, v in value.items()
                     ]
                 )
         else:
-            toml_value = toml_value_map.get(str(value), repr(value))
+            toml_value = toml_value_map.get(repr(value), repr(value))
             toml_option = f"{prefix}{name} = {toml_value}"
         return toml_option
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -859,6 +859,30 @@ def test_cmdline_on_ignored_undeclared_option(
             ).splitlines(),
             id="generate_toml_config_with_combo_of_config_and_cmdline_options",
         ),
+        pytest.param(
+            {"actions": ["check_undeclared"]},
+            ["--pyenv=None", "--generate-toml-config"],
+            dedent(
+                """\
+                # Copy this TOML section into your pyproject.toml to configure FawltyDeps
+                # (default values are commented)
+                [tool.fawltydeps]
+                actions = ['check_undeclared']
+                # output_format = 'human_summary'
+                # code = ['.']
+                # deps = ['.']
+                pyenv = 'None'
+                # custom_mapping_file = ...
+                # ignore_undeclared = []
+                # ignore_unused = []
+                # deps_parser_choice = ...
+                # install_deps = false
+                # verbosity = 0
+                # [tool.fawltydeps.custom_mapping]
+                """
+            ).splitlines(),
+            id="generate_toml_config_with_a_setting_set_to_str_None",
+        ),
     ],
 )
 def test_cmdline_args_in_combination_with_config_file(

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -847,12 +847,12 @@ def test_cmdline_on_ignored_undeclared_option(
                 output_format = 'human_detailed'
                 # code = ['.']
                 deps = ['foobar']
-                # pyenv = None
-                # custom_mapping_file = None
+                # pyenv = ...
+                # custom_mapping_file = ...
                 # ignore_undeclared = []
                 # ignore_unused = []
-                # deps_parser_choice = None
-                # install_deps = False
+                # deps_parser_choice = ...
+                # install_deps = false
                 # verbosity = 0
                 # [tool.fawltydeps.custom_mapping]
                 """


### PR DESCRIPTION
Fixes #265:
- TOML's booleans (true/false) are slightly different to Python's (True/False).
- The way to pass None from TOML is to not set the corresponding config directive.

This was needed to let new tests pass in #298.