### PR TITLE
Rename run_fawltydeps to run_fawltydeps_subprocess

### DIFF
--- a/tests/test_cmdline_options.py
+++ b/tests/test_cmdline_options.py
@@ -8,7 +8,7 @@ Strategy setup consists of three phases:
 1. Collect available CLI options
 2. Create an atomic strategy for each of those options
     Each atomic strategy returns list[str] that are appended
-    to the list of arguments to `run_fawltydeps` function.
+    to the list of arguments to `run_fawltydeps_subprocess` function.
 3. Create a composite strategy that samples from each atomic
     strategy and combine results into a new strategy used in the actual tests.
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -73,7 +73,7 @@ def unused_factory(*deps: str) -> List[UnusedDependency]:
     return [UnusedDependency(dep, [Location(Path("foo"))]) for dep in deps]
 
 
-def run_fawltydeps(
+def run_fawltydeps_subprocess(
     *args: str,
     config_file: Path = Path("/dev/null"),
     to_stdin: Optional[str] = None,


### PR DESCRIPTION
Following conversation with @jherland in https://github.com/tweag/FawltyDeps/pull/271#discussion_r1163887987 a name change of `run_fawltydeps` to `run_fawltydeps_subprocess` to follow the same naming convention as with `run_fawltydeps_function`.

The change is done separately from #271 for more atomic PRs.