### PR TITLE
Add fawltydeps.__main__ module to allow 'python -m fawltydeps'

### DIFF
--- a/fawltydeps/__main__.py
+++ b/fawltydeps/__main__.py
@@ -1,0 +1,8 @@
+"""Entry-point module, to allow `python -m fawltydeps`."""
+
+import sys
+
+from fawltydeps.main import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -256,6 +256,7 @@ def build_parser(
     caller can add its own additional command-line arguments.
     """
     parser = argparse.ArgumentParser(
+        prog=__name__.split(".", maxsplit=1)[0],  # use top-level package name
         description=description,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         add_help=False,  # instead, add --help in populate_parser_other_options()

--- a/tests/test_invocation.py
+++ b/tests/test_invocation.py
@@ -1,0 +1,65 @@
+"""Test various ways to invoke the fawltydeps application."""
+
+import subprocess
+import sys
+from typing import Tuple
+
+import pytest
+
+from fawltydeps.main import Analysis, version
+
+from .utils import run_fawltydeps_function, run_fawltydeps_subprocess
+
+pytestmark = pytest.mark.integration
+
+
+def run_package_main(*args: str) -> Tuple[str, int]:
+    proc = subprocess.run(
+        [sys.executable, "-m", "fawltydeps", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    return proc.stdout.strip(), proc.returncode
+
+
+invocation_methods = [
+    pytest.param(
+        run_fawltydeps_subprocess,
+        id="via command-line entry point: `fawltydeps ...`",
+    ),
+    pytest.param(
+        run_package_main,
+        id="via package.__main__: `python -m fawltydeps ...`",
+    ),
+    pytest.param(
+        run_fawltydeps_function,
+        id="via main() function: `fawltydeps.main.main([...])`",
+    ),
+]
+
+
+@pytest.mark.parametrize("run_fawltydeps", invocation_methods)
+def test_invocation_with_version(run_fawltydeps):
+    if run_fawltydeps is run_fawltydeps_function:
+        pytest.skip("run_fawltydeps_function() does not capture --version output")
+    output, *_, exit_code = run_fawltydeps("--version")
+    assert output == f"FawltyDeps v{version()}"
+    assert exit_code == 0
+
+
+@pytest.mark.parametrize("run_fawltydeps", invocation_methods)
+def test_invocation_with_help(run_fawltydeps):
+    if run_fawltydeps is run_fawltydeps_function:
+        pytest.skip("run_fawltydeps_function() does not capture --version output")
+    output, *_, exit_code = run_fawltydeps("--help")
+    assert output.startswith("usage: fawltydeps")
+    assert exit_code == 0
+
+
+@pytest.mark.parametrize("run_fawltydeps", invocation_methods)
+def test_invocation_in_empty_dir(run_fawltydeps, tmp_path):
+    output, *_, exit_code = run_fawltydeps(str(tmp_path))
+    assert output == Analysis.success_message(True, True)
+    assert exit_code == 0


### PR DESCRIPTION
It is common for Python packages that offer a command-line interface to
expose this via the `__main__` module in the package. See [1] for info.

Also add some tests to verify the various ways we can now invoke the
fawltydeps command-line interface:

- using the `fawltydeps` entry point
- calling the `fawltydeps.main.main()` function from inside Python
- running `python -m fawltydeps`

These tests discovered that the program name shown at the start of the
`--help` message did not make sense when using the latter two invocations.
Fix that by explicitly passing the program name to `argparse`.

Fixes: https://github.com/tweag/FawltyDeps/issues/309

Suggested-by: Timothée Mazzucotelli <pawamoy@pm.me>

[1]: https://docs.python.org/3/library/__main__.html#main-py-in-python-packages
