### PR TITLE
Pin our importlib_metadata version (and some cosmetic fixes)

### DIFF
--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -251,7 +251,7 @@ class LocalPackageResolver(BasePackageResolver):
         # Note that packages_distributions() is not able to return packages
         # that map to zero import names.
         context = DistributionFinder.Context(path=paths)  # type: ignore
-        for dist in MetadataPathFinder().find_distributions(context):  # type: ignore
+        for dist in MetadataPathFinder().find_distributions(context):
             normalized_name = Package.normalize_name(dist.name)
             parent_dir = dist.locate_file("")
             if normalized_name in ret:

--- a/poetry.lock
+++ b/poetry.lock
@@ -184,7 +184,7 @@ zoneinfo = ["backports.zoneinfo (>=0.2.1)", "tzdata (>=2022.7)"]
 
 [[package]]
 name = "importlib-metadata"
-version = "6.0.0"
+version = "6.6.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -519,7 +519,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "0892607a7a5d1e6a7b1324214cb8098e6d3acbb7b376d65d712fd396c38c3629"
+content-hash = "7a2db64d056b62c45b5dab9bf0f8593ed0944db0ea7a824d8ec1131cad7a1e54"
 
 [metadata.files]
 argcomplete = [
@@ -585,8 +585,8 @@ hypothesis = [
     {file = "hypothesis-6.68.2.tar.gz", hash = "sha256:a7eb2b0c9a18560d8197fe35047ceb58e7e8ab7623a3e5a82613f6a2cd71cffa"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-6.0.0-py3-none-any.whl", hash = "sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad"},
-    {file = "importlib_metadata-6.0.0.tar.gz", hash = "sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d"},
+    {file = "importlib_metadata-6.6.0-py3-none-any.whl", hash = "sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed"},
+    {file = "importlib_metadata-6.6.0.tar.gz", hash = "sha256:92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705"},
 ]
 iniconfig = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ fawltydeps = "fawltydeps.main:main"
 # These are the main dependencies for fawltydeps at runtime.
 # Do not add anything here that is only needed by CI/tests/linters/developers
 python = "^3.7.2"
-importlib_metadata = "^6.0.0"
+importlib_metadata = "=6.6.0"
 # isort 5.12.0 drops support for Python v3.7:
 isort = ">=5.10,<5.12.0"
 pip-requirements-parser = "^32.0.1"

--- a/tests/test_invocation.py
+++ b/tests/test_invocation.py
@@ -52,7 +52,7 @@ def test_invocation_with_version(run_fawltydeps):
 @pytest.mark.parametrize("run_fawltydeps", invocation_methods)
 def test_invocation_with_help(run_fawltydeps):
     if run_fawltydeps is run_fawltydeps_function:
-        pytest.skip("run_fawltydeps_function() does not capture --version output")
+        pytest.skip("run_fawltydeps_function() does not capture --help output")
     output, *_, exit_code = run_fawltydeps("--help")
     assert output.startswith("usage: fawltydeps")
     assert exit_code == 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,7 +23,9 @@ logger = logging.getLogger(__name__)
 
 
 def assert_unordered_equivalence(actual: Iterable[Any], expected: Iterable[Any]):
-    assert sorted(actual) == sorted(expected)
+    actual_s = sorted(actual)
+    expected_s = sorted(expected)
+    assert actual_s == expected_s, f"{actual_s!r} != {expected_s!r}"
 
 
 def collect_dep_names(deps: Iterable[DeclaredDependency]) -> Iterable[str]:


### PR DESCRIPTION
(Depends on #313)

Commits:
- `tests.utils.assert_unordered_equivalence()`: More details when it fails
- `test_invocation`: Fix `pytest.skip()` message
- `pyproject.toml`: Pin `importlib_metadata` to latest release ==v6.6.0
