### PR TITLE
Fail execution if not all dependencies are resolved.

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -294,8 +294,10 @@ def main(
         return parser.error(exc.msg)  # exit code 2
     except UnresolvedDependenciesError as exc:
         logger.error(
-            "%s \nIf you use '--install-deps' option "
-            "please make sure that you have all your dependencies installed.",
+            "%s\nFawltyDeps is unable to find the above packages with the "
+            "configured package resolvers. Consider using --pyenv if these "
+            "packages are already installed somewhere, or --custom-mapping-file "
+            "to take full control of the package-to-import-names mapping.",
             str(exc.msg),
         )
         return 5

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -25,7 +25,11 @@ from importlib_metadata import (
     _top_level_inferred,
 )
 
-from fawltydeps.types import CustomMapping, UnparseablePathException
+from fawltydeps.types import (
+    CustomMapping,
+    UnparseablePathException,
+    UnresolvedDependenciesError,
+)
 from fawltydeps.utils import calculated_once, hide_dataclass_fields
 
 if sys.version_info >= (3, 11):
@@ -413,4 +417,9 @@ def resolve_dependencies(
         resolved = resolver.lookup_packages(unresolved)
         logger.debug(f"  Resolved {resolved!r} with {resolver}")
         ret.update(resolved)
+
+    unresolved = deps - ret.keys()
+    if unresolved:
+        raise UnresolvedDependenciesError(names=unresolved)
+
     return ret

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -31,7 +31,7 @@ class UnresolvedDependenciesError(Exception):
     """Exception type when not all dependencies were are resolved"""
 
     def __init__(self, names: Set[str]):
-        self.msg = f"Unresolved dependnencies: {names}"
+        self.msg = f"Unresolved dependencies: {', '.join(sorted(names))}"
 
 
 class ParserChoice(Enum):

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -5,7 +5,7 @@ from dataclasses import asdict, dataclass, field, replace
 from enum import Enum
 from functools import total_ordering
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from fawltydeps.utils import hide_dataclass_fields
 
@@ -25,6 +25,13 @@ class UnparseablePathException(Exception):
 
     def __init__(self, ctx: str, path: Path):
         self.msg = f"{ctx}: {path}"
+
+
+class UnresolvedDependenciesError(Exception):
+    """Exception type when not all dependencies were are resolved"""
+
+    def __init__(self, names: Set[str]):
+        self.msg = f"Unresolved dependnencies: {names}"
 
 
 class ParserChoice(Enum):

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -13,7 +13,7 @@ from fawltydeps.packages import (
     UserDefinedMapping,
     resolve_dependencies,
 )
-from fawltydeps.types import UnparseablePathException
+from fawltydeps.types import UnparseablePathException, UnresolvedDependenciesError
 
 from .utils import SAMPLE_PROJECTS_DIR, test_vectors
 
@@ -304,3 +304,13 @@ def test_resolve_dependencies__informs_once_when_id_mapping_is_used(caplog):
     caplog.set_level(logging.INFO)
     assert resolve_dependencies(dep_names) == expect
     assert caplog.record_tuples == expect_log
+
+
+@pytest.mark.skip(
+    "This test waits for making IdentityMappig optional or not used as a fallback"
+)
+def test_resolve_dependencies__unresolved_dependencies__UnresolvedDependenciesError_raised():
+    dep_names = ["foo", "bar"]
+
+    with pytest.raises(UnresolvedDependenciesError):
+        resolve_dependencies(dep_names)


### PR DESCRIPTION
Prerequisite for #266 . Related to #299.

As discussed in a few team meetings, we decided on an option that if no mapping is found for a dependency (for example because identity mapping is disabled and we did not found everything in the environment) then we report it as an error.

In this PR I introduce:
- `UnresolvedDependenciesError` to be raised when all resolvers have finished and there are still unresolved dependencies in the pool
- exit code 5 for cases where not all dependencies have been maped
- dummy test to be filled when we allow for a case with no fallback to identity mapping (I tested by commenting out adding identity mapping to the resolvers stack). Follow-up PR will introduce `--install-deps` as a cli option, and the `resolve_dependencies` logic will be changed then. 

This PR may be checked commit by commit.
