### PR TITLE
Support multiple `--pyenv` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ This will tell FawltyDeps:
 - to use the Python environment at `.venv/` to map dependency names in
   `pyproject.toml` into import names used in your code under `my_package/`
 
+You can use `--pyenv` multiple times to have FawltyDeps look for packages in
+multiple Python environments. When mapping a dependency into import names,
+FawltyDeps will then use the union of all imports provided by all matching
+packages across those Python environments as valid import names for that
+dependency.
+
 #### Identity mapping
 
 When FawltyDeps is unable to find an installed package that corresponds to a
@@ -270,9 +276,10 @@ Here is a complete list of configuration directives we support:
   Defaults to the current directory, i.e. like `code = ["."]`.
 - `deps`: Files or directories containing the declared dependencies.
   Defaults to the current directory, i.e. like `deps = ["."]`.
-- `pyenv`: The path to the Python environment to use for resolving project
-  dependencies to provided import names. Defaults to the Python environment
-  where FawltyDeps is installed.
+- `pyenvs`: Python environments (directories like `.venv`, `__pypackages__`, or
+  similar) to use for resolving project dependencies into provided import names.
+  Defaults to an empty list, i.e. like `pyenvs = []`, which is interpreted as
+  using the Python environment where FawltyDeps is installed (aka. `sys.path`).
 - `output_format`: Which output format to use by default. One of `human_summary`,
   `human_detailed`, or `json`.
   The default corresponds to `output_format = "human_summary"`.

--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -156,12 +156,15 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
     )
     parser.add_argument(
         "--pyenv",
+        dest="pyenvs",
+        nargs="+",
+        action="union",
         type=Path,
         metavar="PYENV_DIR",
         help=(
-            "Where to find a Python environment that has the project dependencies"
-            " installed, defaults to the Python environment where FawltyDeps is"
-            " installed."
+            "Where to find Python environments that have project dependencies"
+            " installed. When empty (the default), fall back to the Python"
+            " environment where FawltyDeps is installed."
         ),
     )
     parser.add_argument(

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -112,7 +112,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
             (dep.name for dep in self.declared_deps),
             custom_mapping_files=self.settings.custom_mapping_file,
             custom_mapping=self.settings.custom_mapping,
-            pyenv_path=self.settings.pyenv,
+            pyenv_paths=self.settings.pyenvs,
             install_deps=self.settings.install_deps,
         )
 

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -432,15 +432,13 @@ def resolve_dependencies(
     dep_names: Iterable[str],
     custom_mapping_files: Optional[Set[Path]] = None,
     custom_mapping: Optional[CustomMapping] = None,
-    pyenv_path: Optional[Path] = None,
+    pyenv_paths: AbstractSet[Path] = frozenset(),
     install_deps: bool = False,
 ) -> Dict[str, Package]:
     """Associate dependencies with corresponding Package objects.
 
-    Use LocalPackageResolver to find Package objects for each of the given
-    dependencies inside the virtualenv given by 'pyenv_path'. When 'pyenv_path'
-    is None (the default), look for packages in the current Python environment
-    (i.e. equivalent to sys.path).
+    Setup a list of resolvers according to the given settings/arguments, and
+    use these to find Package objects for each of the given dependencies.
 
     Return a dict mapping dependency names to the resolved Package objects.
     """
@@ -457,9 +455,7 @@ def resolve_dependencies(
         )
     )
 
-    resolvers.append(
-        LocalPackageResolver(set() if pyenv_path is None else {pyenv_path})
-    )
+    resolvers.append(LocalPackageResolver(pyenv_paths))
     if install_deps:
         resolvers += [TemporaryPipInstallResolver()]
     # Identity mapping being at the bottom of the resolvers stack ensures that

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -109,7 +109,7 @@ class Settings(BaseSettings):  # type: ignore
     output_format: OutputFormat = OutputFormat.HUMAN_SUMMARY
     code: Set[PathOrSpecial] = {Path(".")}
     deps: Set[Path] = {Path(".")}
-    pyenv: Optional[Path] = None
+    pyenvs: Set[Path] = set()
     custom_mapping_file: Set[Path] = set()
     custom_mapping: Optional[CustomMapping] = None
     ignore_undeclared: Set[str] = set()

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -904,6 +904,30 @@ def test_cmdline_on_ignored_undeclared_option(
             ).splitlines(),
             id="generate_toml_config_with_a_setting_set_to_str_None",
         ),
+        pytest.param(
+            {"pyenvs": ["foo", "bar"]},
+            ["--pyenv", "baz", "xyzzy", "--generate-toml-config"],
+            dedent(
+                """\
+                # Copy this TOML section into your pyproject.toml to configure FawltyDeps
+                # (default values are commented)
+                [tool.fawltydeps]
+                # actions = ['check_undeclared', 'check_unused']
+                # output_format = 'human_summary'
+                # code = ['.']
+                # deps = ['.']
+                pyenvs = ['baz', 'xyzzy']
+                # custom_mapping_file = []
+                # ignore_undeclared = []
+                # ignore_unused = []
+                # deps_parser_choice = ...
+                # install_deps = false
+                # verbosity = 0
+                # [tool.fawltydeps.custom_mapping]
+                """
+            ).splitlines(),
+            id="generate_toml_config_with_multiple_pyenvs",
+        ),
     ],
 )
 def test_cmdline_args_in_combination_with_config_file(

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -35,7 +35,7 @@ def make_json_settings_dict(**kwargs):
         "actions": ["check_undeclared", "check_unused"],
         "code": ["."],
         "deps": ["."],
-        "pyenv": None,
+        "pyenvs": [],
         "custom_mapping_file": [],
         "custom_mapping": None,
         "output_format": "human_summary",
@@ -710,6 +710,25 @@ def test_check_detailed__simple_project_in_fake_venv__resolves_imports_vs_deps(
     assert returncode == 0
 
 
+def test_check_detailed__simple_project_w_2_fake_venv__resolves_imports_vs_deps(
+    fake_venv, project_with_code_and_requirements_txt
+):
+    tmp_path = project_with_code_and_requirements_txt(
+        imports=["some_import", "other_import", "yet_another"],
+        declares=["something", "other"],
+    )
+    venv_dir1, _ = fake_venv({"something": {"some_import"}})
+    venv_dir2, _ = fake_venv({"something": {"other_import"}, "other": {"yet_another"}})
+
+    output, returncode = run_fawltydeps_function(
+        "--detailed", f"{tmp_path}", "--pyenv", f"{venv_dir1}", f"{venv_dir2}"
+    )
+    assert output.splitlines() == [
+        Analysis.success_message(check_undeclared=True, check_unused=True),
+    ]
+    assert returncode == 0
+
+
 @pytest.mark.parametrize(
     "args,imports,dependencies,expected",
     [
@@ -849,7 +868,7 @@ def test_cmdline_on_ignored_undeclared_option(
                 output_format = 'human_detailed'
                 # code = ['.']
                 deps = ['foobar']
-                # pyenv = ...
+                # pyenvs = []
                 # custom_mapping_file = []
                 # ignore_undeclared = []
                 # ignore_unused = []
@@ -873,7 +892,7 @@ def test_cmdline_on_ignored_undeclared_option(
                 # output_format = 'human_summary'
                 # code = ['.']
                 # deps = ['.']
-                pyenv = 'None'
+                pyenvs = ['None']
                 # custom_mapping_file = []
                 # ignore_undeclared = []
                 # ignore_unused = []

--- a/tests/test_install_deps.py
+++ b/tests/test_install_deps.py
@@ -11,9 +11,7 @@ from fawltydeps.packages import (
 
 def test_resolve_dependencies_install_deps__via_local_cache(local_pypi):
     debug_info = "Provided by temporary `pip install`"
-    actual = resolve_dependencies(
-        ["leftpadx", "click"], pyenv_path=None, install_deps=True
-    )
+    actual = resolve_dependencies(["leftpadx", "click"], install_deps=True)
     assert actual == {
         "leftpadx": Package(
             "leftpadx", {"leftpad"}, TemporaryPipInstallResolver, debug_info
@@ -30,9 +28,7 @@ def test_resolve_dependencies_install_deps__handle_pip_install_failure(
     # For now, IdentityMapping "saves the day" and supplies a Package object.
     # Soon, this should result in an unresolved package error instead.
     caplog.set_level(logging.WARNING)
-    actual = resolve_dependencies(
-        ["does_not_exist"], pyenv_path=None, install_deps=True
-    )
+    actual = resolve_dependencies(["does_not_exist"], install_deps=True)
     assert actual == {
         "does_not_exist": Package(
             "does_not_exist", {"does_not_exist"}, IdentityMapping
@@ -47,7 +43,7 @@ def test_resolve_dependencies_install_deps__pip_install_some_packages(
     debug_info = "Provided by temporary `pip install`"
     caplog.set_level(logging.WARNING)
     actual = resolve_dependencies(
-        ["click", "does_not_exist", "leftpadx"], pyenv_path=None, install_deps=True
+        ["click", "does_not_exist", "leftpadx"], install_deps=True
     )
     # pip install is able to install "leftpadx", but "package_does_not_exist"
     # falls through to IdentityMapping.

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -176,7 +176,7 @@ def test_local_env__multiple_pyenvs__merges_imports_for_same_package(fake_venv):
 def test_resolve_dependencies__in_empty_venv__reverts_to_id_mapping(tmp_path):
     venv.create(tmp_path, with_pip=False)
     id_mapping = IdentityMapping()
-    actual = resolve_dependencies(["pip", "setuptools"], pyenv_path=tmp_path)
+    actual = resolve_dependencies(["pip", "setuptools"], pyenv_paths={tmp_path})
     assert actual == id_mapping.lookup_packages({"pip", "setuptools"})
 
 
@@ -188,7 +188,9 @@ def test_resolve_dependencies__in_fake_venv__returns_local_and_id_deps(fake_venv
             "empty_pkg": set(),
         }
     )
-    actual = resolve_dependencies(["PIP", "pandas", "empty-pkg"], pyenv_path=venv_dir)
+    actual = resolve_dependencies(
+        ["PIP", "pandas", "empty-pkg"], pyenv_paths={venv_dir}
+    )
     assert actual == {
         "PIP": Package(
             "pip", {"pip"}, LocalPackageResolver, {str(site_packages): {"pip"}}
@@ -196,5 +198,33 @@ def test_resolve_dependencies__in_fake_venv__returns_local_and_id_deps(fake_venv
         "pandas": Package("pandas", {"pandas"}, IdentityMapping),
         "empty-pkg": Package(
             "empty_pkg", set(), LocalPackageResolver, {str(site_packages): set()}
+        ),
+    }
+
+
+def test_resolve_dependencies__in_2_fake_venvs__returns_local_and_id_deps(fake_venv):
+    venv_dir1, site_dir1 = fake_venv({"some_module": {"first_import"}})
+    venv_dir2, site_dir2 = fake_venv(
+        {"some_module": {"second_import"}, "other-module": {"other_module"}}
+    )
+    actual = resolve_dependencies(
+        ["some_module", "pandas", "other_module"], pyenv_paths={venv_dir1, venv_dir2}
+    )
+    assert actual == {
+        "some_module": Package(
+            "some_module",
+            {"first_import", "second_import"},
+            LocalPackageResolver,
+            {
+                str(site_dir1): {"first_import"},
+                str(site_dir2): {"second_import"},
+            },
+        ),
+        "pandas": Package("pandas", {"pandas"}, IdentityMapping),
+        "other_module": Package(
+            "other_module",
+            {"other_module"},
+            LocalPackageResolver,
+            {str(site_dir2): {"other_module"}},
         ),
     }

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -44,7 +44,7 @@ def verify_requirements(venv_path: Path, requirements: List[str]) -> None:
         for req in requirements
         if "python_version" not in req  # we don't know how to parse these (yet)
     }
-    resolved = LocalPackageResolver(venv_path).lookup_packages(deps)
+    resolved = LocalPackageResolver({venv_path}).lookup_packages(deps)
     assert all(dep in resolved for dep in deps)
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -86,7 +86,9 @@ def generate_expected_resolved_deps(
     if locally_installed_deps:
         ret.update(
             {
-                dep: Package(dep, set(imports), LocalPackageResolver)
+                dep: Package(
+                    Package.normalize_name(dep), set(imports), LocalPackageResolver
+                )
                 for dep, imports in locally_installed_deps.items()
             }
         )
@@ -101,7 +103,11 @@ def generate_expected_resolved_deps(
         if install_deps:
             ret.update(
                 {
-                    dep: Package(dep, set(imports), TemporaryPipInstallResolver)
+                    dep: Package(
+                        Package.normalize_name(dep),
+                        set(imports),
+                        TemporaryPipInstallResolver,
+                    )
                     for dep, imports in other_deps.items()
                 }
             )

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -66,7 +66,7 @@ class Experiment(BaseExperiment):
             actions={Action.REPORT_UNDECLARED, Action.REPORT_UNUSED},
             code=[(project_path / path) for path in self.code],
             deps=[(project_path / path) for path in self.deps],
-            pyenv=self.get_venv_dir(cache),
+            pyenvs={self.get_venv_dir(cache)},
             install_deps=self.install_deps,
         )
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -27,7 +27,7 @@ EXPECT_DEFAULTS = dict(
     actions={Action.REPORT_UNDECLARED, Action.REPORT_UNUSED},
     code={Path(".")},
     deps={Path(".")},
-    pyenv=None,
+    pyenvs=set(),
     custom_mapping_file=set(),
     custom_mapping=None,
     output_format=OutputFormat.HUMAN_SUMMARY,
@@ -273,6 +273,14 @@ settings_tests_samples = [
         cmdline=dict(custom_mapping_file=["mapping.toml"]),
         expect=make_settings_dict(
             custom_mapping_file={Path("mapping.toml")},
+        ),
+    ),
+    SettingsTestVector(
+        "config_file_with_pyenvs_and_cli__cli_pyenvs_overrides_config",
+        config=dict(pyenvs=["foo", "bar"]),
+        cmdline=dict(pyenvs=["baz", "xyzzy"]),
+        expect=make_settings_dict(
+            pyenvs={Path("baz"), Path("xyzzy")},
         ),
     ),
     SettingsTestVector(


### PR DESCRIPTION
These are the commits that were originally part of #313, but now split into this PR.

Commits:
- `LocalPackageResolver`: Accept multiple pyenvs
- Add support for multiple `--pyenv` options
- `settings.print_toml_config()`: Represent sets as sorted lists
