### PR TITLE
`TemporaryPipInstallResolver`: Handle `pip install` errors gracefully

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -94,6 +94,7 @@ def lint(session):
         "too-many-arguments",
         "too-many-instance-attributes",
         "too-many-lines",
+        "unused-argument",
         "use-implicit-booleaness-not-comparison",
     ]
     session.run(

--- a/tests/test_install_deps.py
+++ b/tests/test_install_deps.py
@@ -1,0 +1,63 @@
+"""Verify behavior of TemporaryPipInstallResolver."""
+import logging
+
+from fawltydeps.packages import (
+    IdentityMapping,
+    Package,
+    TemporaryPipInstallResolver,
+    resolve_dependencies,
+)
+
+
+def test_resolve_dependencies_install_deps__via_local_cache(local_pypi):
+    debug_info = "Provided by temporary `pip install`"
+    actual = resolve_dependencies(
+        ["leftpadx", "click"], pyenv_path=None, install_deps=True
+    )
+    assert actual == {
+        "leftpadx": Package(
+            "leftpadx", {"leftpad"}, TemporaryPipInstallResolver, debug_info
+        ),
+        "click": Package("click", {"click"}, TemporaryPipInstallResolver, debug_info),
+    }
+
+
+def test_resolve_dependencies_install_deps__handle_pip_install_failure(
+    caplog, local_pypi
+):
+    # TemporaryPipInstallResolver will handle the inevitable pip install error
+    # and return to resolve_dependencies() with the missing package unresolved.
+    # For now, IdentityMapping "saves the day" and supplies a Package object.
+    # Soon, this should result in an unresolved package error instead.
+    caplog.set_level(logging.WARNING)
+    actual = resolve_dependencies(
+        ["does_not_exist"], pyenv_path=None, install_deps=True
+    )
+    assert actual == {
+        "does_not_exist": Package(
+            "does_not_exist", {"does_not_exist"}, IdentityMapping
+        ),
+    }
+    assert all(word in caplog.text for word in ["pip", "install", "does_not_exist"])
+
+
+def test_resolve_dependencies_install_deps__pip_install_some_packages(
+    caplog, local_pypi
+):
+    debug_info = "Provided by temporary `pip install`"
+    caplog.set_level(logging.WARNING)
+    actual = resolve_dependencies(
+        ["click", "does_not_exist", "leftpadx"], pyenv_path=None, install_deps=True
+    )
+    # pip install is able to install "leftpadx", but "package_does_not_exist"
+    # falls through to IdentityMapping.
+    assert actual == {
+        "click": Package("click", {"click"}, TemporaryPipInstallResolver, debug_info),
+        "does_not_exist": Package(
+            "does_not_exist", {"does_not_exist"}, IdentityMapping
+        ),
+        "leftpadx": Package(
+            "leftpadx", {"leftpad"}, TemporaryPipInstallResolver, debug_info
+        ),
+    }
+    assert all(word in caplog.text for word in ["pip", "install", "does_not_exist"])

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -8,7 +8,6 @@ from fawltydeps.packages import (
     IdentityMapping,
     LocalPackageResolver,
     Package,
-    TemporaryPipInstallResolver,
     resolve_dependencies,
 )
 
@@ -161,18 +160,4 @@ def test_resolve_dependencies__in_fake_venv__returns_local_and_id_deps(fake_venv
         "empty-pkg": Package(
             "empty_pkg", set(), LocalPackageResolver, {str(site_packages): set()}
         ),
-    }
-
-
-@pytest.mark.usefixtures("local_pypi")
-def test_on_installed_venv__returns_local_deps():
-    actual = resolve_dependencies(
-        ["leftpadx", "click"], pyenv_path=None, install_deps=True
-    )
-    debug_info = "Provided by temporary `pip install`"
-    assert actual == {
-        "leftpadx": Package(
-            "leftpadx", {"leftpad"}, TemporaryPipInstallResolver, debug_info
-        ),
-        "click": Package("click", {"click"}, TemporaryPipInstallResolver, debug_info),
     }


### PR DESCRIPTION
Until now, we have not handled the `CalledProcessError` that is raised when `pip install` fails to install the given requirements in `TemporaryPipInstallResolver.temp_installed_requirements()`.

This commit adds two new flags to `.temp_installed_requirements()`:

 - `ignore_errors`: This disables the `CalledProcessError` and logs a warning message instead.
 - `retry_each`: In combination with the above, when `pip install` fails, this will retry `pip install` on each individual requirement in order. The effect of this will be to install the subset of the given requirements that we _can_ install, leaving only the problematic requirements uninstalled.

Using both of these flags enables `TemporaryPipInstallResolver` to do a "best effort" installation of dependencies: Inside the `.temp_installed_requirements()` context, the `LocalPackageResolver` will be able to resolve those dependencies that were successfully installed, and the dependencies we failed to install will be handed off to the next level of the resolver stack.

As of writing this is always the `IdentityMapping`, but this is about to go away, and instead a proper `UnresolvedDependenciesError` will be raised. Together with the warning messages from the failed `pip install` commands, this should inform the user of exactly which packages/dependencies we failed to install, and why.

On the `tests/` side, move our existing `TemporaryPipInstallResolver` test into a new test module: `test_install_deps`, and add two more tests:

 - to test that we no longer propagate a `CalledProcessError` when `pip install` fails (but instead log a warning message), and
 - to test that we are able to install one dependency with `pip install` even if another dependency fails.

Fixes #322 (Handle `pip install` errors in `TemporaryPipInstallResolver`)
