### PR TITLE
Teach FawltyDeps to automatically discover Python environments inside the project

### DIFF
--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -120,8 +120,11 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         "basepaths",
         type=lambda p: None if p == argparse.SUPPRESS else Path(p),
         nargs="*",
-        help="(Optional) directory in which to search for code (imports),"
-        " dependency declarations and/or Python environments",
+        help=(
+            "Optional directories in which to search for code (imports),"
+            " dependency declarations and/or Python environments. Defaults to"
+            " the current directory."
+        ),
     )
     parser.add_argument(
         "--code",
@@ -130,8 +133,8 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         type=parse_path_or_stdin,
         metavar="PATH_OR_STDIN",
         help=(
-            "Code to parse for import statements (file or directory, use '-'"
-            " to read code from stdin; defaults to the current directory)"
+            "Code to parse for import statements (files or directories, or use"
+            " '-' to read code from stdin). Defaults to basepaths (see above)."
         ),
     )
     parser.add_argument(
@@ -141,8 +144,8 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         type=Path,
         metavar="PATH",
         help=(
-            "Where to find dependency declarations (file or directory, defaults"
-            " to looking for supported files in the current directory)"
+            "Where to find dependency declarations (files or directories)."
+            " Defaults to finding supported files under basepaths (see above)."
         ),
     )
     parser.add_argument(
@@ -162,10 +165,10 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         type=Path,
         metavar="PYENV_DIR",
         help=(
-            "Where to find Python environments that have project dependencies"
-            " installed. Defaults to looking for Python environments under the"
-            " current directory, or failing that, using the Python environment"
-            " where FawltyDeps is installed."
+            "Where to search for Python environments that have project"
+            " dependencies installed. Defaults to searching under basepaths"
+            " (see above). If no environments are found, fall back to using the"
+            " Python environment where FawltyDeps is installed."
         ),
     )
     parser.add_argument(
@@ -175,7 +178,8 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         type=Path,
         metavar="FILE_PATH",
         help=(
-            "Path to toml file containing mapping of dependencies to imports defined by the user."
+            "Path to toml file containing mapping of dependencies to imports"
+            " defined by the user."
         ),
     )
 

--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -107,7 +107,7 @@ def populate_output_formats(parser: argparse._ActionsContainer) -> None:
 
 
 def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
-    """Add the source paths (code, deps, env) Settings members to the parser.
+    """Add the source paths (code, deps, pyenv) Settings members to the parser.
 
     None of these options should specify default values
     (and the parser-wide default value should be argparse.SUPPRESS).
@@ -120,8 +120,8 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         "basepaths",
         type=lambda p: None if p == argparse.SUPPRESS else Path(p),
         nargs="*",
-        help="(Optional) directory in which to search for code (imports) "
-        "and/or dependency declarations",
+        help="(Optional) directory in which to search for code (imports),"
+        " dependency declarations and/or Python environments",
     )
     parser.add_argument(
         "--code",
@@ -130,8 +130,8 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         type=parse_path_or_stdin,
         metavar="PATH_OR_STDIN",
         help=(
-            "Code to parse for import statements (file or directory, use '-' "
-            "to read code from stdin; defaults to the current directory)"
+            "Code to parse for import statements (file or directory, use '-'"
+            " to read code from stdin; defaults to the current directory)"
         ),
     )
     parser.add_argument(
@@ -150,8 +150,8 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         type=read_parser_choice,
         choices=list(ParserChoice),
         help=(
-            "Name of the parsing strategy to use for dependency declarations, "
-            "useful for when the file to parse doesn't match a standard name"
+            "Name of the parsing strategy to use for dependency declarations,"
+            " useful for when the file to parse doesn't match a standard name"
         ),
     )
     parser.add_argument(
@@ -163,8 +163,9 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         metavar="PYENV_DIR",
         help=(
             "Where to find Python environments that have project dependencies"
-            " installed. When empty (the default), fall back to the Python"
-            " environment where FawltyDeps is installed."
+            " installed. Defaults to looking for Python environments under the"
+            " current directory, or failing that, using the Python environment"
+            " where FawltyDeps is installed."
         ),
     )
     parser.add_argument(

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -30,6 +30,7 @@ from fawltydeps.types import (
     DeclaredDependency,
     DepsSource,
     ParsedImport,
+    PyEnvSource,
     Source,
     UndeclaredDependency,
     UnparseablePathException,
@@ -73,8 +74,8 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
         source_types: Dict[Action, Set[Type[Source]]] = {
             Action.LIST_IMPORTS: {CodeSource},
             Action.LIST_DEPS: {DepsSource},
-            Action.REPORT_UNDECLARED: {CodeSource, DepsSource},
-            Action.REPORT_UNUSED: {CodeSource, DepsSource},
+            Action.REPORT_UNDECLARED: {CodeSource, DepsSource, PyEnvSource},
+            Action.REPORT_UNUSED: {CodeSource, DepsSource, PyEnvSource},
         }
         return set(
             find_sources(
@@ -112,7 +113,9 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
             (dep.name for dep in self.declared_deps),
             custom_mapping_files=self.settings.custom_mapping_file,
             custom_mapping=self.settings.custom_mapping,
-            pyenv_paths=self.settings.pyenvs,
+            pyenv_paths={
+                src.path for src in self.sources if isinstance(src, PyEnvSource)
+            },
             install_deps=self.settings.install_deps,
         )
 

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -37,6 +37,7 @@ from importlib_metadata import (
 
 from fawltydeps.types import (
     CustomMapping,
+    PyEnvSource,
     UnparseablePathException,
     UnresolvedDependenciesError,
 )
@@ -491,3 +492,19 @@ def resolve_dependencies(
         raise UnresolvedDependenciesError(names=unresolved)
 
     return ret
+
+
+def validate_pyenv_source(path: Path) -> Optional[Set[PyEnvSource]]:
+    """Check if the given directory path is a valid Python environment.
+
+    - If a Python environment is found at the given path, then return a set of
+      package dirs (typically only one) found within this Python environment.
+    - Return None if this is a directory that must be traversed further to find
+      Python environments within.
+    - Raise UnparseablePathException if the given path is not a directory.
+    """
+    if not path.is_dir():
+        raise UnparseablePathException(ctx="Not a directory!", path=path)
+
+    package_dirs = set(LocalPackageResolver.find_package_dirs(path))
+    return {PyEnvSource(dir) for dir in package_dirs} if package_dirs else None

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -48,7 +48,16 @@ class ParserChoice(Enum):
 
 @dataclass(frozen=True, eq=True, order=True)
 class CodeSource:
-    """A Python code source to be parsed for imports statements."""
+    """A Python code source to be parsed for imports statements.
+
+    .path points to the .py or .ipynb file containing Python code, alternatively
+        it points to the "<stdin>" special case which means Python code will be
+        read from standard input.
+    .base_dir is an optional directory that contains modules/packages that
+        should be considered _first_-party (i.e. _not_ third-path dependencies)
+        when imported from the code in .path. More details at
+        https://pycqa.github.io/isort/docs/configuration/options.html#src-paths
+    """
 
     path: PathOrSpecial
     base_dir: Optional[Path] = None
@@ -74,6 +83,13 @@ class DepsSource:
 
     Also include which declared dependencies parser we have chosen to use for
     this file.
+
+    .path points to the file containing dependency declarations.
+    .parser_choice selects the parser/format to be used for extracting
+        dependency declarations from .path. If this is not passed in explicitly
+        (via Settings.deps_parser_choice) it will be automatically determined
+        from looking at .path's filename (see first_applicable_parser() in
+        extract_declared_dependencies.py).
     """
 
     path: Path
@@ -87,11 +103,12 @@ class DepsSource:
 class PyEnvSource:
     """A source to be used for looking up installed Python packages.
 
-    This corresponds to the lib/pythonX.Y/site-packages directory in a
-    system-wide Python installation (under /usr, /usr/local, or similar),
-    in a virtualenv, in a poetry2nix environment, or a similar mechanism that
-    uses this layout. Alternatively, it can be a __pypackages__/X.Y/lib
-    directory within a project that uses PEP582.
+    .path points to a directory that directly contains Python packages, e.g. the
+        lib/pythonX.Y/site-packages directory in a system-wide Python
+        installation (under /usr, /usr/local, or similar), in a virtualenv, in
+        a poetry2nix environment, or a similar mechanism that uses this layout.
+        Alternatively, it can be a __pypackages__/X.Y/lib directory within a
+        project that uses PEP582.
     """
 
     path: Path

--- a/tests/sample_projects/pyenv_galore/expected.toml
+++ b/tests/sample_projects/pyenv_galore/expected.toml
@@ -11,19 +11,7 @@ description = """
 
 [experiments.default]
 description = "Run fawltydeps in an empty project with Python envs present."
-
-# TODO: Auto-detect all Python environments in this project, and use those to
-# eliminate the discovery of code/deps within those environments. For now:
-# explcitly disable code/deps, and list all Python environments in project.
-code = []
-deps = []
-pyenvs = [
-    "poetry2nix_result",
-    "__pypackages__",
-    ".venv",
-    "another-venv",
-]
-# TODO: pyenvs = [""]  # Find all Python environments inside project
+pyenvs = [""]  # Find all Python environments in project
 
 # 3rd-party imports found in the code:
 imports = []


### PR DESCRIPTION
(Depends on #325)

This is at the heart of solving #249, and IMHO one of the major pieces remaining in the Mapping Strategy milestone.

With this, FawltyDeps is able to:
- automatically find Python environments inside the project directory (`basepath`)
- automatically _disregard_ files inside the Python environment for `.code` and `.deps`

Commits:
- `traverse_project`: Add support for finding/validating Python environments
- `main`: Use `PyEnvSource` objects when resolving dependencies
- Update documentation related to Python environments