### PR TITLE
Various cleanups after integrating Python environments into `traverse_project`

### DIFF
--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -141,8 +141,8 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
             setup_resolvers(
                 custom_mapping_files=self.settings.custom_mapping_file,
                 custom_mapping=self.settings.custom_mapping,
-                pyenv_paths={
-                    src.path for src in self.sources if isinstance(src, PyEnvSource)
+                pyenv_srcs={
+                    src for src in self.sources if isinstance(src, PyEnvSource)
                 },
                 install_deps=self.settings.install_deps,
             ),

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -22,7 +22,12 @@ from pydantic.json import custom_pydantic_encoder  # pylint: disable=no-name-in-
 from fawltydeps import extract_declared_dependencies, extract_imports
 from fawltydeps.check import calculate_undeclared, calculate_unused
 from fawltydeps.cli_parser import build_parser
-from fawltydeps.packages import BasePackageResolver, Package, resolve_dependencies
+from fawltydeps.packages import (
+    BasePackageResolver,
+    Package,
+    resolve_dependencies,
+    setup_resolvers,
+)
 from fawltydeps.settings import Action, OutputFormat, Settings, print_toml_config
 from fawltydeps.traverse_project import find_sources
 from fawltydeps.types import (
@@ -133,12 +138,14 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
         """The resolved mapping of dependency names to provided import names."""
         return resolve_dependencies(
             (dep.name for dep in self.declared_deps),
-            custom_mapping_files=self.settings.custom_mapping_file,
-            custom_mapping=self.settings.custom_mapping,
-            pyenv_paths={
-                src.path for src in self.sources if isinstance(src, PyEnvSource)
-            },
-            install_deps=self.settings.install_deps,
+            setup_resolvers(
+                custom_mapping_files=self.settings.custom_mapping_file,
+                custom_mapping=self.settings.custom_mapping,
+                pyenv_paths={
+                    src.path for src in self.sources if isinstance(src, PyEnvSource)
+                },
+                install_deps=self.settings.install_deps,
+            ),
         )
 
     @property

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -62,7 +62,7 @@ class Package:
     installed.
     """
 
-    package_name: str
+    package_name: str  # auto-normalized in .__post_init__()
     import_names: Set[str]
     resolved_with: Type["BasePackageResolver"]
     debug_info: PackageDebugInfo = None
@@ -78,6 +78,10 @@ class Package:
         (e.g. typing_extension).
         """
         return package_name.lower().replace("-", "_")
+
+    def __post_init__(self) -> None:
+        """Ensure Package object invariants."""
+        object.__setattr__(self, "package_name", self.normalize_name(self.package_name))
 
     def is_used(self, imported_names: Iterable[str]) -> bool:
         """Return True iff this package is among the given import names."""

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -48,7 +48,7 @@ class ParserChoice(Enum):
 
 @dataclass(frozen=True, eq=True, order=True)
 class CodeSource:
-    """A Python code source to be parsed for imports statements.
+    """A Python code source to be parsed for import statements.
 
     .path points to the .py or .ipynb file containing Python code, alternatively
         it points to the "<stdin>" special case which means Python code will be

--- a/tests/test_install_deps.py
+++ b/tests/test_install_deps.py
@@ -6,12 +6,15 @@ from fawltydeps.packages import (
     Package,
     TemporaryPipInstallResolver,
     resolve_dependencies,
+    setup_resolvers,
 )
 
 
 def test_resolve_dependencies_install_deps__via_local_cache(local_pypi):
     debug_info = "Provided by temporary `pip install`"
-    actual = resolve_dependencies(["leftpadx", "click"], install_deps=True)
+    actual = resolve_dependencies(
+        ["leftpadx", "click"], setup_resolvers(install_deps=True)
+    )
     assert actual == {
         "leftpadx": Package(
             "leftpadx", {"leftpad"}, TemporaryPipInstallResolver, debug_info
@@ -28,7 +31,9 @@ def test_resolve_dependencies_install_deps__handle_pip_install_failure(
     # For now, IdentityMapping "saves the day" and supplies a Package object.
     # Soon, this should result in an unresolved package error instead.
     caplog.set_level(logging.WARNING)
-    actual = resolve_dependencies(["does_not_exist"], install_deps=True)
+    actual = resolve_dependencies(
+        ["does_not_exist"], setup_resolvers(install_deps=True)
+    )
     assert actual == {
         "does_not_exist": Package(
             "does_not_exist", {"does_not_exist"}, IdentityMapping
@@ -43,7 +48,7 @@ def test_resolve_dependencies_install_deps__pip_install_some_packages(
     debug_info = "Provided by temporary `pip install`"
     caplog.set_level(logging.WARNING)
     actual = resolve_dependencies(
-        ["click", "does_not_exist", "leftpadx"], install_deps=True
+        ["click", "does_not_exist", "leftpadx"], setup_resolvers(install_deps=True)
     )
     # pip install is able to install "leftpadx", but "package_does_not_exist"
     # falls through to IdentityMapping.

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -11,6 +11,7 @@ from fawltydeps.packages import (
     LocalPackageResolver,
     Package,
     resolve_dependencies,
+    setup_resolvers,
 )
 
 major, minor = sys.version_info[:2]
@@ -210,7 +211,9 @@ def test_local_env__multiple_pyenvs__merges_imports_for_same_package(fake_venv):
 def test_resolve_dependencies__in_empty_venv__reverts_to_id_mapping(tmp_path):
     venv.create(tmp_path, with_pip=False)
     id_mapping = IdentityMapping()
-    actual = resolve_dependencies(["pip", "setuptools"], pyenv_paths={tmp_path})
+    actual = resolve_dependencies(
+        ["pip", "setuptools"], setup_resolvers(pyenv_paths={tmp_path})
+    )
     assert actual == id_mapping.lookup_packages({"pip", "setuptools"})
 
 
@@ -223,7 +226,7 @@ def test_resolve_dependencies__in_fake_venv__returns_local_and_id_deps(fake_venv
         }
     )
     actual = resolve_dependencies(
-        ["PIP", "pandas", "empty-pkg"], pyenv_paths={venv_dir}
+        ["PIP", "pandas", "empty-pkg"], setup_resolvers(pyenv_paths={venv_dir})
     )
     assert actual == {
         "PIP": Package(
@@ -242,7 +245,8 @@ def test_resolve_dependencies__in_2_fake_venvs__returns_local_and_id_deps(fake_v
         {"some_module": {"second_import"}, "other-module": {"other_module"}}
     )
     actual = resolve_dependencies(
-        ["some_module", "pandas", "other_module"], pyenv_paths={venv_dir1, venv_dir2}
+        ["some_module", "pandas", "other_module"],
+        setup_resolvers(pyenv_paths={venv_dir1, venv_dir2}),
     )
     assert actual == {
         "some_module": Package(

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -11,6 +11,7 @@ from fawltydeps.packages import (
     Package,
     UserDefinedMapping,
     resolve_dependencies,
+    setup_resolvers,
 )
 from fawltydeps.types import UnparseablePathException, UnresolvedDependenciesError
 
@@ -274,7 +275,9 @@ def test_LocalPackageResolver_lookup_packages(
 def test_resolve_dependencies(vector, isolate_default_resolver):
     dep_names = [dd.name for dd in vector.declared_deps]
     isolate_default_resolver(default_sys_path_env_for_tests)
-    actual = ignore_package_debug_info(resolve_dependencies(dep_names))
+    actual = ignore_package_debug_info(
+        resolve_dependencies(dep_names, setup_resolvers())
+    )
     assert actual == vector.expect_resolved_deps
 
 
@@ -295,7 +298,9 @@ def test_resolve_dependencies__informs_once_when_id_mapping_is_used(
         )
     ]
     caplog.set_level(logging.INFO)
-    actual = ignore_package_debug_info(resolve_dependencies(dep_names))
+    actual = ignore_package_debug_info(
+        resolve_dependencies(dep_names, setup_resolvers())
+    )
     assert actual == expect
     assert caplog.record_tuples == expect_log
 
@@ -307,4 +312,4 @@ def test_resolve_dependencies__unresolved_dependencies__UnresolvedDependenciesEr
     dep_names = ["foo", "bar"]
 
     with pytest.raises(UnresolvedDependenciesError):
-        resolve_dependencies(dep_names)
+        resolve_dependencies(dep_names, setup_resolvers())

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -16,7 +16,7 @@ from typing import Iterator, List, Optional
 import pytest
 from pkg_resources import Requirement
 
-from fawltydeps.packages import LocalPackageResolver
+from fawltydeps.packages import LocalPackageResolver, pyenv_sources
 from fawltydeps.types import TomlData
 
 from .project_helpers import (
@@ -44,7 +44,7 @@ def verify_requirements(venv_path: Path, requirements: List[str]) -> None:
         for req in requirements
         if "python_version" not in req  # we don't know how to parse these (yet)
     }
-    resolved = LocalPackageResolver({venv_path}).lookup_packages(deps)
+    resolved = LocalPackageResolver(pyenv_sources(venv_path)).lookup_packages(deps)
     assert all(dep in resolved for dep in deps)
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -15,6 +15,7 @@ from fawltydeps.packages import (
     TemporaryPipInstallResolver,
     UserDefinedMapping,
     resolve_dependencies,
+    setup_resolvers,
 )
 
 from .utils import default_sys_path_env_for_tests, ignore_package_debug_info
@@ -189,11 +190,13 @@ def test_resolve_dependencies__generates_expected_mappings(
         TemporaryPipInstallResolver.cached_venv = cached_venv
         actual = resolve_dependencies(
             dep_names,
-            custom_mapping_files=set([custom_mapping_file])
-            if custom_mapping_file
-            else None,
-            custom_mapping=user_config_mapping,
-            install_deps=install_deps,
+            setup_resolvers(
+                custom_mapping_files=set([custom_mapping_file])
+                if custom_mapping_file
+                else None,
+                custom_mapping=user_config_mapping,
+                install_deps=install_deps,
+            ),
         )
     finally:
         TemporaryPipInstallResolver.cached_venv = None

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -86,7 +86,7 @@ def generate_expected_resolved_deps(
     ret = {}
     ret.update(
         {
-            dep: Package(Package.normalize_name(dep), imports, LocalPackageResolver)
+            dep: Package(dep, imports, LocalPackageResolver)
             for dep, imports in locally_installed_deps.items()
         }
     )
@@ -100,9 +100,7 @@ def generate_expected_resolved_deps(
     if install_deps:
         ret.update(
             {
-                dep: Package(
-                    Package.normalize_name(dep), imports, TemporaryPipInstallResolver
-                )
+                dep: Package(dep, imports, TemporaryPipInstallResolver)
                 for dep, imports in other_deps.items()
             }
         )


### PR DESCRIPTION
(Depends on #326)

Commits:
- `test_resolver`: Simplify `generate_expected_resolved_deps()` helper
- `packages`: Split `setup_resolvers()` out of `resolve_dependencies()`
- `LocalPackageResolver`: Construct from `PyEnvSource` objects
- `package`: Always normalize `Package.package_name`