### PR TITLE
Test refactoring: fake_project fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,25 +255,6 @@ def project_with_setup_and_requirements(fake_project):
 
 
 @pytest.fixture
-def project_with_setup_pyproject_and_requirements(fake_project):
-    return fake_project(
-        files_with_declared_deps={
-            "requirements.txt": ["pandas", "click"],
-            "subdir/requirements.txt": ["pandas", "tensorflow>=2"],
-            "setup.py": (
-                ["pandas", "click>=1.2"],  # install_requires
-                {"annoy": ["annoy==1.15.2"], "chinese": ["jieba"]},  # extras_require
-            ),
-            "pyproject.toml": (
-                ["pandas", "pydantic>1.10.4"],  # dependencies
-                {"dev": ["pylint >= 2.15.8"]},  # optional-dependencies
-            ),
-        },
-        files_with_imports={"python_file.py": ["django"]},
-    )
-
-
-@pytest.fixture
 def project_with_pyproject(fake_project):
     return fake_project(
         files_with_declared_deps={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,19 +255,6 @@ def project_with_setup_and_requirements(fake_project):
 
 
 @pytest.fixture
-def project_with_pyproject(fake_project):
-    return fake_project(
-        files_with_declared_deps={
-            "pyproject.toml": (
-                ["pandas", "pydantic>1.10.4"],  # dependencies
-                {"dev": ["pylint >= 2.15.8"]},  # optional-dependencies
-            ),
-        },
-        files_with_imports={"python_file.py": ["django"]},
-    )
-
-
-@pytest.fixture
 def project_with_setup_cfg(fake_project):
     return fake_project(
         files_with_declared_deps={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,14 +293,6 @@ def project_with_multiple_python_files(fake_project):
 
 
 @pytest.fixture
-def project_with_code_and_requirements_txt(fake_project):
-    def _inner(*, imports: List[str], declares: List[str]):
-        return fake_project(imports=imports, declared_deps=declares)
-
-    return _inner
-
-
-@pytest.fixture
 def setup_fawltydeps_config(write_tmp_files):
     """Write a custom tmp_path/pyproject.toml with a [tool.fawltydeps] section.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,19 +240,6 @@ def fake_project(write_tmp_files, fake_venv):
 
 
 @pytest.fixture
-def project_with_requirements(fake_project):
-    return fake_project(
-        files_with_declared_deps={
-            "requirements.txt": ["pandas", "click"],
-            "subdir/requirements.txt": ["pandas", "tensorflow>=2"],
-            # This file should be ignored:
-            ".venv/requirements.txt": ["foo_package", "bar_package"],
-        },
-        files_with_imports={"python_file.py": ["django"]},
-    )
-
-
-@pytest.fixture
 def project_with_setup_and_requirements(fake_project):
     return fake_project(
         files_with_declared_deps={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,24 +255,6 @@ def project_with_setup_and_requirements(fake_project):
 
 
 @pytest.fixture
-def project_with_setup_cfg(fake_project):
-    return fake_project(
-        files_with_declared_deps={
-            "setup.cfg": ["pandas", "django"],  # install_requires
-        },
-        extra_file_contents={
-            "setup.py": """\
-                import setuptools
-
-                if __name__ == "__main__":
-                    setuptools.setup()
-                """,
-        },
-        files_with_imports={"python_file.py": ["django"]},
-    )
-
-
-@pytest.fixture
 def project_with_setup_with_cfg_pyproject_and_requirements(fake_project):
     return fake_project(
         files_with_declared_deps={

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -271,12 +271,10 @@ def test_list_imports__pick_multiple_files_dir_and_code__prints_all_imports(
     assert returncode == 0
 
 
-def test_list_deps_detailed__dir__prints_deps_from_requirements_txt(
-    project_with_code_and_requirements_txt,
-):
-    tmp_path = project_with_code_and_requirements_txt(
+def test_list_deps_detailed__dir__prints_deps_from_requirements_txt(fake_project):
+    tmp_path = fake_project(
         imports=["requests", "pandas"],
-        declares=["requests", "pandas"],
+        declared_deps=["requests", "pandas"],
     )
 
     expect = [
@@ -290,12 +288,10 @@ def test_list_deps_detailed__dir__prints_deps_from_requirements_txt(
     assert returncode == 0
 
 
-def test_list_deps_json__dir__prints_deps_from_requirements_txt(
-    project_with_code_and_requirements_txt,
-):
-    tmp_path = project_with_code_and_requirements_txt(
+def test_list_deps_json__dir__prints_deps_from_requirements_txt(fake_project):
+    tmp_path = fake_project(
         imports=["requests", "pandas"],
-        declares=["requests", "pandas"],
+        declared_deps=["requests", "pandas"],
     )
 
     expect = {
@@ -325,12 +321,10 @@ def test_list_deps_json__dir__prints_deps_from_requirements_txt(
     assert returncode == 0
 
 
-def test_list_deps_summary__dir__prints_deps_from_requirements_txt(
-    project_with_code_and_requirements_txt,
-):
-    tmp_path = project_with_code_and_requirements_txt(
+def test_list_deps_summary__dir__prints_deps_from_requirements_txt(fake_project):
+    tmp_path = fake_project(
         imports=["requests", "pandas"],
-        declares=["requests", "pandas"],
+        declared_deps=["requests", "pandas"],
     )
 
     expect = ["pandas", "requests"]
@@ -496,13 +490,10 @@ project_tests_samples = [
 @pytest.mark.parametrize(
     "vector", [pytest.param(v, id=v.id) for v in project_tests_samples]
 )
-def test_check_undeclared_and_unused(
-    vector,
-    project_with_code_and_requirements_txt,
-):
-    tmp_path = project_with_code_and_requirements_txt(
+def test_check_undeclared_and_unused(vector, fake_project):
+    tmp_path = fake_project(
         imports=vector.imports,
-        declares=vector.declares,
+        declared_deps=vector.declares,
     )
     output, errors, returncode = run_fawltydeps_subprocess(
         *[option.format(path=tmp_path) for option in vector.options]
@@ -520,11 +511,11 @@ def test_check_undeclared_and_unused(
 
 
 def test_check_json__simple_project__can_report_both_undeclared_and_unused(
-    project_with_code_and_requirements_txt,
+    fake_project,
 ):
-    tmp_path = project_with_code_and_requirements_txt(
+    tmp_path = fake_project(
         imports=["requests"],
-        declares=["pandas"],
+        declared_deps=["pandas"],
     )
 
     expect = {
@@ -572,12 +563,10 @@ def test_check_json__simple_project__can_report_both_undeclared_and_unused(
     assert returncode == 3  # --json does not affect exit code
 
 
-def test_check_undeclared__simple_project__reports_only_undeclared(
-    project_with_code_and_requirements_txt,
-):
-    tmp_path = project_with_code_and_requirements_txt(
+def test_check_undeclared__simple_project__reports_only_undeclared(fake_project):
+    tmp_path = fake_project(
         imports=["requests"],
-        declares=["pandas"],
+        declared_deps=["pandas"],
     )
 
     expect = [
@@ -596,12 +585,10 @@ def test_check_undeclared__simple_project__reports_only_undeclared(
     assert returncode == 3
 
 
-def test_check_unused__simple_project__reports_only_unused(
-    project_with_code_and_requirements_txt,
-):
-    tmp_path = project_with_code_and_requirements_txt(
+def test_check_unused__simple_project__reports_only_unused(fake_project):
+    tmp_path = fake_project(
         imports=["requests"],
-        declares=["pandas"],
+        declared_deps=["pandas"],
     )
 
     expect = [
@@ -620,12 +607,10 @@ def test_check_unused__simple_project__reports_only_unused(
     assert returncode == 4
 
 
-def test__no_action__defaults_to_check_action(
-    project_with_code_and_requirements_txt,
-):
-    tmp_path = project_with_code_and_requirements_txt(
+def test__no_action__defaults_to_check_action(fake_project):
+    tmp_path = fake_project(
         imports=["requests"],
-        declares=["pandas"],
+        declared_deps=["pandas"],
     )
 
     expect = [
@@ -644,12 +629,10 @@ def test__no_action__defaults_to_check_action(
     assert returncode == 3
 
 
-def test__no_options__defaults_to_check_action_in_current_dir(
-    project_with_code_and_requirements_txt,
-):
-    tmp_path = project_with_code_and_requirements_txt(
+def test__no_options__defaults_to_check_action_in_current_dir(fake_project):
+    tmp_path = fake_project(
         imports=["requests"],
-        declares=["pandas"],
+        declared_deps=["pandas"],
     )
 
     expect = [
@@ -668,12 +651,10 @@ def test__no_options__defaults_to_check_action_in_current_dir(
     assert returncode == 3
 
 
-def test_check__summary__writes_only_names_of_unused_and_undeclared(
-    project_with_code_and_requirements_txt,
-):
-    tmp_path = project_with_code_and_requirements_txt(
+def test_check__summary__writes_only_names_of_unused_and_undeclared(fake_project):
+    tmp_path = fake_project(
         imports=["requests"],
-        declares=["pandas"],
+        declared_deps=["pandas"],
     )
 
     expect = [
@@ -691,18 +672,21 @@ def test_check__summary__writes_only_names_of_unused_and_undeclared(
 
 
 def test_check_detailed__simple_project_in_fake_venv__resolves_imports_vs_deps(
-    fake_venv, project_with_code_and_requirements_txt
+    fake_project,
 ):
-    tmp_path = project_with_code_and_requirements_txt(
+    tmp_path = fake_project(
         imports=["requests"],
-        declares=["pandas"],
+        declared_deps=["pandas"],
+        # A venv where the "pandas" package provides a "requests" import name
+        # should satisfy our comparison
+        fake_venvs={".venv": {"pandas": {"requests"}}},
     )
-    # A venv where the "pandas" package provides a "requests" import name
-    # should satisfy our comparison
-    venv_dir, _ = fake_venv({"pandas": {"requests"}})
 
     output, returncode = run_fawltydeps_function(
-        "--detailed", f"--code={tmp_path}", f"--deps={tmp_path}", f"--pyenv={venv_dir}"
+        "--detailed",
+        f"--code={tmp_path}",
+        f"--deps={tmp_path}",
+        f"--pyenv={tmp_path}/.venv",
     )
     assert output.splitlines() == [
         Analysis.success_message(check_undeclared=True, check_unused=True),
@@ -711,17 +695,19 @@ def test_check_detailed__simple_project_in_fake_venv__resolves_imports_vs_deps(
 
 
 def test_check_detailed__simple_project_w_2_fake_venv__resolves_imports_vs_deps(
-    fake_venv, project_with_code_and_requirements_txt
+    fake_project,
 ):
-    tmp_path = project_with_code_and_requirements_txt(
+    tmp_path = fake_project(
         imports=["some_import", "other_import", "yet_another"],
-        declares=["something", "other"],
+        declared_deps=["something", "other"],
+        fake_venvs={
+            "venv1": {"something": {"some_import"}},
+            "venv2": {"something": {"other_import"}, "other": {"yet_another"}},
+        },
     )
-    venv_dir1, _ = fake_venv({"something": {"some_import"}})
-    venv_dir2, _ = fake_venv({"something": {"other_import"}, "other": {"yet_another"}})
 
     output, returncode = run_fawltydeps_function(
-        "--detailed", f"{tmp_path}", "--pyenv", f"{venv_dir1}", f"{venv_dir2}"
+        "--detailed", f"{tmp_path}", "--pyenv", f"{tmp_path}/venv1", f"{tmp_path}/venv2"
     )
     assert output.splitlines() == [
         Analysis.success_message(check_undeclared=True, check_unused=True),
@@ -792,15 +778,11 @@ def test_check_detailed__simple_project_w_2_fake_venv__resolves_imports_vs_deps(
     ],
 )
 def test_cmdline_on_ignored_undeclared_option(
-    args,
-    imports,
-    dependencies,
-    expected,
-    project_with_code_and_requirements_txt,
+    args, imports, dependencies, expected, fake_project
 ):
-    tmp_path = project_with_code_and_requirements_txt(
+    tmp_path = fake_project(
         imports=imports,
-        declares=dependencies,
+        declared_deps=dependencies,
     )
     output, returncode = run_fawltydeps_function(*args, basepath=tmp_path)
     assert output.splitlines() == expected
@@ -931,17 +913,13 @@ def test_cmdline_on_ignored_undeclared_option(
     ],
 )
 def test_cmdline_args_in_combination_with_config_file(
-    config,
-    args,
-    expect,
-    project_with_code_and_requirements_txt,
-    setup_fawltydeps_config,
+    config, args, expect, fake_project, setup_fawltydeps_config
 ):
     # We keep the project itself constant (one undeclared + one unused dep),
     # but we vary the FD configuration directives and command line args
-    tmp_path = project_with_code_and_requirements_txt(
+    tmp_path = fake_project(
         imports=["requests"],
-        declares=["pandas"],
+        declared_deps=["pandas"],
     )
     setup_fawltydeps_config(config)
     output, errors, returncode = run_fawltydeps_subprocess(

--- a/tests/test_configured_run.py
+++ b/tests/test_configured_run.py
@@ -64,12 +64,10 @@ configured_run_tests_samples = [
 @pytest.mark.parametrize(
     "vector", [pytest.param(v, id=v.id) for v in configured_run_tests_samples]
 )
-def test_run_with_pyproject_toml_settings(
-    vector, project_with_code_and_requirements_txt
-):
-    tmp_path = project_with_code_and_requirements_txt(
+def test_run_with_pyproject_toml_settings(vector, fake_project):
+    tmp_path = fake_project(
         imports=vector.imports,
-        declares=vector.dependencies,
+        declared_deps=vector.dependencies,
     )
     path = tmp_path / "pyproject.toml"
     path.write_text(dedent(vector.toml_contents))

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -525,14 +525,25 @@ def test_find_and_parse_sources__project_with_pyproject__returns_list(fake_proje
     assert_unordered_equivalence(actual, expect)
 
 
-def test_find_and_parse_sources__project_with_setup_cfg__returns_list(
-    project_with_setup_cfg,
-):
+def test_find_and_parse_sources__project_with_setup_cfg__returns_list(fake_project):
+    tmp_path = fake_project(
+        files_with_declared_deps={
+            "setup.cfg": ["pandas", "django"],  # install_requires
+        },
+        extra_file_contents={
+            "setup.py": """\
+                import setuptools
+
+                if __name__ == "__main__":
+                    setuptools.setup()
+                """,
+        },
+    )
     expect = [
         "pandas",
         "django",
     ]
-    settings = Settings(code=set(), deps={project_with_setup_cfg})
+    settings = Settings(code=set(), deps={tmp_path})
     deps_sources = list(find_sources(settings, {DepsSource}))
     actual = collect_dep_names(parse_sources(deps_sources))
     assert_unordered_equivalence(actual, expect)

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -466,28 +466,41 @@ def test_parse_sources__parse_only_requirements_from_subdir__returns_list(
 
 
 def test_find_and_parse_sources__project_with_pyproject_setup_and_requirements__returns_list(
-    project_with_setup_pyproject_and_requirements,
+    fake_project,
 ):
+    tmp_path = fake_project(
+        files_with_declared_deps={
+            "requirements.txt": ["pandas", "click"],
+            "subdir/requirements.txt": ["pandas", "tensorflow>=2"],
+            "setup.py": (
+                ["pandas", "click>=1.2"],  # install_requires
+                {"annoy": ["annoy==1.15.2"], "chinese": ["jieba"]},  # extras_require
+            ),
+            "pyproject.toml": (
+                ["pandas", "pydantic>1.10.4"],  # dependencies
+                {"dev": ["pylint >= 2.15.8"]},  # optional-dependencies
+            ),
+        },
+        files_with_imports={"python_file.py": ["django"]},
+    )
     expect = [
         # from requirements.txt:
         "pandas",
         "click",
+        # from subdir/requirements.txt:
+        "pandas",
+        "tensorflow",
         # from setup.py:
         "pandas",
         "click",
         "annoy",
         "jieba",
-        # from subdir/requirements.txt:
-        "pandas",
-        "tensorflow",
         # from pyproject.toml:
         "pandas",
         "pydantic",
         "pylint",
     ]
-    settings = Settings(
-        code=set(), deps={project_with_setup_pyproject_and_requirements}
-    )
+    settings = Settings(code=set(), deps={tmp_path})
     deps_sources = list(find_sources(settings, {DepsSource}))
     actual = collect_dep_names(parse_sources(deps_sources))
     assert_unordered_equivalence(actual, expect)

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -481,7 +481,6 @@ def test_find_and_parse_sources__project_with_pyproject_setup_and_requirements__
                 {"dev": ["pylint >= 2.15.8"]},  # optional-dependencies
             ),
         },
-        files_with_imports={"python_file.py": ["django"]},
     )
     expect = [
         # from requirements.txt:
@@ -506,15 +505,21 @@ def test_find_and_parse_sources__project_with_pyproject_setup_and_requirements__
     assert_unordered_equivalence(actual, expect)
 
 
-def test_find_and_parse_sources__project_with_pyproject__returns_list(
-    project_with_pyproject,
-):
+def test_find_and_parse_sources__project_with_pyproject__returns_list(fake_project):
+    tmp_path = fake_project(
+        files_with_declared_deps={
+            "pyproject.toml": (
+                ["pandas", "pydantic>1.10.4"],  # dependencies
+                {"dev": ["pylint >= 2.15.8"]},  # optional-dependencies
+            ),
+        },
+    )
     expect = [
         "pandas",
         "pydantic",
         "pylint",
     ]
-    settings = Settings(code=set(), deps={project_with_pyproject})
+    settings = Settings(code=set(), deps={tmp_path})
     deps_sources = list(find_sources(settings, {DepsSource}))
     actual = collect_dep_names(parse_sources(deps_sources))
     assert_unordered_equivalence(actual, expect)

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -417,11 +417,17 @@ def test_parse_setup_py__multiple_entries_in_extras_require__returns_list(
     assert_unordered_equivalence(result, expected)
 
 
-def test_find_and_parse_sources__simple_project__returns_list(
-    project_with_requirements,
-):
+def test_find_and_parse_sources__simple_project__returns_list(fake_project):
     expect = ["pandas", "click", "pandas", "tensorflow"]
-    settings = Settings(code=set(), deps={project_with_requirements})
+    tmp_path = fake_project(
+        files_with_declared_deps={
+            "requirements.txt": ["pandas", "click"],
+            "subdir/requirements.txt": ["pandas", "tensorflow>=2"],
+            # This file should be ignored:
+            ".venv/requirements.txt": ["foo_package", "bar_package"],
+        },
+    )
+    settings = Settings(code=set(), deps={tmp_path})
     deps_sources = list(find_sources(settings, {DepsSource}))
     actual = collect_dep_names(parse_sources(deps_sources))
     assert_unordered_equivalence(actual, expect)


### PR DESCRIPTION
While planning the addition of a new `--list-source` command-line options, I found a need for a more general fixture to create a temporary Python project with imports, declared deps, as well as Python environments.

This PR introduces that fixture, and replaces a handful of less general fixtures with the new one.

Commits:
- `fake_venv`: Allow customization of venv location and Python version
- `conftest`: Add a generalized `fake_project()` fixture
- `tests`: Replace only use of `project_with_requirements()`
- `tests`: Replace only use of `project_with_setup_pyproject_and_requirements`
- `tests`: Replace only use of `project_with_pyproject()`
- `tests`: Replace only use of `project_with_setup_cfg()`
- `tests`: Replace `project_with_code_and_requirements_txt` with `fake_project`
