### PR TITLE
Allow isort >= 5.12 when running on Python > 3.7

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -222,6 +222,20 @@ plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
+name = "isort"
+version = "5.12.0"
+description = "A Python utility / library to sort Python imports."
+category = "main"
+optional = false
+python-versions = ">=3.8.0"
+
+[package.extras]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
+plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
+
+[[package]]
 name = "lazy-object-proxy"
 version = "1.9.0"
 description = "A fast and thorough lazy object proxy."
@@ -519,7 +533,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "7a2db64d056b62c45b5dab9bf0f8593ed0944db0ea7a824d8ec1131cad7a1e54"
+content-hash = "199cef43bf737e18bee1d606577a7e7f53a0616cc95db354ca64936a810b33f6"
 
 [metadata.files]
 argcomplete = [
@@ -595,6 +609,8 @@ iniconfig = [
 isort = [
     {file = "isort-5.11.5-py3-none-any.whl", hash = "sha256:ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746"},
     {file = "isort-5.11.5.tar.gz", hash = "sha256:6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db"},
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.9.0.tar.gz", hash = "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,11 @@ fawltydeps = "fawltydeps.main:main"
 # Do not add anything here that is only needed by CI/tests/linters/developers
 python = "^3.7.2"
 importlib_metadata = "=6.6.0"
-# isort 5.12.0 drops support for Python v3.7:
-isort = ">=5.10,<5.12.0"
+isort = [
+    # isort 5.12.0 drops support for Python v3.7:
+    {version = "^5.10", python = ">=3.8"},
+    {version = ">=5.10,<5.12.0", python = "<3.8"},
+]
 pip-requirements-parser = "^32.0.1"
 pydantic = "^1.10.4"
 tomli = {version = "^2.0.1", python = "<3.11"}
@@ -71,7 +74,11 @@ optional = true
 [tool.poetry.group.format.dependencies]
 black = "^22"
 colorama = "^0.4.6"
-isort = ">=5.10,<5.12.0"
+isort = [
+    # isort 5.12.0 drops support for Python v3.7:
+    {version = "^5.10", python = ">=3.8"},
+    {version = ">=5.10,<5.12.0", python = "<3.8"},
+]
 codespell = "^2.2.2"
 
 [tool.poetry.group.dev]


### PR DESCRIPTION
Fixes issue #334.
