### PR TITLE
Change development status to 3- Alpha

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 repository = "https://github.com/tweag/FawltyDeps"
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 3 - Alpha",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
     "Intended Audience :: Developers",


### PR DESCRIPTION
According to [wiki](https://en.wikipedia.org/wiki/Software_release_life_cycle)'s description pf stages of development . 

> The alpha phase usually ends with a [feature freeze](https://en.wikipedia.org/wiki/Freeze_(software_engineering)), indicating that no more features will be added to the software.

Before reaching the mapping milestone we will not be feature complete. In fact I am not sure open source software ever is feature complete. 

FawltyDeps fulfills other criteria for alpha version:
> In general, an alpha version or release of a software package intends to do something particular, mostly does so, yet is not guaranteed to do so fully.

In fact, when mapping milestone is complete we will fall into beta stage:
> A beta phase generally begins when the software is feature complete but likely to contain several known or unknown bugs.