### PR TITLE
ADD CLI option for --install-deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Here is a complete list of configuration directives we support:
   declared dependencies. Must be one of `"requirements.txt"`, `"setup.py"`,
   `"setup.cfg"`, `"pyproject.toml"`, or leave it unset (i.e. the default) for
   auto-detection (based on filename).
+- `install-deps`: Install Python dependencies gathered with FawltyDeps to
+  a temporary virtual environment. Dependencies will be installed from PyPI.
 - `verbosity`: An integer controlling the default log level of FawltyDeps:
   - `-2`: Only `CRITICAL`-level log messages are shown.
   - `-1`: `ERROR`-level log messages and above are shown.

--- a/README.md
+++ b/README.md
@@ -299,8 +299,9 @@ Here is a complete list of configuration directives we support:
   declared dependencies. Must be one of `"requirements.txt"`, `"setup.py"`,
   `"setup.cfg"`, `"pyproject.toml"`, or leave it unset (i.e. the default) for
   auto-detection (based on filename).
-- `install-deps`: Install Python dependencies gathered with FawltyDeps to
-  a temporary virtual environment. Dependencies will be installed from PyPI.
+- `install-deps`: Automatically install Python dependencies gathered with
+  FawltyDeps into a temporary virtual environment. This will use `pip install`,
+  which downloads packages from PyPI by default.
 - `verbosity`: An integer controlling the default log level of FawltyDeps:
   - `-2`: Only `CRITICAL`-level log messages are shown.
   - `-1`: `ERROR`-level log messages and above are shown.

--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -172,6 +172,15 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         ),
     )
     parser.add_argument(
+        "--install-deps",
+        dest="install_deps",
+        action="store_true",
+        help=(
+            "Allow FawltyDeps to `pip install` declared dependencies into a"
+            " separate temporary virtualenv to discover the imports they expose."
+        ),
+    )
+    parser.add_argument(
         "--custom-mapping-file",
         nargs="+",
         action="union",

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -910,6 +910,30 @@ def test_cmdline_on_ignored_undeclared_option(
             ).splitlines(),
             id="generate_toml_config_with_multiple_pyenvs",
         ),
+        pytest.param(
+            {},
+            ["--install-deps", "--generate-toml-config"],
+            dedent(
+                """\
+                # Copy this TOML section into your pyproject.toml to configure FawltyDeps
+                # (default values are commented)
+                [tool.fawltydeps]
+                # actions = ['check_undeclared', 'check_unused']
+                # output_format = 'human_summary'
+                # code = ['.']
+                # deps = ['.']
+                # pyenvs = ['.']
+                # ignore_undeclared = []
+                # ignore_unused = []
+                # deps_parser_choice = ...
+                install_deps = true
+                # verbosity = 0
+                # custom_mapping_file = []
+                # [tool.fawltydeps.custom_mapping]
+                """
+            ).splitlines(),
+            id="generate_toml_config_with_install_deps",
+        ),
     ],
 )
 def test_cmdline_args_in_combination_with_config_file(

--- a/tests/test_cmdline_options.py
+++ b/tests/test_cmdline_options.py
@@ -60,7 +60,7 @@ example_python_stdin = dedent(
 """
 )
 venvs = [str(project_with_no_issues / ".venv")]
-other = ["--generate-toml-file", "--version"]
+other = ["--generate-toml-config", "--version", "--install-deps"]
 
 
 # Options below contain paths specific for an input project

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -40,7 +40,6 @@ EXPECT_DEFAULTS = dict(
     code={Path(".")},
     deps={Path(".")},
     pyenvs={Path(".")},
-    custom_mapping_file=set(),
     custom_mapping=None,
     output_format=OutputFormat.HUMAN_SUMMARY,
     ignore_undeclared=set(),
@@ -48,6 +47,7 @@ EXPECT_DEFAULTS = dict(
     deps_parser_choice=None,
     install_deps=False,
     verbosity=0,
+    custom_mapping_file=set(),
 )
 
 


### PR DESCRIPTION
In this PR, `--install-deps` option is exposet to the user. It is almost the last piece of puzzle to add installing dependencies in a temporal virtual environment as a dependenceny mapping resolver.

We are left with describing it in the documentation #282 .

I tested the `--install-deps` option in CLi and if the virtual environment contains a dependency it is not installed in the temporal environment 👍  