### PR TITLE
Fix Settings.pyenvs to _actually_ use basepath by default

### DIFF
--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -342,7 +342,7 @@ def pyenv_sources(*pyenv_paths: Path) -> Set[PyEnvSource]:
     for path in pyenv_paths:
         package_dirs = set(LocalPackageResolver.find_package_dirs(path))
         if not package_dirs:
-            logger.warning(f"Could not find a Python env at {path}!")
+            logger.debug(f"Could not find a Python env at {path}!")
         ret.update(PyEnvSource(d) for d in package_dirs)
     if pyenv_paths and not ret:
         raise ValueError(f"Could not find any Python env in {pyenv_paths}!")

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -110,7 +110,7 @@ class Settings(BaseSettings):  # type: ignore
     output_format: OutputFormat = OutputFormat.HUMAN_SUMMARY
     code: Set[PathOrSpecial] = {Path(".")}
     deps: Set[Path] = {Path(".")}
-    pyenvs: Set[Path] = set()
+    pyenvs: Set[Path] = {Path(".")}
     custom_mapping: Optional[CustomMapping] = None
     ignore_undeclared: Set[str] = set()
     ignore_unused: Set[str] = set()
@@ -189,11 +189,17 @@ class Settings(BaseSettings):  # type: ignore
         if base_paths:
             code_paths = args_dict.setdefault("code", base_paths)
             deps_paths = args_dict.setdefault("deps", base_paths)
-            if code_paths != base_paths and deps_paths != base_paths:
+            pyenv_paths = args_dict.setdefault("pyenvs", base_paths)
+            if (
+                code_paths != base_paths
+                and deps_paths != base_paths
+                and pyenv_paths != base_paths
+            ):
                 msg = (
-                    "All three path specifications (code, deps, and base)"
-                    f"have been used. Use at most 2. basepaths={base_paths}, "
-                    f"code_paths={code_paths}, deps_paths={deps_paths}"
+                    "All four path specifications (code, deps, pyenvs, and base)"
+                    f"have been used. Use at most 3. basepaths={base_paths}, "
+                    f"code_paths={code_paths}, deps_paths={deps_paths}, "
+                    f"pyenv_paths={pyenv_paths}"
                 )
                 raise argparse.ArgumentError(argument=None, message=msg)
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -35,7 +35,7 @@ def make_json_settings_dict(**kwargs):
         "actions": ["check_undeclared", "check_unused"],
         "code": ["."],
         "deps": ["."],
-        "pyenvs": [],
+        "pyenvs": ["."],
         "custom_mapping": None,
         "output_format": "human_summary",
         "ignore_undeclared": [],
@@ -850,7 +850,7 @@ def test_cmdline_on_ignored_undeclared_option(
                 output_format = 'human_detailed'
                 # code = ['.']
                 deps = ['foobar']
-                # pyenvs = []
+                # pyenvs = ['.']
                 # ignore_undeclared = []
                 # ignore_unused = []
                 # deps_parser_choice = ...


### PR DESCRIPTION
This is a rather embarrasing omission from PR #326 (Teach FawltyDeps to automatically discover Python environments inside the project):

Although that PR did include code to traverse within a given `--pyenv` path to find Python environments, the PR "forgot" to actually switch the _default_ behavior of `--pyenv`:

The default value of `settings.pyenvs` remained an empty set, and there were no changes to have `basepath` influence the value of `settings.pyenvs`.

This PR fixes that:

- When neither `--pyenv` nor `basepath` is given, `settings.pyenvs` should default to the current directory.
- When `--pyenv` is not given, but `basepath` is given, `basepath` should override the default `settings.pyenvs`.
- When `--pyenv` is given, it overrides `basepath`.

In short `settings.pyenvs` should behave exactly like `.code` and `.deps`.

---

Commits:
- `test_settings`: Prepare for including `--pyenv` in `basepath`-related tests
- Fix `Settings.pyenvs` to _actually_ use `basepath` by default
