### PR TITLE
Add `--list-sources` to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ one of these can be used at a time:
 - `--check-unused`: Report only unused dependencies
 - `--list-imports`: List third-party imports extracted from the project
 - `--list-deps`: List declared dependencies extracted from the project
+- `--list-sources`: List files/directories from which imports, declared
+  dependencies and installed packages would be extracted
 
 When none of these are specified, the default action is `--check`.
 
@@ -110,6 +112,9 @@ To include both code from stdin (`import foo`) and a file path (`file.py`), use:
 ```sh
 echo "import foo" | fawltydeps --list-imports --code - file.py
 ```
+
+At any time, if you want to see where FawltyDeps is looking for Python code,
+you can use the `--list-sources --detailed` options.
 
 #### Where to find declared dependencies
 

--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -60,6 +60,16 @@ def populate_parser_actions(parser: argparse._ActionsContainer) -> None:
         help="Report only unused dependencies",
     )
     parser.add_argument(
+        "--list-sources",
+        dest="actions",
+        action="store_const",
+        const={Action.LIST_SOURCES},
+        help=(
+            "List input paths used to extract imports, declared dependencies "
+            "and find installed packages"
+        ),
+    )
+    parser.add_argument(
         "--list-imports",
         dest="actions",
         action="store_const",

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -82,7 +82,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
 
         # The following members are calculated once, on-demand, by the
         # @property @calculated_once methods below:
-        self._source: Optional[Set[Source]] = None
+        self._sources: Optional[Set[Source]] = None
         self._imports: Optional[List[ParsedImport]] = None
         self._declared_deps: Optional[List[DeclaredDependency]] = None
         self._resolved_deps: Optional[Dict[str, Package]] = None
@@ -199,6 +199,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
             frozenset: partial(sorted, key=str),
             set: partial(sorted, key=str),
             type(BasePackageResolver): lambda klass: klass.__name__,
+            type(Source): lambda klass: klass.__name__,
         }
         encoder = partial(custom_pydantic_encoder, custom_type_encoders)
         json_dict = {
@@ -206,6 +207,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
             # Using properties with an underscore do not trigger computations.
             # They are populated only if the computations were already required
             # by settings.actions.
+            "sources": self._sources,
             "imports": self._imports,
             "declared_deps": self._declared_deps,
             "resolved_deps": self._resolved_deps,

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -63,6 +63,7 @@ class OrderedEnum(Enum):
 class Action(OrderedEnum):
     """Actions provided by the FawltyDeps application."""
 
+    LIST_SOURCES = "list_sources"
     LIST_IMPORTS = "list_imports"
     LIST_DEPS = "list_deps"
     REPORT_UNDECLARED = "check_undeclared"


### PR DESCRIPTION
Make the traversal logic in FawltyDeps more visible/debuggable to the end user:
- Add the `*Source` objects to the JSON output
- Add the `--list-sources` CLI action with a human-readable version of the same

---

Commits:
- `main`: Add `Analysis.sources` to JSON output
- Add `--list-sources` CLI argument
- `main`: Reformat `print_human_readable()` to fix pylint's 'Too many branches'
