### PR TITLE
Run fawltydeps against itself in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Tests 
+name: Tests
 
 on: [workflow_call]
 
@@ -30,3 +30,5 @@ jobs:
         run: poetry run nox --no-venv --no-install --non-interactive -s tests -- -vv
       - name: Run integration tests on Python ${{ matrix.python-version }}
         run: poetry run nox --no-venv --no-install --non-interactive -s integration_tests -- -vv
+      - name: Run fawltydeps
+        run: poetry run fawltydeps --code fawltydeps/ --deps pyproject.toml --ignore-unused black codespell colorama hypothesis mypy nox pylint pytest types-setuptools

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,4 +31,4 @@ jobs:
       - name: Run integration tests on Python ${{ matrix.python-version }}
         run: poetry run nox --no-venv --no-install --non-interactive -s integration_tests -- -vv
       - name: Run fawltydeps on Python ${{ matrix.python-version }}
-        run: poetry run fawltydeps --code fawltydeps/ --deps pyproject.toml --pyenv ~/.cache/pypoetry/virtualenvs --ignore-unused black codespell colorama hypothesis mypy nox pylint pytest types-setuptools -vv
+        run: poetry run nox --no-venv --no-install --non-interactive -s self_test -- -vv

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,4 +31,4 @@ jobs:
       - name: Run integration tests on Python ${{ matrix.python-version }}
         run: poetry run nox --no-venv --no-install --non-interactive -s integration_tests -- -vv
       - name: Run fawltydeps
-        run: poetry run fawltydeps --code fawltydeps/ --deps pyproject.toml --ignore-unused black codespell colorama hypothesis mypy nox pylint pytest types-setuptools
+        run: poetry run fawltydeps --code fawltydeps/ --deps pyproject.toml --pyenv ~/.cache/pypoetry/virtualenvs --ignore-unused black codespell colorama hypothesis mypy nox pylint pytest types-setuptools

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,5 +30,5 @@ jobs:
         run: poetry run nox --no-venv --no-install --non-interactive -s tests -- -vv
       - name: Run integration tests on Python ${{ matrix.python-version }}
         run: poetry run nox --no-venv --no-install --non-interactive -s integration_tests -- -vv
-      - name: Run fawltydeps
-        run: poetry run fawltydeps --code fawltydeps/ --deps pyproject.toml --pyenv ~/.cache/pypoetry/virtualenvs --ignore-unused black codespell colorama hypothesis mypy nox pylint pytest types-setuptools
+      - name: Run fawltydeps on Python ${{ matrix.python-version }}
+        run: poetry run fawltydeps --code fawltydeps/ --deps pyproject.toml --pyenv ~/.cache/pypoetry/virtualenvs --ignore-unused black codespell colorama hypothesis mypy nox pylint pytest types-setuptools -vv

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 import hashlib
+import sys
 from pathlib import Path
 from typing import Iterable
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,7 +84,8 @@ def integration_tests(session):
 @nox.session(python=python_versions)
 def self_test(session):
     install_groups(session)
-    venv_path = session.run("poetry", "env", "info", "--path", silent=True).strip()
+    # For --pyenv, use Nox's virtualenv, or fall back to current virtualenv
+    venv_path = getattr(session.virtualenv, "location", sys.prefix)
     session.run("fawltydeps", f"--pyenv={venv_path}")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -82,6 +82,13 @@ def integration_tests(session):
 
 
 @nox.session(python=python_versions)
+def self_test(session):
+    install_groups(session)
+    venv_path = session.run("poetry", "env", "info", "--path", silent=True).strip()
+    session.run("fawltydeps", f"--pyenv={venv_path}")
+
+
+@nox.session(python=python_versions)
 def lint(session):
     install_groups(session, include=["lint"])
     session.run("mypy")

--- a/poetry.lock
+++ b/poetry.lock
@@ -667,6 +667,23 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "setuptools"
+version = "68.0.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -890,4 +907,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7.2"
-content-hash = "ab919c83f7d121044f7146f185296de56e47f4106c879a1fb76912c98b36406a"
+content-hash = "e5ff0b0f1e43d2f9bd977f6454372eb60e626d612e30dc881454c56cbe9cf42d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,3 +151,20 @@ uri-ignore-words-list = "*"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.fawltydeps]
+code = ["fawltydeps"]
+deps = ["pyproject.toml"]
+ignore_unused = [
+    # Tools not meant to be imported
+    "black",
+    "codespell",
+    "hypothesis",
+    "mypy",
+    "nox",
+    "pylint",
+    "pytest",
+    # Other dependencies that enable functionality in the above tools
+    "colorama",
+    "types-setuptools",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ pip-requirements-parser = "^32.0.1"
 pydantic = "^1.10.4"
 tomli = {version = "^2.0.1", python = "<3.11"}
 typing-extensions = {version = "^4.4.0", python = "<3.8"}
+setuptools = "^68.0.0"
 
 [tool.poetry.group.nox]
 optional = true


### PR DESCRIPTION
Closed #123 

This PR adds a functionality of running fawltydeps against itself in the GitHub Actions CI.
While running fawltydeps, it reads in the python environment from `~/.cache/pypoetry/virtualenvs` and ignores format related dependencies (`black`, `codespell`, `colorama`, `hypothesis`, `mypy`, `nox`, `pylint`, `pytest`, and `types-setuptools`).

Also, this PR declares `setuptools` as a dependency since `pkg_resources` has been imported to the main code.