### PR TITLE
Make identity mapping and install-deps mutually exclusive

### DIFF
--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -474,11 +474,8 @@ def setup_resolvers(
 
     if install_deps:
         yield TemporaryPipInstallResolver()
-
-    # Identity mapping being at the end of the resolver sequence ensures that
-    # _all_ deps are matched. TODO: If we make the identity mapping optional,
-    # we must remember to properly handle/signal unresolved dependencies.
-    yield IdentityMapping()
+    else:
+        yield IdentityMapping()
 
 
 def resolve_dependencies(

--- a/tests/test_install_deps.py
+++ b/tests/test_install_deps.py
@@ -41,6 +41,22 @@ def test_resolve_dependencies_install_deps__raises_unresolved_error_on_pip_insta
     assert all(word in caplog.text for word in ["pip", "install", "does_not_exist"])
 
 
+def test_resolve_dependencies_install_deps__unresolved_error_only_warns_failing_packages(
+    caplog, local_pypi
+):
+    # When we fail to install _some_ - but not all - packages, the error message
+    # should only mention the packages that we failed to install.
+    caplog.set_level(logging.WARNING)
+    deps = {"click", "does_not_exist", "leftpadx"}
+
+    with pytest.raises(UnresolvedDependenciesError):
+        resolve_dependencies(deps, setup_resolvers(install_deps=True))
+
+    assert "Failed to install 'does_not_exist'" in caplog.text
+    assert "Failed to install 'click'" not in caplog.text
+    assert "Failed to install 'leftpadx'" not in caplog.text
+
+
 def test_resolve_dependencies_install_deps_on_mixed_packages__raises_unresolved_error(
     caplog, local_pypi
 ):

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -313,11 +313,8 @@ def test_resolve_dependencies__informs_once_when_id_mapping_is_used(
     assert caplog.record_tuples == expect_log
 
 
-@pytest.mark.skip(
-    "This test waits for making IdentityMappig optional or not used as a fallback"
-)
 def test_resolve_dependencies__unresolved_dependencies__UnresolvedDependenciesError_raised():
     dep_names = ["foo", "bar"]
 
     with pytest.raises(UnresolvedDependenciesError):
-        resolve_dependencies(dep_names, setup_resolvers())
+        resolve_dependencies(dep_names, setup_resolvers(install_deps=True))


### PR DESCRIPTION
This PR constitutes the last missing piece of the mapping puzzle.

Identity mapping is suppressed if and only if install-deps is chosen.
Prior to this PR, any dependencies unresolved by `pip install` were passed to identity mapping. It was practically impossible to have any unresolved dependencies and therefore to have the `UnresolvedDependencyError` raised. This error is now raised in the only case where the `TemporaryPipResolver` fails to install a given dependency. In all other cases, identity mapping still resolves any dependencies left unresolved by prior resolvers in the stack.

Closes #299