### PR TITLE
Relax regex re. recognizing requirements.txt

### DIFF
--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -367,7 +367,7 @@ PARSER_CHOICES = {
         lambda path: path.name == "pyproject.toml", parse_pyproject_toml
     ),
     ParserChoice.REQUIREMENTS_TXT: ParsingStrategy(
-        lambda path: re.compile(r".*\brequirements\b.*\.(txt|in)").match(path.name)
+        lambda path: re.compile(r".*requirements.*\.(txt|in)").match(path.name)
         is not None,
         parse_requirements_txt,
     ),


### PR DESCRIPTION
Zhihan found that the plotly project has some requirements files that
are not recognized by FawltyDeps, with names like `requirements_abc.txt`.

Using the underscore as a separator in the filename does not match our
regex, which requires a word boundary (`"\b"`) around the `"requirements"`
string in the filename.

Fix our regex: There is no reason why the underscore separator should
disqualify this as a requirements file, and simplifying the regex to
`".*requirements.*\.(txt|in)"` is unlikely to introduce false positives
(files that should _not_ be recognized as `requirements.txt` files, but
now are).

Also add unit tests precisely for parsing filenames of dependency files
as I could not find another test case that tested exactly this.
