### PR TITLE
Handle Python code with embedded encoding declarations

### DIFF
--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -5,6 +5,7 @@ import configparser
 import logging
 import re
 import sys
+import tokenize
 from dataclasses import replace
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -111,7 +112,8 @@ def parse_setup_py(path: Path) -> Iterator[DeclaredDependency]:
             and node.value.func.id == "setup"
         )
 
-    setup_contents = ast.parse(path.read_text(), filename=str(source.path))
+    with tokenize.open(path) as setup_py:
+        setup_contents = ast.parse(setup_py.read(), filename=str(source.path))
     for node in ast.walk(setup_contents):
         tracked_vars.evaluate(node)
         if _is_setup_function_call(node):

--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -3,6 +3,7 @@
 import ast
 import json
 import logging
+import tokenize
 from pathlib import Path
 from typing import Iterable, Iterator, Optional, TextIO, Tuple, Union
 
@@ -159,9 +160,10 @@ def parse_python_file(
     """
     if not local_context:
         local_context = make_isort_config(Path("."), (path.parent,))
-    yield from parse_code(
-        path.read_text(), source=Location(path), local_context=local_context
-    )
+    with tokenize.open(path) as pyfile:
+        yield from parse_code(
+            pyfile.read(), source=Location(path), local_context=local_context
+        )
 
 
 def parse_source(

--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -4,7 +4,7 @@ import ast
 import json
 import logging
 from pathlib import Path
-from typing import Iterable, Iterator, Optional, TextIO, Tuple
+from typing import Iterable, Iterator, Optional, TextIO, Tuple, Union
 
 import isort
 
@@ -37,12 +37,22 @@ ISORT_FALLBACK_CONFIG = make_isort_config(Path("."))
 
 
 def parse_code(
-    code: str, *, source: Location, local_context: isort.Config = ISORT_FALLBACK_CONFIG
+    code: Union[str, bytes],
+    *,
+    source: Location,
+    local_context: isort.Config = ISORT_FALLBACK_CONFIG,
 ) -> Iterator[ParsedImport]:
-    """Extract import statements from a string containing Python code.
+    """Extract import statements from a (byte)string containing Python code.
 
     Generate (i.e. yield) the module names that are imported in the order
     they appear in the code.
+
+    The given code can be either a str or a bytes object. If a bytes object is
+    used, the approrpiate encoding of the source code will be auto-detected,
+    but if a str object is used, we assume that the caller has already decoded
+    the source correctly, e.g. by using the tokenize.open() helper or similar.
+    For more details about Python source file encodings, please see
+    https://docs.python.org/3/reference/lexical_analysis.html#encoding-declarations.
     """
 
     def is_external_import(name: str) -> bool:

--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -5,7 +5,7 @@ import json
 import logging
 import tokenize
 from pathlib import Path
-from typing import Iterable, Iterator, Optional, TextIO, Tuple, Union
+from typing import BinaryIO, Iterable, Iterator, Optional, Tuple, Union
 
 import isort
 
@@ -167,7 +167,7 @@ def parse_python_file(
 
 
 def parse_source(
-    src: CodeSource, stdin: Optional[TextIO] = None
+    src: CodeSource, stdin: Optional[BinaryIO] = None
 ) -> Iterator[ParsedImport]:
     """Invoke a suitable parser for the given source.
 
@@ -206,7 +206,7 @@ def parse_source(
 
 
 def parse_sources(
-    sources: Iterable[CodeSource], stdin: Optional[TextIO] = None
+    sources: Iterable[CodeSource], stdin: Optional[BinaryIO] = None
 ) -> Iterator[ParsedImport]:
     """Parse import statements from the given sources."""
     for source in sources:

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -15,7 +15,7 @@ import logging
 import sys
 from functools import partial
 from operator import attrgetter
-from typing import Dict, Iterator, List, Optional, Set, TextIO, Type
+from typing import BinaryIO, Dict, Iterator, List, Optional, Set, TextIO, Type
 
 try:  # import from Pydantic V2
     from pydantic.v1.json import custom_pydantic_encoder
@@ -78,7 +78,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
         .imports).
     """
 
-    def __init__(self, settings: Settings, stdin: Optional[TextIO] = None):
+    def __init__(self, settings: Settings, stdin: Optional[BinaryIO] = None):
         self.settings = settings
         self.stdin = stdin
         self.version = version()
@@ -167,7 +167,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
         )
 
     @classmethod
-    def create(cls, settings: Settings, stdin: Optional[TextIO] = None) -> "Analysis":
+    def create(cls, settings: Settings, stdin: Optional[BinaryIO] = None) -> "Analysis":
         """Exercise FawltyDeps' core logic according to the given settings.
 
         Perform the actions specified in 'settings.actions' and apply the other
@@ -347,7 +347,7 @@ def print_output(
 
 def main(
     cmdline_args: Optional[List[str]] = None,  # defaults to sys.argv[1:]
-    stdin: TextIO = sys.stdin,
+    stdin: BinaryIO = sys.stdin.buffer,
     stdout: TextIO = sys.stdout,
 ) -> int:
     """Command-line entry point."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,12 +24,15 @@ def local_pypi(request, monkeypatch):
 
 @pytest.fixture
 def write_tmp_files(tmp_path: Path):
-    def _inner(file_contents: Dict[str, str]) -> Path:
+    def _inner(file_contents: Dict[str, Union[str, bytes]]) -> Path:
         for filename, contents in file_contents.items():
             path = tmp_path / filename
             assert path.relative_to(tmp_path)
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(dedent(contents))
+            if isinstance(contents, bytes):
+                path.write_bytes(contents)
+            else:
+                path.write_text(dedent(contents))
         return tmp_path
 
     return _inner

--- a/tests/sample_projects/legacy_encoding/big5.py
+++ b/tests/sample_projects/legacy_encoding/big5.py
@@ -1,0 +1,8 @@
+# -*- coding: big5 -*-
+
+
+# Some Traditional Chinese characters: 一些中文字符
+def big5_f():
+    """用於測試的函數"""
+    # 註釋
+    return 0

--- a/tests/sample_projects/legacy_encoding/expected.toml
+++ b/tests/sample_projects/legacy_encoding/expected.toml
@@ -1,0 +1,22 @@
+[project]
+# General information about a simplified project: Its name, why we test it,
+# its relation to real world projects
+name = "legacy_encoding"
+description = "Python source in an encoding incompatible with UTF-8."
+
+[experiments.default]
+description = "Run fawltydeps with no options on entire project"
+requirements = []  # rely on identity mapping
+
+# No 3rd-party imports found in the code:
+imports = []
+
+# No declared dependencies found in the project configuration:
+declared_deps = []
+
+# Import names in the code that do not have a matching dependency declared:
+undeclared_deps = []
+
+# Declared dependencies which were never `import`ed from the code:
+# "black" and "tox" will be ignored since they are in the default_ignored_unused list
+unused_deps = []

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -23,6 +23,7 @@ from fawltydeps.types import Location, UnusedDependency
 from .test_extract_imports_simple import generate_notebook
 from .utils import (
     assert_unordered_equivalence,
+    dedent_bytes,
     run_fawltydeps_function,
     run_fawltydeps_subprocess,
 )
@@ -278,6 +279,25 @@ def test_list_imports__pick_multiple_files_dir_and_code__prints_all_imports(
         "--list-imports", "--code", "-", f"{path_code2}", to_stdin=code
     )
     expect = ["django", "requests", "foo", "numpy"]
+    assert_unordered_equivalence(output.splitlines()[:-2], expect)
+    assert returncode == 0
+
+
+def test_list_imports__stdin_with_legacy_encoding__prints_all_imports():
+    code = dedent_bytes(
+        b"""\
+        # -*- coding: big5 -*-
+
+        # Some Traditional Chinese characters:
+        chars = "\xa4@\xa8\xc7\xa4\xa4\xa4\xe5\xa6r\xb2\xc5"
+
+        import numpy
+        """
+    )
+    output, returncode = run_fawltydeps_function(
+        "--list-imports", "--code", "-", to_stdin=code
+    )
+    expect = ["numpy"]
     assert_unordered_equivalence(output.splitlines()[:-2], expect)
     assert returncode == 0
 

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -14,7 +14,12 @@ from fawltydeps.settings import Settings
 from fawltydeps.traverse_project import find_sources
 from fawltydeps.types import DepsSource
 
-from .utils import assert_unordered_equivalence, collect_dep_names, deps_factory
+from .utils import (
+    assert_unordered_equivalence,
+    collect_dep_names,
+    dedent_bytes,
+    deps_factory,
+)
 
 
 @pytest.mark.parametrize(
@@ -280,6 +285,21 @@ def test_parse_requirements_txt(write_tmp_files, file_content, expect_deps):
             """,
             ["pandas", "click", "annoy", "foobar"],
             id="nested_variable_reference__succeeds",
+        ),
+        pytest.param(
+            dedent_bytes(
+                b"""\
+                # -*- coding: big5 -*-
+                from setuptools import setup
+
+                setup(
+                    name="\xa4@\xa8\xc7\xa4\xa4\xa4\xe5\xa6r\xb2\xc5",
+                    install_requires=["pandas", "click"]
+                )
+                """
+            ),
+            ["pandas", "click"],
+            id="legacy_encoding__succeeds",
         ),
     ],
 )

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -15,6 +15,8 @@ from fawltydeps.extract_imports import (
 )
 from fawltydeps.types import CodeSource, Location, ParsedImport, PathOrSpecial
 
+from .utils import dedent_bytes
+
 
 def imports_w_linenos(
     names_w_linenos: List[Tuple[str, int]],
@@ -194,6 +196,20 @@ def write_code_sources(write_tmp_files):
             ),
             [],
             id="stdlib_import_with_if_else_fallback__ignores_all",
+        ),
+        pytest.param(
+            dedent_bytes(
+                b"""\
+                # -*- coding: big5 -*-
+
+                # Some Traditional Chinese characters:
+                chars = "\xa4@\xa8\xc7\xa4\xa4\xa4\xe5\xa6r\xb2\xc5"
+
+                import numpy
+                """
+            ),
+            [("numpy", 6)],
+            id="legacy_encoding__is_correctly_interpreted",
         ),
     ],
 )

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -1,6 +1,7 @@
 """Test that we can extract simple imports from Python code."""
 import json
 import logging
+from io import BytesIO
 from pathlib import Path
 from textwrap import dedent
 from typing import Dict, List, Tuple, Union
@@ -561,3 +562,19 @@ def test_parse_sources__ignore_first_party_imports(
     ]
 
     assert list(parse_sources(code_sources)) == expect
+
+
+def test_parse_sources__legacy_encoding_on_stdin__extracts_import():
+    code = dedent_bytes(
+        b"""\
+        # -*- coding: big5 -*-
+
+        # Some Traditional Chinese characters:
+        chars = "\xa4@\xa8\xc7\xa4\xa4\xa4\xe5\xa6r\xb2\xc5"
+
+        import numpy
+        """
+    )
+
+    expect = imports_w_linenos([("numpy", 6)], "<stdin>")
+    assert list(parse_sources([CodeSource("<stdin>")], BytesIO(code))) == expect

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -241,6 +241,25 @@ def test_parse_python_file__combo_of_simple_imports__extracts_all_externals(
     assert list(parse_python_file(tmp_path / "test.py")) == expect
 
 
+def test_parse_python_file__legacy_encoding__extracts_import(tmp_path):
+    script = tmp_path / "big5.py"
+    script.write_bytes(
+        dedent_bytes(
+            b"""\
+            # -*- coding: big5 -*-
+
+            # Some Traditional Chinese characters:
+            chars = "\xa4@\xa8\xc7\xa4\xa4\xa4\xe5\xa6r\xb2\xc5"
+
+            import numpy
+            """
+        )
+    )
+
+    expect = imports_w_linenos([("numpy", 6)], script)
+    assert list(parse_python_file(script)) == expect
+
+
 def test_parse_notebook_file__simple_imports__extracts_all(tmp_path):
     code = generate_notebook([["import pandas\n", "import pytorch"]])
     script = tmp_path / "test.ipynb"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ import subprocess
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
 from fawltydeps.main import main
 from fawltydeps.packages import IdentityMapping, LocalPackageResolver, Package
@@ -129,19 +129,21 @@ def run_fawltydeps_subprocess(
 def run_fawltydeps_function(
     *args: str,
     config_file: Path = Path("/dev/null"),
-    to_stdin: Optional[str] = None,
+    to_stdin: Optional[Union[str, bytes]] = None,
     basepath: Optional[Path] = None,
 ) -> Tuple[str, int]:
     """Run FawltyDeps with `main` function. Designed for unit tests.
 
     Ignores logging output and returns stdout and the exit code
     """
+    if isinstance(to_stdin, str):
+        to_stdin = to_stdin.encode()
     output = io.StringIO()
     exit_code = main(
         cmdline_args=([str(basepath)] if basepath else [])
         + [f"--config-file={str(config_file)}"]
         + list(args),
-        stdin=io.StringIO(to_stdin),
+        stdin=io.BytesIO(to_stdin or b""),
         stdout=output,
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from textwrap import dedent
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
 
 from fawltydeps.main import main
@@ -21,6 +22,12 @@ from fawltydeps.types import (
 SAMPLE_PROJECTS_DIR = Path(__file__).with_name("sample_projects")
 
 logger = logging.getLogger(__name__)
+
+
+def dedent_bytes(data: bytes) -> bytes:
+    """Like textwrap.dedent(), but for bytes instead of str."""
+    text = data.decode(encoding="utf-8", errors="surrogateescape")
+    return dedent(text).encode(encoding="utf-8", errors="surrogateescape")
 
 
 def walk_dir(path: Path) -> Iterator[Path]:


### PR DESCRIPTION
As #374 demonstrates, FawltyDeps does not interpret/follow encoding declarations in Python source code.

These encoding declarations have been part of Python for a long time, first introduced in [PEP 263](https://peps.python.org/pep-0263/), and currently documented here: https://docs.python.org/3/reference/lexical_analysis.html#encoding-declarations

As far as I can see, these encoding declarations do not really apply to Jupyter notebooks, for the simple reason that notebooks are stored in JSON files, and JSON is specified to always be UTF-8 encdoded. Still we need to support these in three cases:
- for Python source files passed to `extract_imports.parse_python_file()`,
- for Python source code passed directly on FawltyDeps' stdin,
- for `setup.py` files parsed by `extract_declared_dependencies.py.parse_setup_py()`

For the first and last cases, we use the [`tokenize.open()` from the stdlib](https://docs.python.org/3/library/tokenize.html#tokenize.open) to automatically determine the appropriate encoding, and for the second case we use the fact that `ast.parse()` and [the underlying `compile()` built-in function](https://docs.python.org/3/library/functions.html#compile) support passing a un-decoded `bytes` object directly. This involves ensuring that we now read stdin in binary mode instead of text mode, but otherwise the changes introduced in this PR are mostly straightforward.

Commits:
- `sample_projects`: Add example use of legacy encoding
- `tests/utils`: Add `dedent_bytes()`: `textwrap.dedent()` for byte strings
- `extract_imports.parse_code()`: Accept code as `bytes` object
- `extract_imports.parse_python_file()`: Handle legacy encodings
- Handle legacy-encoded Python code passed to stdin
- `extract_declared_dependencies.parse_setup_py()`: Handle legacy encodings
