### PR TITLE
Separate `check-undeclared`, `check-unused` pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 -   id: check-undeclared
-    name: FawltyDeps
+    name: FawltyDeps-undeclared
     description: "FawltyDeps: Check for undeclared dependencies"
     entry: fawltydeps --check-undeclared
     language: python
@@ -8,8 +8,8 @@
       - --code
     pass_filenames: true
 -   id: check-unused
-    name: FawltyDeps
-    description: "FawltyDeps: Check for undeclared dependencies"
+    name: FawltyDeps-unused
+    description: "FawltyDeps: Check for unused dependencies"
     entry: fawltydeps --check-unused
     language: python
     files: ".*\\.py|ipynb"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,14 +3,13 @@
     description: "FawltyDeps: Check for undeclared dependencies"
     entry: fawltydeps --check-undeclared
     language: python
-    files: ".*\\.py|ipynb"
-    args:
-      - --code
-    pass_filenames: true
+    args: [--code]
+    types_or: [python, jupyter]
+
 -   id: check-unused
     name: FawltyDeps-unused
     description: "FawltyDeps: Check for unused dependencies"
     entry: fawltydeps --check-unused
     language: python
-    files: ".*\\.py|ipynb"
-    pass_filenames: false
+    args: [--deps]
+    files: "(.*requirements.*\\.(txt|in)|pyproject\\.toml|setup\\.(py|cfg))"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 -   id: check-undeclared
     name: FawltyDeps-undeclared
     description: "FawltyDeps: Check for undeclared dependencies"
-    entry: fawltydeps --check-undeclared
+    entry: fawltydeps --check-undeclared --detailed
     language: python
     args: [--code]
     types_or: [python, jupyter]
@@ -9,7 +9,7 @@
 -   id: check-unused
     name: FawltyDeps-unused
     description: "FawltyDeps: Check for unused dependencies"
-    entry: fawltydeps --check-unused
+    entry: fawltydeps --check-unused --detailed
     language: python
     args: [--deps]
     files: "(.*requirements.*\\.(txt|in)|pyproject\\.toml|setup\\.(py|cfg))"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,16 @@
--   id: check
+-   id: check-undeclared
     name: FawltyDeps
-    description: Python dependency checker
-    entry: fawltydeps
+    description: "FawltyDeps: Check for undeclared dependencies"
+    entry: fawltydeps --check-undeclared
     language: python
+    files: ".*\\.py|ipynb"
+    args:
+      - --code
+    pass_filenames: true
+-   id: check-unused
+    name: FawltyDeps
+    description: "FawltyDeps: Check for undeclared dependencies"
+    entry: fawltydeps --check-unused
+    language: python
+    files: ".*\\.py|ipynb"
     pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -600,9 +600,8 @@ tool, you can add something like this to your project's
 ```yaml
 repos:
   - repo: https://github.com/tweag/FawltyDeps
-    rev: v0.13.2
+    rev: v0.13.3
     hooks:
-      - id: check
-        args:
-          - --detailed
+      - id: check-undeclared
+      - id: check-unused
 ```


### PR DESCRIPTION
The `check-undeclared` hook runs only on files being committed.

Fixes: GH-385

With https://github.com/msabramo/fawltydeps-demo1/blob/GH-385-fix-my-fork/.pre-commit-config.yaml, I get this output:

```
$ cat .pre-commit-config.yaml
repos:
  - repo: https://github.com/msabramo/FawltyDeps
    rev: 4bca742
    hooks:
      - id: check-undeclared
        args:
          - --detailed
          - --code     # --code always has to be last argument, because it must precede list of files
      - id: check-unused
        args:
          - --detailed

$ cat main.py
import requests
import pandas


$ cat another.py
import sqlite


$ cat requirements.txt
requests
pyramid

$ git status
On branch GH-385-fix-my-fork
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	new file:   main.py

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	another.py



$ git commit
FawltyDeps...............................................................Failed
- hook id: check-undeclared
- exit code: 3

These imports appear to be undeclared dependencies:
- 'pandas' imported at:
    main.py:2

FawltyDeps...............................................................Failed
- hook id: check-unused
- exit code: 4

These dependencies appear to be unused (i.e. not imported):
- 'pyramid' declared in:
    requirements.txt
```