### PR TITLE
Preliminary refactoring before `--ignore` feature

### DIFF
--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -1,0 +1,157 @@
+"""Utilities for traversing directory structures."""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Generic, Iterator, List, NamedTuple, Set, Tuple, TypeVar
+
+from fawltydeps.utils import dirs_between
+
+T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+
+
+class DirId(NamedTuple):
+    """Unique ID for a directory, independent of name/links.
+
+    We use device/inode details from stat() to uniquely identify a directory
+    on the current host. This allows us to detect e.g. when we're about to
+    traverse the same directory for the second time.
+    """
+
+    dev: int
+    ino: int
+
+    @classmethod
+    @lru_cache()  # Cache stat() calls
+    def from_path(cls, path: Path) -> "DirId":
+        """Construct DirId from given directory path."""
+        dir_stat = path.stat()
+        return cls(dir_stat.st_dev, dir_stat.st_ino)
+
+
+@dataclass
+class DirectoryTraversal(Generic[T]):
+    """Encapsulate the efficient traversal of a directory structure.
+
+    In short, this is os.walk() on steroids.
+
+    We want to:
+    1. Visit a number of (possibly overlapping/nested) directories. We want to
+       visit them exactly _once_. We also want to properly handle symlinks to
+       directories, including being resistant to infinite traversal loops caused
+       by recursive symlinks.
+    2. Have data attached to selected directories, and have these pieces of data
+       compose as we traverse the directory structure. For example, if we attach
+       FOO to directory /some/dir, and attach BAR to directory /some/dir/subdir,
+       then we want both FOO and BAR to be available while we traverse
+       /some/dir/subdir and below. To attach multiple pieces of data to a
+       single directory, pass all pieces (in order) to .add().
+    3. Allow the traversal to adjust itself while in progress. For example,
+       while traversing /some/dir we want to be able "ignore" a directory
+       (including /some/dir or any parent) from (further) traversal. Likewise,
+       we should be able to _add_ more directories to the traversal. (For a
+       given traversal, re-adding a directory that was already traversed shall
+       have no effect, if you want to re-traverse then setup a _new_ traversal.)
+
+    Note that we _do_ assume that the directory structures being traversed
+    remain unchanged during traversal. I.e. adding new entries to a directory
+    that has otherwise already been traversed will not cause it to traversed
+    again.
+    """
+
+    to_traverse: Set[Path] = field(default_factory=set)
+    to_ignore: Set[DirId] = field(default_factory=set)  # includes already-traversed
+    attached: Dict[DirId, List[T]] = field(default_factory=dict)
+
+    def add(self, dir_path: Path, *attach_data: T) -> None:
+        """Add one directory to this traversal, optionally w/attached data.
+
+        - Any attached data will be supplied to the given directory and its
+          subdirectories when it is being .traverse()d.
+        - Multiple data items may be attached simply by passing them (in order)
+          as additional arguments to this method. A directory can also be added
+          multiple times with different attached data; all the attached data
+          will be supplied (in the order it was added) by .traverse().
+        - A parent directory and a child directory may both be added with
+          different data attached. The child directory will be supplied both the
+          parent's data (first) and its own data (last) by .traverse().
+        - No matter how many times a directory is added, it will still only be
+          traversed _once_. If a directory has already been traversed by this
+          instance, it will _not_ be re-traversed.
+        """
+        if not dir_path.is_dir():
+            raise NotADirectoryError(dir_path)
+        dir_id = DirId.from_path(dir_path)
+        self.to_traverse.add(dir_path)
+        self.attached.setdefault(dir_id, []).extend(attach_data)
+
+    def ignore(self, dir_path: Path) -> None:
+        """Ignore a directory in future traversal.
+
+        The given directory or its subdirectories will _not_ be traversed
+        (although explicitly .add()ed subdirectories _will_ be traversed).
+        """
+        self.to_ignore.add(DirId.from_path(dir_path))
+
+    def traverse(self) -> Iterator[Tuple[Path, Set[Path], Set[Path], List[T]]]:
+        """Perform the traversal of the added directories.
+
+        For each directory traverse, yield a 4-element tuple consisting of:
+        - The path to the current directory being traversed.
+        - The set of all (immediate) subdirectories in the current directory.
+          This is NOT a mutable list, as you might expect from os.walk();
+          instead, to prevent traversing into a subdirectory, you can call
+          .ignore() with the relevant subdirectory.
+        - The set of all files in the current directory.
+        - An ordered list of attached data items, for each of the directory
+          levels starting at the base directory (the top-most parent directory
+          passed to .add()), up to and including the current directory.
+
+        Directories that have already been .ignore()d will not be traversed, nor
+        will a directory previously traversed by this instance be re-traversed.
+        """
+
+        def accumulate_attached_data(parent_dir: Path, child_dir: Path) -> Iterator[T]:
+            """Yield attached data items for child_dir (starting from parent_dir).
+
+            For each directory level from parent_dir to child_dir (inclusive),
+            yield each attached data item in the order they were attached.
+            """
+            for dir_path in reversed(list(dirs_between(parent_dir, child_dir))):
+                for data in self.attached.get(DirId.from_path(dir_path), []):
+                    yield data
+
+        while True:
+            remaining = sorted(
+                path
+                for path in self.to_traverse
+                if DirId.from_path(path) not in self.to_ignore
+            )
+            if not remaining:  # nothing left to do
+                break
+            logger.debug(f"Left to traverse: {remaining}")
+            base_dir = remaining[0]
+            assert base_dir.is_dir()  # sanity check
+            for cur, subdirs, filenames in os.walk(base_dir, followlinks=True):
+                cur_dir = Path(cur)
+                cur_id = DirId.from_path(cur_dir)
+                if cur_id in self.to_ignore:
+                    logger.debug(f"  Ignoring {cur_dir}")
+                    subdirs[:] = []  # don't recurse into subdirs
+                    continue  # skip to next
+
+                logger.debug(f"  Traversing {cur_dir}")
+                self.to_ignore.add(cur_id)  # don't re-traverse this dir
+                # At this yield, the caller takes over control, and may modify
+                # .to_traverse/.to_ignore/.attached (typically via .add() or
+                # .ignore()). We cannot assume anything about their state here.
+                yield (
+                    cur_dir,
+                    {cur_dir / subdir for subdir in subdirs},
+                    {cur_dir / filename for filename in filenames},
+                    list(accumulate_attached_data(base_dir, cur_dir)),
+                )

--- a/fawltydeps/traverse_project.py
+++ b/fawltydeps/traverse_project.py
@@ -63,8 +63,8 @@ def find_sources(  # pylint: disable=too-many-branches,too-many-statements
         else:  # must traverse directory
             # sanity check: convince mypy that SpecialPath is already handled
             assert isinstance(path_or_special, Path)
-            traversal.add(path_or_special, CodeSource)
-            traversal.add(path_or_special, path_or_special)  # also record base dir
+            # record also base dir for later
+            traversal.add(path_or_special, CodeSource, path_or_special)
 
     for path in settings.deps if DepsSource in source_types else []:
         # exceptions raised by validate_deps_source() are propagated here

--- a/fawltydeps/traverse_project.py
+++ b/fawltydeps/traverse_project.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 from typing import AbstractSet, Iterator, Optional, Set, Type, Union
 
+from fawltydeps.dir_traversal import DirectoryTraversal
 from fawltydeps.extract_declared_dependencies import validate_deps_source
 from fawltydeps.extract_imports import validate_code_source
 from fawltydeps.packages import validate_pyenv_source
@@ -14,7 +15,6 @@ from fawltydeps.types import (
     Source,
     UnparseablePathException,
 )
-from fawltydeps.utils import DirectoryTraversal
 
 logger = logging.getLogger(__name__)
 

--- a/fawltydeps/traverse_project.py
+++ b/fawltydeps/traverse_project.py
@@ -83,14 +83,14 @@ def find_sources(  # pylint: disable=too-many-branches,too-many-statements
         if package_dirs is not None:  # Python environment dir given directly
             logger.debug(f"find_sources() Found {package_dirs}")
             yield from package_dirs
-            traversal.ignore(path)  # disable traversal of path below
+            traversal.skip_dir(path)  # disable traversal of path below
         else:  # must traverse directory to find Python environments
             traversal.add(path, PyEnvSource)
 
     for _cur_dir, subdirs, files, extras in traversal.traverse():
         for subdir in subdirs:  # don't recurse into dot dirs
             if subdir.name.startswith("."):
-                traversal.ignore(subdir)
+                traversal.skip_dir(subdir)
 
         types = {t for t in extras if t in source_types}
         assert len(types) > 0
@@ -99,7 +99,7 @@ def find_sources(  # pylint: disable=too-many-branches,too-many-statements
                 package_dirs = validate_pyenv_source(path)
                 if package_dirs is not None:  # pyenvs found here
                     yield from package_dirs
-                    traversal.ignore(path)  # don't recurse into Python environment
+                    traversal.skip_dir(path)  # don't recurse into Python environment
         if CodeSource in types:
             # Retrieve base_dir from closest ancestor, i.e. last Path in extras
             base_dir = next((x for x in reversed(extras) if isinstance(x, Path)), None)

--- a/fawltydeps/utils.py
+++ b/fawltydeps/utils.py
@@ -1,23 +1,10 @@
 """Common utilities"""
 
 import logging
-import os
-from dataclasses import dataclass, field, is_dataclass
-from functools import lru_cache, wraps
+from dataclasses import is_dataclass
+from functools import wraps
 from pathlib import Path
-from typing import (
-    Callable,
-    Dict,
-    Generic,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    TypeVar,
-    no_type_check,
-)
+from typing import Callable, Iterator, Optional, TypeVar, no_type_check
 
 import importlib_metadata
 
@@ -43,149 +30,6 @@ def dirs_between(parent: Path, child: Path) -> Iterator[Path]:
     yield child
     if child != parent:
         yield from dirs_between(parent, child.parent)
-
-
-class DirId(NamedTuple):
-    """Unique ID for a directory, independent of name/links.
-
-    We use device/inode details from stat() to uniquely identify a directory
-    on the current host. This allows us to detect e.g. when we're about to
-    traverse the same directory for the second time.
-    """
-
-    dev: int
-    ino: int
-
-    @classmethod
-    @lru_cache()  # Cache stat() calls
-    def from_path(cls, path: Path) -> "DirId":
-        """Construct DirId from given directory path."""
-        dir_stat = path.stat()
-        return cls(dir_stat.st_dev, dir_stat.st_ino)
-
-
-@dataclass
-class DirectoryTraversal(Generic[T]):
-    """Encapsulate the efficient traversal of a directory structure.
-
-    In short, this is os.walk() on steroids.
-
-    We want to:
-    1. Visit a number of (possibly overlapping/nested) directories. We want to
-       visit them exactly _once_. We also want to properly handle symlinks to
-       directories, including being resistant to infinite traversal loops caused
-       by recursive symlinks.
-    2. Have data attached to selected directories, and have these pieces of data
-       compose as we traverse the directory structure. For example, if we attach
-       FOO to directory /some/dir, and attach BAR to directory /some/dir/subdir,
-       then we want both FOO and BAR to be available while we traverse
-       /some/dir/subdir and below. To attach multiple pieces of data to a
-       single directory, pass all pieces (in order) to .add().
-    3. Allow the traversal to adjust itself while in progress. For example,
-       while traversing /some/dir we want to be able "ignore" a directory
-       (including /some/dir or any parent) from (further) traversal. Likewise,
-       we should be able to _add_ more directories to the traversal. (For a
-       given traversal, re-adding a directory that was already traversed shall
-       have no effect, if you want to re-traverse then setup a _new_ traversal.)
-
-    Note that we _do_ assume that the directory structures being traversed
-    remain unchanged during traversal. I.e. adding new entries to a directory
-    that has otherwise already been traversed will not cause it to traversed
-    again.
-    """
-
-    to_traverse: Set[Path] = field(default_factory=set)
-    to_ignore: Set[DirId] = field(default_factory=set)  # includes already-traversed
-    attached: Dict[DirId, List[T]] = field(default_factory=dict)
-
-    def add(self, dir_path: Path, *attach_data: T) -> None:
-        """Add one directory to this traversal, optionally w/attached data.
-
-        - Any attached data will be supplied to the given directory and its
-          subdirectories when it is being .traverse()d.
-        - Multiple data items may be attached simply by passing them (in order)
-          as additional arguments to this method. A directory can also be added
-          multiple times with different attached data; all the attached data
-          will be supplied (in the order it was added) by .traverse().
-        - A parent directory and a child directory may both be added with
-          different data attached. The child directory will be supplied both the
-          parent's data (first) and its own data (last) by .traverse().
-        - No matter how many times a directory is added, it will still only be
-          traversed _once_. If a directory has already been traversed by this
-          instance, it will _not_ be re-traversed.
-        """
-        if not dir_path.is_dir():
-            raise NotADirectoryError(dir_path)
-        dir_id = DirId.from_path(dir_path)
-        self.to_traverse.add(dir_path)
-        self.attached.setdefault(dir_id, []).extend(attach_data)
-
-    def ignore(self, dir_path: Path) -> None:
-        """Ignore a directory in future traversal.
-
-        The given directory or its subdirectories will _not_ be traversed
-        (although explicitly .add()ed subdirectories _will_ be traversed).
-        """
-        self.to_ignore.add(DirId.from_path(dir_path))
-
-    def traverse(self) -> Iterator[Tuple[Path, Set[Path], Set[Path], List[T]]]:
-        """Perform the traversal of the added directories.
-
-        For each directory traverse, yield a 4-element tuple consisting of:
-        - The path to the current directory being traversed.
-        - The set of all (immediate) subdirectories in the current directory.
-          This is NOT a mutable list, as you might expect from os.walk();
-          instead, to prevent traversing into a subdirectory, you can call
-          .ignore() with the relevant subdirectory.
-        - The set of all files in the current directory.
-        - An ordered list of attached data items, for each of the directory
-          levels starting at the base directory (the top-most parent directory
-          passed to .add()), up to and including the current directory.
-
-        Directories that have already been .ignore()d will not be traversed, nor
-        will a directory previously traversed by this instance be re-traversed.
-        """
-
-        def accumulate_attached_data(parent_dir: Path, child_dir: Path) -> Iterator[T]:
-            """Yield attached data items for child_dir (starting from parent_dir).
-
-            For each directory level from parent_dir to child_dir (inclusive),
-            yield each attached data item in the order they were attached.
-            """
-            for dir_path in reversed(list(dirs_between(parent_dir, child_dir))):
-                for data in self.attached.get(DirId.from_path(dir_path), []):
-                    yield data
-
-        while True:
-            remaining = sorted(
-                path
-                for path in self.to_traverse
-                if DirId.from_path(path) not in self.to_ignore
-            )
-            if not remaining:  # nothing left to do
-                break
-            logger.debug(f"Left to traverse: {remaining}")
-            base_dir = remaining[0]
-            assert base_dir.is_dir()  # sanity check
-            for cur, subdirs, filenames in os.walk(base_dir, followlinks=True):
-                cur_dir = Path(cur)
-                cur_id = DirId.from_path(cur_dir)
-                if cur_id in self.to_ignore:
-                    logger.debug(f"  Ignoring {cur_dir}")
-                    subdirs[:] = []  # don't recurse into subdirs
-                    continue  # skip to next
-
-                logger.debug(f"  Traversing {cur_dir}")
-                self.to_ignore.add(cur_id)  # don't re-traverse this dir
-                # At this yield, the caller takes over control, and may modify
-                # .to_traverse/.to_ignore/.attached (typically via .add() or
-                # .ignore()). We cannot assume anything about their state here.
-                yield (
-                    cur_dir,
-                    {cur_dir / subdir for subdir in subdirs},
-                    {cur_dir / filename for filename in filenames},
-                    list(accumulate_attached_data(base_dir, cur_dir)),
-                )
 
 
 def hide_dataclass_fields(instance: object, *field_names: str) -> None:

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -6,7 +6,7 @@ from typing import Generic, List, Optional, Set, Tuple, TypeVar
 
 import pytest
 
-from fawltydeps.utils import DirectoryTraversal
+from fawltydeps.dir_traversal import DirectoryTraversal
 
 from .utils import assert_unordered_equivalence
 

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -96,7 +96,7 @@ class DirectoryTraversalVector(Generic[T]):
     id: str
     given: List[BaseEntry]
     add: List[Tuple[str, Tuple[T, ...]]] = field(default_factory=lambda: [(".", ())])
-    ignore: List[str] = field(default_factory=list)
+    skip_dirs: List[str] = field(default_factory=list)
     expect: List[ExpectedTraverseStep] = field(default_factory=list)
     expect_alternatives: Optional[List[List[ExpectedTraverseStep]]] = None
 
@@ -141,10 +141,10 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
         ],
     ),
     DirectoryTraversalVector(
-        "add_subdir__ignore_parent_with_data__traverse_only_subdir_with_no_data",
+        "add_subdir__skip_parent_with_data__traverse_only_subdir_with_no_data",
         given=[Dir("sub")],
         add=[(".", (123,)), ("sub", ())],
-        ignore=["."],
+        skip_dirs=["."],
         expect=[ExpectedTraverseStep("sub", [], [], [])],
     ),
     DirectoryTraversalVector(
@@ -258,8 +258,8 @@ def test_DirectoryTraversal(vector: DirectoryTraversalVector, tmp_path):
     traversal: DirectoryTraversal = DirectoryTraversal()
     for path, data_items in vector.add:
         traversal.add(tmp_path / path, *data_items)
-    for path in vector.ignore:
-        traversal.ignore(tmp_path / path)
+    for path in vector.skip_dirs:
+        traversal.skip_dir(tmp_path / path)
 
     actual = [
         (cur_dir, set(subdirs), set(files), list(data))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from pprint import pformat
 from textwrap import dedent
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
@@ -43,10 +44,12 @@ def walk_dir(path: Path) -> Iterator[Path]:
             yield Path(root, filename)
 
 
-def assert_unordered_equivalence(actual: Iterable[Any], expected: Iterable[Any]):
+def assert_unordered_equivalence(actual: Iterable[Any], expect: Iterable[Any]):
     actual_s = sorted(actual)
-    expected_s = sorted(expected)
-    assert actual_s == expected_s, f"{actual_s!r} != {expected_s!r}"
+    expect_s = sorted(expect)
+    assert (
+        actual_s == expect_s
+    ), f"--- EXPECTED ---\n{pformat(expect_s)}\n--- BUT GOT ---\n{pformat(actual_s)}"
 
 
 def collect_dep_names(deps: Iterable[DeclaredDependency]) -> Iterable[str]:


### PR DESCRIPTION
Preliminary changes to clean up the code in preparation for work on supporting gitignore-style patterns for ignoring parts of the project during traversal.

Commits:
- `tests/utils.py`: Better output when `assert_unordered_equivalence` fails
- `DirectoryTraversal`: Allow attaching multiple data items in `.add()`
- Move `DirectoryTraversal` into its own module
- `dir_traversal`: Rename `.ignore()` to `.skip_dir()`
- `dir_traversal`: Refactor data on each traversal step into its own class
- `test_dir_traversal`: Make use of `ExpectedTraverseStep` self-documenting
