### PR TITLE
Integrate gitignore_parser into FawltyDeps

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,10 @@
 MIT License
 
 Copyright (c) Tweag I/O Limited.
+Some parts are:
+Copyright (c) 2018 Michael Herrmann
+Copyright (c) 2015 Steve Cook
+
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 from fawltydeps.gitignore_parser import Rule as ExcludeRule
+from fawltydeps.gitignore_parser import match_rules
 from fawltydeps.utils import dirs_between
 
 T = TypeVar("T")
@@ -150,15 +151,7 @@ class DirectoryTraversal(Generic[T]):
 
     def _do_exclude(self, path: Path, is_dir: bool) -> bool:
         """Check if given path is excluded by any of our exclude rules."""
-        abs_path = path.resolve()
-        for rule in reversed(self.exclude_rules):
-            try:
-                if rule.match(abs_path, is_dir):
-                    logger.debug(f"    exclude rule {rule!r} matches {abs_path}")
-                    return not rule.negated
-            except ValueError:  # abs_path not relative to rule.base_path
-                pass
-        return False
+        return match_rules(self.exclude_rules, path.resolve(), is_dir)
 
     def traverse(self) -> Iterator[TraversalStep[T]]:
         """Perform the traversal of the added directories.

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -71,7 +71,7 @@ class TraversalStep(Generic[T]):
 
 
 @dataclass
-class DirectoryTraversal(Generic[T]):  # type: ignore
+class DirectoryTraversal(Generic[T]):
     """Encapsulate the efficient traversal of a directory structure.
 
     In short, this is os.walk() on steroids.
@@ -105,7 +105,7 @@ class DirectoryTraversal(Generic[T]):  # type: ignore
     to_traverse: Dict[Path, DirId] = field(default_factory=dict)
     skip_dirs: Set[DirId] = field(default_factory=set)  # includes already-traversed
     attached: Dict[DirId, List[T]] = field(default_factory=dict)
-    exclude_rules: List[gitignore_parser.IgnoreRule] = field(default_factory=list)  # type: ignore
+    exclude_rules: List[gitignore_parser.Rule] = field(default_factory=list)
 
     def add(self, dir_path: Path, *attach_data: T) -> None:
         """Add one directory to this traversal, optionally w/attached data.

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -157,7 +157,7 @@ class DirectoryTraversal(Generic[T]):
         if rule.anchored and base_dir is None:
             raise ExcludeRuleError(f"Anchored pattern without base_dir in {pattern!r}")
 
-        logger.debug(f"Adding rule {rule!r} @ {rule.base_path!r}")
+        logger.debug(f"Adding rule {rule!r} @ {rule.base_dir!r}")
         self.exclude_rules.append(rule)
 
     def _do_exclude(self, path: Path, is_dir: bool) -> bool:
@@ -166,10 +166,10 @@ class DirectoryTraversal(Generic[T]):
         for rule in reversed(self.exclude_rules):
             try:
                 if rule.match(abs_path, is_dir):
-                    if rule.directory_only and not is_dir:
+                    if rule.dir_only and not is_dir:
                         continue  # this rule does not match after all
                     logger.debug(f"    exclude rule {rule!r} matches {abs_path}")
-                    return not rule.negation
+                    return not rule.negated
             except ValueError:  # abs_path not relative to rule.base_path
                 pass
         return False

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -17,7 +17,7 @@ from typing import (
     TypeVar,
 )
 
-from fawltydeps import gitignore_parser
+from fawltydeps.gitignore_parser import Rule as ExcludeRule
 from fawltydeps.utils import dirs_between
 
 T = TypeVar("T")
@@ -97,7 +97,7 @@ class DirectoryTraversal(Generic[T]):
     to_traverse: Dict[Path, DirId] = field(default_factory=dict)
     skip_dirs: Set[DirId] = field(default_factory=set)  # includes already-traversed
     attached: Dict[DirId, List[T]] = field(default_factory=dict)
-    exclude_rules: List[gitignore_parser.Rule] = field(default_factory=list)
+    exclude_rules: List[ExcludeRule] = field(default_factory=list)
 
     def add(self, dir_path: Path, *attach_data: T) -> None:
         """Add one directory to this traversal, optionally w/attached data.
@@ -143,11 +143,7 @@ class DirectoryTraversal(Generic[T]):
         returned while traversing the parent.
         """
         logger.debug(f"Parsing rule from pattern {pattern!r}")
-        rule = gitignore_parser.Rule.from_pattern(pattern.rstrip("\n"), base_dir)
-        if rule.anchored and base_dir is None:
-            raise gitignore_parser.RuleError(
-                "Anchored pattern without base_dir", pattern
-            )
+        rule = ExcludeRule.from_pattern(pattern.rstrip("\n"), base_dir)
 
         logger.debug(f"Adding rule {rule!r} @ {rule.base_dir!r}")
         self.exclude_rules.append(rule)

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -162,10 +162,10 @@ class DirectoryTraversal(Generic[T]):
 
     def _do_exclude(self, path: Path, is_dir: bool) -> bool:
         """Check if given path is excluded by any of our exclude rules."""
-        abs_path = str(path.resolve())
+        abs_path = path.resolve()
         for rule in reversed(self.exclude_rules):
             try:
-                if rule.match(abs_path):
+                if rule.match(abs_path, is_dir):
                     if rule.directory_only and not is_dir:
                         continue  # this rule does not match after all
                     logger.debug(f"    exclude rule {rule!r} matches {abs_path}")

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -143,7 +143,7 @@ class DirectoryTraversal(Generic[T]):
         returned while traversing the parent.
         """
         logger.debug(f"Parsing rule from pattern {pattern!r}")
-        rule = gitignore_parser.rule_from_pattern(pattern.rstrip("\n"), base_dir)
+        rule = gitignore_parser.Rule.from_pattern(pattern.rstrip("\n"), base_dir)
         if rule.anchored and base_dir is None:
             raise gitignore_parser.RuleError(
                 "Anchored pattern without base_dir", pattern

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -44,14 +44,6 @@ class DirId(NamedTuple):
         return cls(dir_stat.st_dev, dir_stat.st_ino)
 
 
-class ExcludeRuleMissing(Exception):
-    """A blank line or comment passed to DirectoryTraversal.exclude()."""
-
-
-class ExcludeRuleError(ValueError):
-    """Error while parsing an exclude pattern in DirectoryTraversal.exclude()."""
-
-
 @dataclass(frozen=True, order=True)
 class TraversalStep(Generic[T]):
     """Encapsulate a single step/directory in an ongoing directory traversal.
@@ -152,10 +144,10 @@ class DirectoryTraversal(Generic[T]):
         """
         logger.debug(f"Parsing rule from pattern {pattern!r}")
         rule = gitignore_parser.rule_from_pattern(pattern.rstrip("\n"), base_dir)
-        if rule is None:
-            raise ExcludeRuleMissing(f"No rule found in {pattern!r}")
         if rule.anchored and base_dir is None:
-            raise ExcludeRuleError(f"Anchored pattern without base_dir in {pattern!r}")
+            raise gitignore_parser.RuleError(
+                "Anchored pattern without base_dir", pattern
+            )
 
         logger.debug(f"Adding rule {rule!r} @ {rule.base_dir!r}")
         self.exclude_rules.append(rule)

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -17,8 +17,7 @@ from typing import (
     TypeVar,
 )
 
-import gitignore_parser  # type: ignore
-
+from fawltydeps import gitignore_parser
 from fawltydeps.utils import dirs_between
 
 T = TypeVar("T")
@@ -150,12 +149,6 @@ class DirectoryTraversal(Generic[T]):  # type: ignore
 
         Files that match an exclude pattern will not be part of the step.files
         returned while traversing the parent.
-
-        TODO: Consider building our own gitignore parse based on
-        fnmatch_pathname_to_regex() from
-        https://github.com/mherrmann/gitignore_parser/blob/8ea4444243e79aa6a359d58b9e9196c15ae6d2d8/gitignore_parser.py#L151
-        which itself is based on
-        https://github.com/snark/ignorance/blob/c9ec7881165e309c6d18cf00d8d62c9b80ea1168/ignorance/utils.py#L44
         """
         logger.debug(f"Parsing rule from pattern {pattern!r}")
         rule = gitignore_parser.rule_from_pattern(pattern.rstrip("\n"), base_dir)

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -154,8 +154,6 @@ class DirectoryTraversal(Generic[T]):
         for rule in reversed(self.exclude_rules):
             try:
                 if rule.match(abs_path, is_dir):
-                    if rule.dir_only and not is_dir:
-                        continue  # this rule does not match after all
                     logger.debug(f"    exclude rule {rule!r} matches {abs_path}")
                     return not rule.negated
             except ValueError:  # abs_path not relative to rule.base_path

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -1,0 +1,220 @@
+import collections
+import os
+import re
+
+from os.path import abspath, dirname
+from pathlib import Path
+from typing import Reversible, Union
+
+def handle_negation(file_path, rules: Reversible["IgnoreRule"]):
+    for rule in reversed(rules):
+        if rule.match(file_path):
+            return not rule.negation
+    return False
+
+def parse_gitignore(full_path, base_dir=None):
+    if base_dir is None:
+        base_dir = dirname(full_path)
+    rules = []
+    with open(full_path) as ignore_file:
+        counter = 0
+        for line in ignore_file:
+            counter += 1
+            line = line.rstrip('\n')
+            rule = rule_from_pattern(line, base_path=Path(base_dir).resolve(),
+                                     source=(full_path, counter))
+            if rule:
+                rules.append(rule)
+    if not any(r.negation for r in rules):
+        return lambda file_path: any(r.match(file_path) for r in rules)
+    else:
+        # We have negation rules. We can't use a simple "any" to evaluate them.
+        # Later rules override earlier rules.
+        return lambda file_path: handle_negation(file_path, rules)
+
+def rule_from_pattern(pattern, base_path=None, source=None):
+    """
+    Take a .gitignore match pattern, such as "*.py[cod]" or "**/*.bak",
+    and return an IgnoreRule suitable for matching against files and
+    directories. Patterns which do not match files, such as comments
+    and blank lines, will return None.
+    Because git allows for nested .gitignore files, a base_path value
+    is required for correct behavior. The base path should be absolute.
+    """
+    if base_path and base_path != Path(base_path).resolve():
+        raise ValueError('base_path must be absolute')
+    # Store the exact pattern for our repr and string functions
+    orig_pattern = pattern
+    # Early returns follow
+    # Discard comments and separators
+    if pattern.strip() == '' or pattern[0] == '#':
+        return
+    # Strip leading bang before examining double asterisks
+    if pattern[0] == '!':
+        negation = True
+        pattern = pattern[1:]
+    else:
+        negation = False
+    # Multi-asterisks not surrounded by slashes (or at the start/end) should
+    # be treated like single-asterisks.
+    pattern = re.sub(r'([^/])\*{2,}', r'\1*', pattern)
+    pattern = re.sub(r'\*{2,}([^/])', r'*\1', pattern)
+
+    # Special-casing '/', which doesn't match any files or directories
+    if pattern.rstrip() == '/':
+        return
+
+    directory_only = pattern[-1] == '/'
+    # A slash is a sign that we're tied to the base_path of our rule
+    # set.
+    anchored = '/' in pattern[:-1]
+    if pattern[0] == '/':
+        pattern = pattern[1:]
+    if pattern[0] == '*' and len(pattern) >= 2 and pattern[1] == '*':
+        pattern = pattern[2:]
+        anchored = False
+    if pattern[0] == '/':
+        pattern = pattern[1:]
+    if pattern[-1] == '/':
+        pattern = pattern[:-1]
+    # patterns with leading hashes or exclamation marks are escaped with a
+    # backslash in front, unescape it
+    if pattern[0] == '\\' and pattern[1] in ('#', '!'):
+        pattern = pattern[1:]
+    # trailing spaces are ignored unless they are escaped with a backslash
+    i = len(pattern)-1
+    striptrailingspaces = True
+    while i > 1 and pattern[i] == ' ':
+        if pattern[i-1] == '\\':
+            pattern = pattern[:i-1] + pattern[i:]
+            i = i - 1
+            striptrailingspaces = False
+        else:
+            if striptrailingspaces:
+                pattern = pattern[:i]
+        i = i - 1
+    regex = fnmatch_pathname_to_regex(
+        pattern, directory_only, negation, anchored=bool(anchored)
+    )
+    return IgnoreRule(
+        pattern=orig_pattern,
+        regex=regex,
+        negation=negation,
+        directory_only=directory_only,
+        anchored=anchored,
+        base_path=_normalize_path(base_path) if base_path else None,
+        source=source
+    )
+
+
+IGNORE_RULE_FIELDS = [
+    'pattern', 'regex',  # Basic values
+    'negation', 'directory_only', 'anchored',  # Behavior flags
+    'base_path',  # Meaningful for gitignore-style behavior
+    'source'  # (file, line) tuple for reporting
+]
+
+
+class IgnoreRule(collections.namedtuple('IgnoreRule_', IGNORE_RULE_FIELDS)):
+    def __str__(self):
+        return self.pattern
+
+    def __repr__(self):
+        return ''.join(['IgnoreRule(\'', self.pattern, '\')'])
+
+    def match(self, abs_path: Union[str, Path]):
+        matched = False
+        if self.base_path:
+            rel_path = str(_normalize_path(abs_path).relative_to(self.base_path))
+        else:
+            rel_path = str(_normalize_path(abs_path))
+        # Path() strips the trailing slash, so we need to preserve it
+        # in case of directory-only negation
+        if self.negation and type(abs_path) == str and abs_path[-1] == '/':
+            rel_path += '/'
+        if rel_path.startswith('./'):
+            rel_path = rel_path[2:]
+        if re.search(self.regex, rel_path):
+            matched = True
+        return matched
+
+
+# Frustratingly, python's fnmatch doesn't provide the FNM_PATHNAME
+# option that .gitignore's behavior depends on.
+def fnmatch_pathname_to_regex(
+    pattern, directory_only: bool, negation: bool, anchored: bool = False
+):
+    """
+    Implements fnmatch style-behavior, as though with FNM_PATHNAME flagged;
+    the path separator will not match shell-style '*' and '.' wildcards.
+    """
+    i, n = 0, len(pattern)
+
+    seps = [re.escape(os.sep)]
+    if os.altsep is not None:
+        seps.append(re.escape(os.altsep))
+    seps_group = '[' + '|'.join(seps) + ']'
+    nonsep = r'[^{}]'.format('|'.join(seps))
+
+    res = []
+    while i < n:
+        c = pattern[i]
+        i += 1
+        if c == '*':
+            try:
+                if pattern[i] == '*':
+                    i += 1
+                    if i < n and pattern[i] == '/':
+                        i += 1
+                        res.append(''.join(['(.*', seps_group, ')?']))
+                    else:
+                        res.append('.*')
+                else:
+                    res.append(''.join([nonsep, '*']))
+            except IndexError:
+                res.append(''.join([nonsep, '*']))
+        elif c == '?':
+            res.append(nonsep)
+        elif c == '/':
+            res.append(seps_group)
+        elif c == '[':
+            j = i
+            if j < n and pattern[j] == '!':
+                j += 1
+            if j < n and pattern[j] == ']':
+                j += 1
+            while j < n and pattern[j] != ']':
+                j += 1
+            if j >= n:
+                res.append('\\[')
+            else:
+                stuff = pattern[i:j].replace('\\', '\\\\').replace('/', '')
+                i = j + 1
+                if stuff[0] == '!':
+                    stuff = ''.join(['^', stuff[1:]])
+                elif stuff[0] == '^':
+                    stuff = ''.join('\\' + stuff)
+                res.append('[{}]'.format(stuff))
+        else:
+            res.append(re.escape(c))
+    if anchored:
+        res.insert(0, '^')
+    else:
+        res.insert(0, f"(^|{seps_group})")
+    if not directory_only:
+        res.append('$')
+    elif directory_only and negation:
+        res.append('/$')
+    else:
+        res.append('($|\\/)')
+    return ''.join(res)
+
+
+def _normalize_path(path: Union[str, Path]) -> Path:
+    """Normalize a path without resolving symlinks.
+
+    This is equivalent to `Path.resolve()` except that it does not resolve symlinks.
+    Note that this simplifies paths by removing double slashes, `..`, `.` etc. like
+    `Path.resolve()` does.
+    """
+    return Path(abspath(path))

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -192,7 +192,7 @@ class Rule(NamedTuple):
         """Return True iff the given 'abs_path' should be ignored."""
         if self.base_dir:
             try:
-                rel_path = str(abs_path.relative_to(self.base_dir))
+                rel_path = abs_path.relative_to(self.base_dir).as_posix()
             except ValueError:  # abs_path not relative to self.base_dir
                 return False
         else:

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -45,11 +45,7 @@ def parse_gitignore_lines(
     for lineno, line in enumerate(lines, start=1):
         source = None if file_hint is None else Location(file_hint, lineno=lineno)
         line = line.rstrip("\n")
-        rule = rule_from_pattern(
-            line,
-            base_path=None if base_dir is None else base_dir.resolve(),
-            source=source,
-        )
+        rule = rule_from_pattern(line, base_dir, source)
         if rule:
             rules.append(rule)
     if not any(r.negation for r in rules):
@@ -82,7 +78,7 @@ def rule_from_pattern(  # pylint: disable=too-many-branches
     return None. Because git allows for nested .gitignore files, a base_path
     value is required for correct behavior. The base path should be absolute.
     """
-    if base_path is not None and base_path != base_path.resolve():
+    if base_path is not None and not base_path.is_absolute():
         raise ValueError("base_path must be absolute")
     # Store the exact pattern for our repr and string functions
     orig_pattern = pattern

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -1,16 +1,17 @@
 import collections
 import os
 import re
-
 from os.path import abspath, dirname
 from pathlib import Path
 from typing import Reversible, Union
+
 
 def handle_negation(file_path, rules: Reversible["IgnoreRule"]):
     for rule in reversed(rules):
         if rule.match(file_path):
             return not rule.negation
     return False
+
 
 def parse_gitignore(full_path, base_dir=None):
     if base_dir is None:
@@ -20,9 +21,10 @@ def parse_gitignore(full_path, base_dir=None):
         counter = 0
         for line in ignore_file:
             counter += 1
-            line = line.rstrip('\n')
-            rule = rule_from_pattern(line, base_path=Path(base_dir).resolve(),
-                                     source=(full_path, counter))
+            line = line.rstrip("\n")
+            rule = rule_from_pattern(
+                line, base_path=Path(base_dir).resolve(), source=(full_path, counter)
+            )
             if rule:
                 rules.append(rule)
     if not any(r.negation for r in rules):
@@ -31,6 +33,7 @@ def parse_gitignore(full_path, base_dir=None):
         # We have negation rules. We can't use a simple "any" to evaluate them.
         # Later rules override earlier rules.
         return lambda file_path: handle_negation(file_path, rules)
+
 
 def rule_from_pattern(pattern, base_path=None, source=None):
     """
@@ -42,51 +45,51 @@ def rule_from_pattern(pattern, base_path=None, source=None):
     is required for correct behavior. The base path should be absolute.
     """
     if base_path and base_path != Path(base_path).resolve():
-        raise ValueError('base_path must be absolute')
+        raise ValueError("base_path must be absolute")
     # Store the exact pattern for our repr and string functions
     orig_pattern = pattern
     # Early returns follow
     # Discard comments and separators
-    if pattern.strip() == '' or pattern[0] == '#':
+    if pattern.strip() == "" or pattern[0] == "#":
         return
     # Strip leading bang before examining double asterisks
-    if pattern[0] == '!':
+    if pattern[0] == "!":
         negation = True
         pattern = pattern[1:]
     else:
         negation = False
     # Multi-asterisks not surrounded by slashes (or at the start/end) should
     # be treated like single-asterisks.
-    pattern = re.sub(r'([^/])\*{2,}', r'\1*', pattern)
-    pattern = re.sub(r'\*{2,}([^/])', r'*\1', pattern)
+    pattern = re.sub(r"([^/])\*{2,}", r"\1*", pattern)
+    pattern = re.sub(r"\*{2,}([^/])", r"*\1", pattern)
 
     # Special-casing '/', which doesn't match any files or directories
-    if pattern.rstrip() == '/':
+    if pattern.rstrip() == "/":
         return
 
-    directory_only = pattern[-1] == '/'
+    directory_only = pattern[-1] == "/"
     # A slash is a sign that we're tied to the base_path of our rule
     # set.
-    anchored = '/' in pattern[:-1]
-    if pattern[0] == '/':
+    anchored = "/" in pattern[:-1]
+    if pattern[0] == "/":
         pattern = pattern[1:]
-    if pattern[0] == '*' and len(pattern) >= 2 and pattern[1] == '*':
+    if pattern[0] == "*" and len(pattern) >= 2 and pattern[1] == "*":
         pattern = pattern[2:]
         anchored = False
-    if pattern[0] == '/':
+    if pattern[0] == "/":
         pattern = pattern[1:]
-    if pattern[-1] == '/':
+    if pattern[-1] == "/":
         pattern = pattern[:-1]
     # patterns with leading hashes or exclamation marks are escaped with a
     # backslash in front, unescape it
-    if pattern[0] == '\\' and pattern[1] in ('#', '!'):
+    if pattern[0] == "\\" and pattern[1] in ("#", "!"):
         pattern = pattern[1:]
     # trailing spaces are ignored unless they are escaped with a backslash
-    i = len(pattern)-1
+    i = len(pattern) - 1
     striptrailingspaces = True
-    while i > 1 and pattern[i] == ' ':
-        if pattern[i-1] == '\\':
-            pattern = pattern[:i-1] + pattern[i:]
+    while i > 1 and pattern[i] == " ":
+        if pattern[i - 1] == "\\":
+            pattern = pattern[: i - 1] + pattern[i:]
             i = i - 1
             striptrailingspaces = False
         else:
@@ -103,24 +106,27 @@ def rule_from_pattern(pattern, base_path=None, source=None):
         directory_only=directory_only,
         anchored=anchored,
         base_path=_normalize_path(base_path) if base_path else None,
-        source=source
+        source=source,
     )
 
 
 IGNORE_RULE_FIELDS = [
-    'pattern', 'regex',  # Basic values
-    'negation', 'directory_only', 'anchored',  # Behavior flags
-    'base_path',  # Meaningful for gitignore-style behavior
-    'source'  # (file, line) tuple for reporting
+    "pattern",
+    "regex",  # Basic values
+    "negation",
+    "directory_only",
+    "anchored",  # Behavior flags
+    "base_path",  # Meaningful for gitignore-style behavior
+    "source",  # (file, line) tuple for reporting
 ]
 
 
-class IgnoreRule(collections.namedtuple('IgnoreRule_', IGNORE_RULE_FIELDS)):
+class IgnoreRule(collections.namedtuple("IgnoreRule_", IGNORE_RULE_FIELDS)):
     def __str__(self):
         return self.pattern
 
     def __repr__(self):
-        return ''.join(['IgnoreRule(\'', self.pattern, '\')'])
+        return "".join(["IgnoreRule('", self.pattern, "')"])
 
     def match(self, abs_path: Union[str, Path]):
         matched = False
@@ -130,9 +136,9 @@ class IgnoreRule(collections.namedtuple('IgnoreRule_', IGNORE_RULE_FIELDS)):
             rel_path = str(_normalize_path(abs_path))
         # Path() strips the trailing slash, so we need to preserve it
         # in case of directory-only negation
-        if self.negation and type(abs_path) == str and abs_path[-1] == '/':
-            rel_path += '/'
-        if rel_path.startswith('./'):
+        if self.negation and type(abs_path) == str and abs_path[-1] == "/":
+            rel_path += "/"
+        if rel_path.startswith("./"):
             rel_path = rel_path[2:]
         if re.search(self.regex, rel_path):
             matched = True
@@ -153,61 +159,61 @@ def fnmatch_pathname_to_regex(
     seps = [re.escape(os.sep)]
     if os.altsep is not None:
         seps.append(re.escape(os.altsep))
-    seps_group = '[' + '|'.join(seps) + ']'
-    nonsep = r'[^{}]'.format('|'.join(seps))
+    seps_group = "[" + "|".join(seps) + "]"
+    nonsep = r"[^{}]".format("|".join(seps))
 
     res = []
     while i < n:
         c = pattern[i]
         i += 1
-        if c == '*':
+        if c == "*":
             try:
-                if pattern[i] == '*':
+                if pattern[i] == "*":
                     i += 1
-                    if i < n and pattern[i] == '/':
+                    if i < n and pattern[i] == "/":
                         i += 1
-                        res.append(''.join(['(.*', seps_group, ')?']))
+                        res.append("".join(["(.*", seps_group, ")?"]))
                     else:
-                        res.append('.*')
+                        res.append(".*")
                 else:
-                    res.append(''.join([nonsep, '*']))
+                    res.append("".join([nonsep, "*"]))
             except IndexError:
-                res.append(''.join([nonsep, '*']))
-        elif c == '?':
+                res.append("".join([nonsep, "*"]))
+        elif c == "?":
             res.append(nonsep)
-        elif c == '/':
+        elif c == "/":
             res.append(seps_group)
-        elif c == '[':
+        elif c == "[":
             j = i
-            if j < n and pattern[j] == '!':
+            if j < n and pattern[j] == "!":
                 j += 1
-            if j < n and pattern[j] == ']':
+            if j < n and pattern[j] == "]":
                 j += 1
-            while j < n and pattern[j] != ']':
+            while j < n and pattern[j] != "]":
                 j += 1
             if j >= n:
-                res.append('\\[')
+                res.append("\\[")
             else:
-                stuff = pattern[i:j].replace('\\', '\\\\').replace('/', '')
+                stuff = pattern[i:j].replace("\\", "\\\\").replace("/", "")
                 i = j + 1
-                if stuff[0] == '!':
-                    stuff = ''.join(['^', stuff[1:]])
-                elif stuff[0] == '^':
-                    stuff = ''.join('\\' + stuff)
-                res.append('[{}]'.format(stuff))
+                if stuff[0] == "!":
+                    stuff = "".join(["^", stuff[1:]])
+                elif stuff[0] == "^":
+                    stuff = "".join("\\" + stuff)
+                res.append("[{}]".format(stuff))
         else:
             res.append(re.escape(c))
     if anchored:
-        res.insert(0, '^')
+        res.insert(0, "^")
     else:
         res.insert(0, f"(^|{seps_group})")
     if not directory_only:
-        res.append('$')
+        res.append("$")
     elif directory_only and negation:
-        res.append('/$')
+        res.append("/$")
     else:
-        res.append('($|\\/)')
-    return ''.join(res)
+        res.append("($|\\/)")
+    return "".join(res)
 
 
 def _normalize_path(path: Union[str, Path]) -> Path:

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -193,7 +193,10 @@ class Rule(NamedTuple):
     def match(self, abs_path: Path, is_dir: bool) -> bool:
         """Return True iff the given 'abs_path' should be ignored."""
         if self.base_dir:
-            rel_path = str(abs_path.relative_to(self.base_dir))
+            try:
+                rel_path = str(abs_path.relative_to(self.base_dir))
+            except ValueError:  # abs_path not relative to self.base_dir
+                return False
         else:
             rel_path = str(abs_path)
         # Path() strips the trailing slash, so we need to preserve it

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -177,6 +177,9 @@ class Rule(NamedTuple):
             pattern = pattern[:-1]
         pattern = pattern.replace("\\ ", " ")  # unescape remaining spaces
 
+        if anchored and base_dir is None:
+            raise RuleError("Anchored pattern without base_dir", pattern, source)
+
         return cls(
             pattern=orig_pattern,
             regex=fnmatch_pathname_to_regex(pattern, dir_only, negated, anchored),

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -6,7 +6,9 @@ import os
 import re
 from os.path import abspath
 from pathlib import Path
-from typing import Callable, Iterable, NamedTuple, Optional, Tuple
+from typing import Callable, Iterable, NamedTuple, Optional
+
+from fawltydeps.types import Location
 
 
 def parse_gitignore(
@@ -42,7 +44,7 @@ def parse_gitignore_lines(
     """
     rules = []
     for lineno, line in enumerate(lines, start=1):
-        source = None if file_hint is None else (file_hint, lineno)
+        source = None if file_hint is None else Location(file_hint, lineno=lineno)
         line = line.rstrip("\n")
         rule = rule_from_pattern(
             line,
@@ -72,7 +74,7 @@ def parse_gitignore_lines(
 def rule_from_pattern(  # pylint: disable=too-many-branches
     pattern: str,
     base_path: Optional[Path] = None,
-    source: Optional[Tuple[Path, int]] = None,
+    source: Optional[Location] = None,
 ) -> Optional[Rule]:
     """
     Take a .gitignore match pattern, such as "*.py[cod]" or "**/*.bak",
@@ -158,7 +160,7 @@ class Rule(NamedTuple):
     directory_only: bool
     anchored: bool
     base_path: Optional[Path]  # meaningful for gitignore-style behavior
-    source: Optional[Tuple[Path, int]]  # (file, line) tuple for reporting
+    source: Optional[Location]
 
     def __str__(self) -> str:
         return self.pattern

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -192,7 +192,6 @@ class Rule(NamedTuple):
 
     def match(self, abs_path: Path, is_dir: bool) -> bool:
         """Return True iff the given 'abs_path' should be ignored."""
-        matched = False
         if self.base_dir:
             rel_path = str(abs_path.relative_to(self.base_dir))
         else:
@@ -203,9 +202,12 @@ class Rule(NamedTuple):
             rel_path += "/"
         if rel_path.startswith("./"):
             rel_path = rel_path[2:]
-        if self.regex.search(rel_path):
-            matched = True
-        return matched
+        match = self.regex.search(rel_path)
+        if match:
+            if self.dir_only and not is_dir and match.end() == match.endpos:
+                return False
+            return True
+        return False
 
 
 # Static regex fragments used below:

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -79,7 +79,7 @@ def rule_from_pattern(  # pylint: disable=too-many-branches
     value is required for correct behavior. The base path should be absolute.
     """
     if base_path is not None and not base_path.is_absolute():
-        raise ValueError("base_path must be absolute")
+        raise ValueError("base_path must be absolute: {base_path}")
     # Store the exact pattern for our repr and string functions
     orig_pattern = pattern
     # Early returns follow
@@ -161,7 +161,7 @@ class Rule(NamedTuple):
         return self.pattern
 
     def __repr__(self) -> str:
-        return "".join(["Rule('", self.pattern, "')"])
+        return f"Rule({self.pattern!r}, {self.regex!r}, ...)"
 
     def match(self, abs_path: Path, is_dir: bool) -> bool:
         """Return True iff the given 'abs_path' should be ignored."""

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import re
-from os.path import abspath
 from pathlib import Path
 from typing import Callable, Iterable, NamedTuple, Optional
 
@@ -144,7 +143,7 @@ def rule_from_pattern(  # pylint: disable=too-many-branches
         negation=negation,
         directory_only=directory_only,
         anchored=anchored,
-        base_path=_normalize_path(base_path) if base_path else None,
+        base_path=base_path,
         source=source,
     )
 
@@ -172,9 +171,9 @@ class Rule(NamedTuple):
         """Return True iff the given 'abs_path' should be ignored."""
         matched = False
         if self.base_path:
-            rel_path = str(_normalize_path(abs_path).relative_to(self.base_path))
+            rel_path = str(abs_path.relative_to(self.base_path))
         else:
-            rel_path = str(_normalize_path(abs_path))
+            rel_path = str(abs_path)
         # Path() strips the trailing slash, so we need to preserve it
         # in case of directory-only negation
         if self.negation and is_dir:
@@ -256,13 +255,3 @@ def fnmatch_pathname_to_regex(  # pylint: disable=too-many-branches,too-many-sta
     else:
         res.append("($|\\/)")
     return "".join(res)
-
-
-def _normalize_path(path: Path) -> Path:
-    """Normalize a path without resolving symlinks.
-
-    This is equivalent to `Path.resolve()` except that it does not resolve symlinks.
-    Note that this simplifies paths by removing double slashes, `..`, `.` etc. like
-    `Path.resolve()` does.
-    """
-    return Path(abspath(path))

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -25,7 +25,7 @@ except ModuleNotFoundError:
 from fawltydeps import extract_declared_dependencies, extract_imports
 from fawltydeps.check import calculate_undeclared, calculate_unused
 from fawltydeps.cli_parser import build_parser
-from fawltydeps.dir_traversal import ExcludeRuleError, ExcludeRuleMissing
+from fawltydeps.gitignore_parser import RuleError as ExcludeRuleError
 from fawltydeps.packages import (
     BasePackageResolver,
     Package,
@@ -366,8 +366,8 @@ def main(
         analysis = Analysis.create(settings, stdin)
     except UnparseablePathException as exc:
         return parser.error(exc.msg)  # exit code 2
-    except (ExcludeRuleMissing, ExcludeRuleError) as exc:
-        return parser.error(f"Error while parsing exclude pattern: {exc.args[0]}")
+    except ExcludeRuleError as exc:
+        return parser.error(f"Error while parsing exclude pattern: {exc}")
     except UnresolvedDependenciesError as exc:
         logger.error(
             "%s\nFawltyDeps is unable to find the above packages with the "

--- a/poetry.lock
+++ b/poetry.lock
@@ -233,16 +233,6 @@ docs = ["furo (>=2023.5.20)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1
 testing = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
-name = "gitignore-parser"
-version = "0.1.10"
-description = "A spec-compliant gitignore parser for Python 3.5+"
-optional = false
-python-versions = "*"
-files = [
-    {file = "gitignore_parser-0.1.10.tar.gz", hash = "sha256:bb0b4c8c61543c106c2ea5cd35dcd159e5a3fad2c1995b52bfe43c13ada0914e"},
-]
-
-[[package]]
 name = "hypothesis"
 version = "6.79.4"
 description = "A library for property-based testing"
@@ -1082,4 +1072,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2"
-content-hash = "e423aaf4500f333aa12d975799dbd7c57b70684344f80974e4f92388c1f5b32a"
+content-hash = "e857ed918d80ef3531b5d29a4b0eeb8c33b8e48413c582e15b036ccf9d2bec58"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ setuptools = [
     {version = ">=68.0.0", python = ">=3.8"},
     {version = ">=68.0.0,<68.1.0", python = "<3.8"},
 ]
-gitignore-parser = "^0.1.8"
 
 [tool.poetry.group.nox]
 optional = true

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -274,7 +274,7 @@ def test_list_imports__missing_exclude_pattern__fails_with_exit_code_2(tmp_path)
     _output, errors, returncode = run_fawltydeps_subprocess(
         "--list-imports", "--exclude="
     )
-    assert "Error while parsing exclude pattern: No rule found in ''" in errors
+    assert "Error while parsing exclude pattern: No rule found: ''" in errors
     assert returncode == 2
 
 
@@ -282,7 +282,7 @@ def test_list_imports__comment_in_exclude_pattern__fails_with_exit_code_2(tmp_pa
     _output, errors, returncode = run_fawltydeps_subprocess(
         "--list-imports", "--exclude", "# comment"
     )
-    assert "Error while parsing exclude pattern: No rule found in '# comment'" in errors
+    assert "Error while parsing exclude pattern: No rule found: '# comment'" in errors
     assert returncode == 2
 
 
@@ -291,7 +291,7 @@ def test_list_imports__error_in_exclude_pattern__fails_with_exit_code_2(tmp_path
         "--list-imports", "--exclude=foo/bar"
     )
     assert (
-        "Error while parsing exclude pattern: Anchored pattern without base_dir in 'foo/bar'"
+        "Error while parsing exclude pattern: Anchored pattern without base_dir: 'foo/bar'"
         in errors
     )
     assert returncode == 2

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -7,12 +7,8 @@ from typing import Generic, List, Optional, Tuple, Type, TypeVar, Union
 
 import pytest
 
-from fawltydeps.dir_traversal import (
-    DirectoryTraversal,
-    ExcludeRuleError,
-    ExcludeRuleMissing,
-    TraversalStep,
-)
+from fawltydeps.dir_traversal import DirectoryTraversal, TraversalStep
+from fawltydeps.gitignore_parser import RuleError, RuleMissing
 
 from .utils import assert_unordered_equivalence
 
@@ -116,7 +112,7 @@ class ExcludePattern:
     # Here, instead, we default base_dir to "" (which is automatically prefixed
     # by tmp_path in the test code below). This makes it easier to test anchored
     # exclude patterns. Pass None explicitly to test the default .exclude()
-    # behavior (which will cause anchored patterns to raise ExcludeRuleError).
+    # behavior (which will cause anchored patterns to raise RuleError).
     base_dir: Optional[str] = ""
 
 
@@ -345,7 +341,7 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
         "gitignore_parsing__disregard_blank_lines",
         given=[File("dir/file")],
         exclude_patterns=[ExcludePattern(""), ExcludePattern("")],
-        exclude_exceptions=[ExcludeRuleMissing, ExcludeRuleMissing],
+        exclude_exceptions=[RuleMissing, RuleMissing],
         expect=[
             ExpectedTraverseStep(".", subdirs=["dir"]),
             ExpectedTraverseStep("dir", files=["file"]),
@@ -363,7 +359,7 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
             ExcludePattern("#do_not_exclude"),  # comment
             ExcludePattern("\\#do_exclude"),  # match literal '#'
         ],
-        exclude_exceptions=[ExcludeRuleMissing],
+        exclude_exceptions=[RuleMissing],
         expect=[
             ExpectedTraverseStep(
                 ".", files=["#do_not_exclude"], excluded_files=["#do_exclude"]
@@ -464,7 +460,7 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
         "anchored_pattern__must_have_base_dir",
         given=[File("file")],
         exclude_patterns=[ExcludePattern("/file", None)],
-        exclude_exceptions=[ExcludeRuleError],
+        exclude_exceptions=[RuleError],
         expect=[ExpectedTraverseStep(".", files=["file"])],
     ),
     DirectoryTraversalVector(

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -3,15 +3,14 @@
 from pathlib import Path
 from textwrap import dedent
 from typing import Optional
-from unittest.mock import mock_open, patch
 
-from fawltydeps.gitignore_parser import parse_gitignore
+from fawltydeps.gitignore_parser import parse_gitignore_lines
 
 
 def _parse(data: str, fake_base_dir: Optional[str] = None):
-    with patch("builtins.open", mock_open(read_data=data)):
-        success = parse_gitignore(f"{fake_base_dir}/.gitignore", fake_base_dir)
-        return success
+    return parse_gitignore_lines(
+        data.split("\n"), fake_base_dir, Path(fake_base_dir, ".gitignore")
+    )
 
 
 def test_simple():

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -3,7 +3,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase, main
 from unittest.mock import mock_open, patch
 
-from gitignore_parser import parse_gitignore
+from fawltydeps.gitignore_parser import parse_gitignore
 
 
 class Test(TestCase):

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -27,7 +27,7 @@ test_vectors = [
         does_match=[
             "/some/dir/main.pyc",
             "/some/dir/dir/main.pyc",
-            "/some/dir/__pycache__",
+            "/some/dir/__pycache__/",
         ],
         doesnt_match=["/some/dir/main.py"],
     ),
@@ -106,8 +106,8 @@ test_vectors = [
         "ignore_directory",
         [".venv/"],
         does_match=[
-            "/some/dir/.venv",
-            "/some/dir/.venv/folder",
+            "/some/dir/.venv/",
+            "/some/dir/.venv/folder/",
             "/some/dir/.venv/file.txt",
         ],
         doesnt_match=[
@@ -118,7 +118,7 @@ test_vectors = [
     GitignoreParserTestVector(
         "ignore_directory_asterisk",
         [".venv/*"],
-        does_match=["/some/dir/.venv/folder", "/some/dir/.venv/file.txt"],
+        does_match=["/some/dir/.venv/folder/", "/some/dir/.venv/file.txt"],
         doesnt_match=["/some/dir/.venv"],
     ),
     GitignoreParserTestVector(
@@ -188,7 +188,7 @@ test_vectors = [
         ["*"],
         does_match=[
             "/some/dir/file.txt",
-            "/some/dir/directory",
+            "/some/dir/directory/",
             "/some/dir/directory-trailing/",
         ],
         doesnt_match=[],
@@ -220,6 +220,8 @@ test_vectors = [
 def test_gitignore_parser(vector: GitignoreParserTestVector):
     base_dir = Path(vector.base_dir)
     matches = parse_gitignore_lines(vector.patterns, base_dir, base_dir / ".gitignore")
+    # Use a trailing '/' in the test vectors to signal is_dir=True.
+    # This trailing slash is stripped by Path() in any case.
     for path in vector.does_match:
         assert matches(Path(path), isinstance(path, str) and path.endswith("/"))
     for path in vector.doesnt_match:

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -106,11 +106,12 @@ test_vectors = [
         "ignore_directory",
         [".venv/"],
         does_match=[
-            "/some/dir/.venv/",
+            "/some/dir/.venv/",  # a dir
             "/some/dir/.venv/folder/",
             "/some/dir/.venv/file.txt",
         ],
         doesnt_match=[
+            "/some/dir/.venv",  # not a dir
             "/some/dir/.venv_other_folder",
             "/some/dir/.venv_no_folder.py",
         ],

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -1,183 +1,176 @@
-from unittest.mock import patch, mock_open
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import TestCase, main
+from unittest.mock import mock_open, patch
 
 from gitignore_parser import parse_gitignore
-
-from unittest import TestCase, main
 
 
 class Test(TestCase):
     def test_simple(self):
         matches = _parse_gitignore_string(
-            '__pycache__/\n'
-            '*.py[cod]',
-            fake_base_dir='/home/michael'
+            "__pycache__/\n" "*.py[cod]", fake_base_dir="/home/michael"
         )
-        self.assertFalse(matches('/home/michael/main.py'))
-        self.assertTrue(matches('/home/michael/main.pyc'))
-        self.assertTrue(matches('/home/michael/dir/main.pyc'))
-        self.assertTrue(matches('/home/michael/__pycache__'))
+        self.assertFalse(matches("/home/michael/main.py"))
+        self.assertTrue(matches("/home/michael/main.pyc"))
+        self.assertTrue(matches("/home/michael/dir/main.pyc"))
+        self.assertTrue(matches("/home/michael/__pycache__"))
 
     def test_incomplete_filename(self):
-        matches = _parse_gitignore_string('o.py', fake_base_dir='/home/michael')
-        self.assertTrue(matches('/home/michael/o.py'))
-        self.assertFalse(matches('/home/michael/foo.py'))
-        self.assertFalse(matches('/home/michael/o.pyc'))
-        self.assertTrue(matches('/home/michael/dir/o.py'))
-        self.assertFalse(matches('/home/michael/dir/foo.py'))
-        self.assertFalse(matches('/home/michael/dir/o.pyc'))
+        matches = _parse_gitignore_string("o.py", fake_base_dir="/home/michael")
+        self.assertTrue(matches("/home/michael/o.py"))
+        self.assertFalse(matches("/home/michael/foo.py"))
+        self.assertFalse(matches("/home/michael/o.pyc"))
+        self.assertTrue(matches("/home/michael/dir/o.py"))
+        self.assertFalse(matches("/home/michael/dir/foo.py"))
+        self.assertFalse(matches("/home/michael/dir/o.pyc"))
 
     def test_wildcard(self):
-        matches = _parse_gitignore_string(
-            'hello.*',
-            fake_base_dir='/home/michael'
-        )
-        self.assertTrue(matches('/home/michael/hello.txt'))
-        self.assertTrue(matches('/home/michael/hello.foobar/'))
-        self.assertTrue(matches('/home/michael/dir/hello.txt'))
-        self.assertTrue(matches('/home/michael/hello.'))
-        self.assertFalse(matches('/home/michael/hello'))
-        self.assertFalse(matches('/home/michael/helloX'))
+        matches = _parse_gitignore_string("hello.*", fake_base_dir="/home/michael")
+        self.assertTrue(matches("/home/michael/hello.txt"))
+        self.assertTrue(matches("/home/michael/hello.foobar/"))
+        self.assertTrue(matches("/home/michael/dir/hello.txt"))
+        self.assertTrue(matches("/home/michael/hello."))
+        self.assertFalse(matches("/home/michael/hello"))
+        self.assertFalse(matches("/home/michael/helloX"))
 
     def test_anchored_wildcard(self):
-        matches = _parse_gitignore_string(
-            '/hello.*',
-            fake_base_dir='/home/michael'
-        )
-        self.assertTrue(matches('/home/michael/hello.txt'))
-        self.assertTrue(matches('/home/michael/hello.c'))
-        self.assertFalse(matches('/home/michael/a/hello.java'))
+        matches = _parse_gitignore_string("/hello.*", fake_base_dir="/home/michael")
+        self.assertTrue(matches("/home/michael/hello.txt"))
+        self.assertTrue(matches("/home/michael/hello.c"))
+        self.assertFalse(matches("/home/michael/a/hello.java"))
 
     def test_trailingspaces(self):
         matches = _parse_gitignore_string(
-            'ignoretrailingspace \n'
-            'notignoredspace\\ \n'
-            'partiallyignoredspace\\  \n'
-            'partiallyignoredspace2 \\  \n'
-            'notignoredmultiplespace\\ \\ \\ ',
-            fake_base_dir='/home/michael'
+            "ignoretrailingspace \n"
+            "notignoredspace\\ \n"
+            "partiallyignoredspace\\  \n"
+            "partiallyignoredspace2 \\  \n"
+            "notignoredmultiplespace\\ \\ \\ ",
+            fake_base_dir="/home/michael",
         )
-        self.assertTrue(matches('/home/michael/ignoretrailingspace'))
-        self.assertFalse(matches('/home/michael/ignoretrailingspace '))
-        self.assertTrue(matches('/home/michael/partiallyignoredspace '))
-        self.assertFalse(matches('/home/michael/partiallyignoredspace  '))
-        self.assertFalse(matches('/home/michael/partiallyignoredspace'))
-        self.assertTrue(matches('/home/michael/partiallyignoredspace2  '))
-        self.assertFalse(matches('/home/michael/partiallyignoredspace2   '))
-        self.assertFalse(matches('/home/michael/partiallyignoredspace2 '))
-        self.assertFalse(matches('/home/michael/partiallyignoredspace2'))
-        self.assertTrue(matches('/home/michael/notignoredspace '))
-        self.assertFalse(matches('/home/michael/notignoredspace'))
-        self.assertTrue(matches('/home/michael/notignoredmultiplespace   '))
-        self.assertFalse(matches('/home/michael/notignoredmultiplespace'))
+        self.assertTrue(matches("/home/michael/ignoretrailingspace"))
+        self.assertFalse(matches("/home/michael/ignoretrailingspace "))
+        self.assertTrue(matches("/home/michael/partiallyignoredspace "))
+        self.assertFalse(matches("/home/michael/partiallyignoredspace  "))
+        self.assertFalse(matches("/home/michael/partiallyignoredspace"))
+        self.assertTrue(matches("/home/michael/partiallyignoredspace2  "))
+        self.assertFalse(matches("/home/michael/partiallyignoredspace2   "))
+        self.assertFalse(matches("/home/michael/partiallyignoredspace2 "))
+        self.assertFalse(matches("/home/michael/partiallyignoredspace2"))
+        self.assertTrue(matches("/home/michael/notignoredspace "))
+        self.assertFalse(matches("/home/michael/notignoredspace"))
+        self.assertTrue(matches("/home/michael/notignoredmultiplespace   "))
+        self.assertFalse(matches("/home/michael/notignoredmultiplespace"))
 
     def test_comment(self):
         matches = _parse_gitignore_string(
-                        'somematch\n'
-                        '#realcomment\n'
-                        'othermatch\n'
-                        '\\#imnocomment',
-            fake_base_dir='/home/michael'
+            "somematch\n" "#realcomment\n" "othermatch\n" "\\#imnocomment",
+            fake_base_dir="/home/michael",
         )
-        self.assertTrue(matches('/home/michael/somematch'))
-        self.assertFalse(matches('/home/michael/#realcomment'))
-        self.assertTrue(matches('/home/michael/othermatch'))
-        self.assertTrue(matches('/home/michael/#imnocomment'))
+        self.assertTrue(matches("/home/michael/somematch"))
+        self.assertFalse(matches("/home/michael/#realcomment"))
+        self.assertTrue(matches("/home/michael/othermatch"))
+        self.assertTrue(matches("/home/michael/#imnocomment"))
 
     def test_ignore_directory(self):
-        matches = _parse_gitignore_string('.venv/', fake_base_dir='/home/michael')
-        self.assertTrue(matches('/home/michael/.venv'))
-        self.assertTrue(matches('/home/michael/.venv/folder'))
-        self.assertTrue(matches('/home/michael/.venv/file.txt'))
-        self.assertFalse(matches('/home/michael/.venv_other_folder'))
-        self.assertFalse(matches('/home/michael/.venv_no_folder.py'))
+        matches = _parse_gitignore_string(".venv/", fake_base_dir="/home/michael")
+        self.assertTrue(matches("/home/michael/.venv"))
+        self.assertTrue(matches("/home/michael/.venv/folder"))
+        self.assertTrue(matches("/home/michael/.venv/file.txt"))
+        self.assertFalse(matches("/home/michael/.venv_other_folder"))
+        self.assertFalse(matches("/home/michael/.venv_no_folder.py"))
 
     def test_ignore_directory_asterisk(self):
-        matches = _parse_gitignore_string('.venv/*', fake_base_dir='/home/michael')
-        self.assertFalse(matches('/home/michael/.venv'))
-        self.assertTrue(matches('/home/michael/.venv/folder'))
-        self.assertTrue(matches('/home/michael/.venv/file.txt'))
+        matches = _parse_gitignore_string(".venv/*", fake_base_dir="/home/michael")
+        self.assertFalse(matches("/home/michael/.venv"))
+        self.assertTrue(matches("/home/michael/.venv/folder"))
+        self.assertTrue(matches("/home/michael/.venv/file.txt"))
 
     def test_negation(self):
         matches = _parse_gitignore_string(
-            '''
+            """
 *.ignore
 !keep.ignore
-            ''',
-            fake_base_dir='/home/michael'
+            """,
+            fake_base_dir="/home/michael",
         )
-        self.assertTrue(matches('/home/michael/trash.ignore'))
-        self.assertFalse(matches('/home/michael/keep.ignore'))
-        self.assertTrue(matches('/home/michael/waste.ignore'))
+        self.assertTrue(matches("/home/michael/trash.ignore"))
+        self.assertFalse(matches("/home/michael/keep.ignore"))
+        self.assertTrue(matches("/home/michael/waste.ignore"))
 
     def test_literal_exclamation_mark(self):
-        matches = _parse_gitignore_string('\\!ignore_me!', fake_base_dir='/home/michael')
-        self.assertTrue(matches('/home/michael/!ignore_me!'))
-        self.assertFalse(matches('/home/michael/ignore_me!'))
-        self.assertFalse(matches('/home/michael/ignore_me'))
+        matches = _parse_gitignore_string(
+            "\\!ignore_me!", fake_base_dir="/home/michael"
+        )
+        self.assertTrue(matches("/home/michael/!ignore_me!"))
+        self.assertFalse(matches("/home/michael/ignore_me!"))
+        self.assertFalse(matches("/home/michael/ignore_me"))
 
     def test_double_asterisks(self):
-        matches = _parse_gitignore_string('foo/**/Bar', fake_base_dir='/home/michael')
-        self.assertTrue(matches('/home/michael/foo/hello/Bar'))
-        self.assertTrue(matches('/home/michael/foo/world/Bar'))
-        self.assertTrue(matches('/home/michael/foo/Bar'))
-        self.assertFalse(matches('/home/michael/foo/BarBar'))
+        matches = _parse_gitignore_string("foo/**/Bar", fake_base_dir="/home/michael")
+        self.assertTrue(matches("/home/michael/foo/hello/Bar"))
+        self.assertTrue(matches("/home/michael/foo/world/Bar"))
+        self.assertTrue(matches("/home/michael/foo/Bar"))
+        self.assertFalse(matches("/home/michael/foo/BarBar"))
 
     def test_double_asterisk_without_slashes_handled_like_single_asterisk(self):
-        matches = _parse_gitignore_string('a/b**c/d', fake_base_dir='/home/michael')
-        self.assertTrue(matches('/home/michael/a/bc/d'))
-        self.assertTrue(matches('/home/michael/a/bXc/d'))
-        self.assertTrue(matches('/home/michael/a/bbc/d'))
-        self.assertTrue(matches('/home/michael/a/bcc/d'))
-        self.assertFalse(matches('/home/michael/a/bcd'))
-        self.assertFalse(matches('/home/michael/a/b/c/d'))
-        self.assertFalse(matches('/home/michael/a/bb/cc/d'))
-        self.assertFalse(matches('/home/michael/a/bb/XX/cc/d'))
+        matches = _parse_gitignore_string("a/b**c/d", fake_base_dir="/home/michael")
+        self.assertTrue(matches("/home/michael/a/bc/d"))
+        self.assertTrue(matches("/home/michael/a/bXc/d"))
+        self.assertTrue(matches("/home/michael/a/bbc/d"))
+        self.assertTrue(matches("/home/michael/a/bcc/d"))
+        self.assertFalse(matches("/home/michael/a/bcd"))
+        self.assertFalse(matches("/home/michael/a/b/c/d"))
+        self.assertFalse(matches("/home/michael/a/bb/cc/d"))
+        self.assertFalse(matches("/home/michael/a/bb/XX/cc/d"))
 
     def test_more_asterisks_handled_like_single_asterisk(self):
-        matches = _parse_gitignore_string('***a/b', fake_base_dir='/home/michael')
-        self.assertTrue(matches('/home/michael/XYZa/b'))
-        self.assertFalse(matches('/home/michael/foo/a/b'))
-        matches = _parse_gitignore_string('a/b***', fake_base_dir='/home/michael')
-        self.assertTrue(matches('/home/michael/a/bXYZ'))
-        self.assertFalse(matches('/home/michael/a/b/foo'))
+        matches = _parse_gitignore_string("***a/b", fake_base_dir="/home/michael")
+        self.assertTrue(matches("/home/michael/XYZa/b"))
+        self.assertFalse(matches("/home/michael/foo/a/b"))
+        matches = _parse_gitignore_string("a/b***", fake_base_dir="/home/michael")
+        self.assertTrue(matches("/home/michael/a/bXYZ"))
+        self.assertFalse(matches("/home/michael/a/b/foo"))
 
     def test_directory_only_negation(self):
-        matches = _parse_gitignore_string('''
+        matches = _parse_gitignore_string(
+            """
 data/**
 !data/**/
 !.gitkeep
 !data/01_raw/*
-            ''',
-            fake_base_dir='/home/michael'
+            """,
+            fake_base_dir="/home/michael",
         )
-        self.assertFalse(matches('/home/michael/data/01_raw/'))
-        self.assertFalse(matches('/home/michael/data/01_raw/.gitkeep'))
-        self.assertFalse(matches('/home/michael/data/01_raw/raw_file.csv'))
-        self.assertFalse(matches('/home/michael/data/02_processed/'))
-        self.assertFalse(matches('/home/michael/data/02_processed/.gitkeep'))
-        self.assertTrue(matches('/home/michael/data/02_processed/processed_file.csv'))
+        self.assertFalse(matches("/home/michael/data/01_raw/"))
+        self.assertFalse(matches("/home/michael/data/01_raw/.gitkeep"))
+        self.assertFalse(matches("/home/michael/data/01_raw/raw_file.csv"))
+        self.assertFalse(matches("/home/michael/data/02_processed/"))
+        self.assertFalse(matches("/home/michael/data/02_processed/.gitkeep"))
+        self.assertTrue(matches("/home/michael/data/02_processed/processed_file.csv"))
 
     def test_single_asterisk(self):
-        matches = _parse_gitignore_string('*', fake_base_dir='/home/michael')
-        self.assertTrue(matches('/home/michael/file.txt'))
-        self.assertTrue(matches('/home/michael/directory'))
-        self.assertTrue(matches('/home/michael/directory-trailing/'))
+        matches = _parse_gitignore_string("*", fake_base_dir="/home/michael")
+        self.assertTrue(matches("/home/michael/file.txt"))
+        self.assertTrue(matches("/home/michael/directory"))
+        self.assertTrue(matches("/home/michael/directory-trailing/"))
 
     def test_supports_path_type_argument(self):
-        matches = _parse_gitignore_string('file1\n!file2', fake_base_dir='/home/michael')
-        self.assertTrue(matches(Path('/home/michael/file1')))
-        self.assertFalse(matches(Path('/home/michael/file2')))
+        matches = _parse_gitignore_string(
+            "file1\n!file2", fake_base_dir="/home/michael"
+        )
+        self.assertTrue(matches(Path("/home/michael/file1")))
+        self.assertFalse(matches(Path("/home/michael/file2")))
 
     def test_slash_in_range_does_not_match_dirs(self):
-        matches = _parse_gitignore_string('abc[X-Z/]def', fake_base_dir='/home/michael')
-        self.assertFalse(matches('/home/michael/abcdef'))
-        self.assertTrue(matches('/home/michael/abcXdef'))
-        self.assertTrue(matches('/home/michael/abcYdef'))
-        self.assertTrue(matches('/home/michael/abcZdef'))
-        self.assertFalse(matches('/home/michael/abc/def'))
-        self.assertFalse(matches('/home/michael/abcXYZdef'))
+        matches = _parse_gitignore_string("abc[X-Z/]def", fake_base_dir="/home/michael")
+        self.assertFalse(matches("/home/michael/abcdef"))
+        self.assertTrue(matches("/home/michael/abcXdef"))
+        self.assertTrue(matches("/home/michael/abcYdef"))
+        self.assertTrue(matches("/home/michael/abcZdef"))
+        self.assertFalse(matches("/home/michael/abc/def"))
+        self.assertFalse(matches("/home/michael/abcXYZdef"))
 
     def test_symlink_to_another_directory(self):
         """Test the behavior of a symlink to another directory.
@@ -188,11 +181,11 @@ data/**
         This test ensures that the issue is now fixed.
         """
         with TemporaryDirectory() as project_dir, TemporaryDirectory() as another_dir:
-            matches = _parse_gitignore_string('link', fake_base_dir=project_dir)
+            matches = _parse_gitignore_string("link", fake_base_dir=project_dir)
 
             # Create a symlink to another directory.
-            link = Path(project_dir, 'link')
-            target = Path(another_dir, 'target')
+            link = Path(project_dir, "link")
+            target = Path(another_dir, "target")
             link.symlink_to(target)
 
             # Check the intended behavior according to
@@ -201,10 +194,12 @@ data/**
             # files.
             self.assertTrue(matches(link))
 
+
 def _parse_gitignore_string(data: str, fake_base_dir: str = None):
-    with patch('builtins.open', mock_open(read_data=data)):
-        success = parse_gitignore(f'{fake_base_dir}/.gitignore', fake_base_dir)
+    with patch("builtins.open", mock_open(read_data=data)):
+        success = parse_gitignore(f"{fake_base_dir}/.gitignore", fake_base_dir)
         return success
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -1,0 +1,210 @@
+from unittest.mock import patch, mock_open
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from gitignore_parser import parse_gitignore
+
+from unittest import TestCase, main
+
+
+class Test(TestCase):
+    def test_simple(self):
+        matches = _parse_gitignore_string(
+            '__pycache__/\n'
+            '*.py[cod]',
+            fake_base_dir='/home/michael'
+        )
+        self.assertFalse(matches('/home/michael/main.py'))
+        self.assertTrue(matches('/home/michael/main.pyc'))
+        self.assertTrue(matches('/home/michael/dir/main.pyc'))
+        self.assertTrue(matches('/home/michael/__pycache__'))
+
+    def test_incomplete_filename(self):
+        matches = _parse_gitignore_string('o.py', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/o.py'))
+        self.assertFalse(matches('/home/michael/foo.py'))
+        self.assertFalse(matches('/home/michael/o.pyc'))
+        self.assertTrue(matches('/home/michael/dir/o.py'))
+        self.assertFalse(matches('/home/michael/dir/foo.py'))
+        self.assertFalse(matches('/home/michael/dir/o.pyc'))
+
+    def test_wildcard(self):
+        matches = _parse_gitignore_string(
+            'hello.*',
+            fake_base_dir='/home/michael'
+        )
+        self.assertTrue(matches('/home/michael/hello.txt'))
+        self.assertTrue(matches('/home/michael/hello.foobar/'))
+        self.assertTrue(matches('/home/michael/dir/hello.txt'))
+        self.assertTrue(matches('/home/michael/hello.'))
+        self.assertFalse(matches('/home/michael/hello'))
+        self.assertFalse(matches('/home/michael/helloX'))
+
+    def test_anchored_wildcard(self):
+        matches = _parse_gitignore_string(
+            '/hello.*',
+            fake_base_dir='/home/michael'
+        )
+        self.assertTrue(matches('/home/michael/hello.txt'))
+        self.assertTrue(matches('/home/michael/hello.c'))
+        self.assertFalse(matches('/home/michael/a/hello.java'))
+
+    def test_trailingspaces(self):
+        matches = _parse_gitignore_string(
+            'ignoretrailingspace \n'
+            'notignoredspace\\ \n'
+            'partiallyignoredspace\\  \n'
+            'partiallyignoredspace2 \\  \n'
+            'notignoredmultiplespace\\ \\ \\ ',
+            fake_base_dir='/home/michael'
+        )
+        self.assertTrue(matches('/home/michael/ignoretrailingspace'))
+        self.assertFalse(matches('/home/michael/ignoretrailingspace '))
+        self.assertTrue(matches('/home/michael/partiallyignoredspace '))
+        self.assertFalse(matches('/home/michael/partiallyignoredspace  '))
+        self.assertFalse(matches('/home/michael/partiallyignoredspace'))
+        self.assertTrue(matches('/home/michael/partiallyignoredspace2  '))
+        self.assertFalse(matches('/home/michael/partiallyignoredspace2   '))
+        self.assertFalse(matches('/home/michael/partiallyignoredspace2 '))
+        self.assertFalse(matches('/home/michael/partiallyignoredspace2'))
+        self.assertTrue(matches('/home/michael/notignoredspace '))
+        self.assertFalse(matches('/home/michael/notignoredspace'))
+        self.assertTrue(matches('/home/michael/notignoredmultiplespace   '))
+        self.assertFalse(matches('/home/michael/notignoredmultiplespace'))
+
+    def test_comment(self):
+        matches = _parse_gitignore_string(
+                        'somematch\n'
+                        '#realcomment\n'
+                        'othermatch\n'
+                        '\\#imnocomment',
+            fake_base_dir='/home/michael'
+        )
+        self.assertTrue(matches('/home/michael/somematch'))
+        self.assertFalse(matches('/home/michael/#realcomment'))
+        self.assertTrue(matches('/home/michael/othermatch'))
+        self.assertTrue(matches('/home/michael/#imnocomment'))
+
+    def test_ignore_directory(self):
+        matches = _parse_gitignore_string('.venv/', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/.venv'))
+        self.assertTrue(matches('/home/michael/.venv/folder'))
+        self.assertTrue(matches('/home/michael/.venv/file.txt'))
+        self.assertFalse(matches('/home/michael/.venv_other_folder'))
+        self.assertFalse(matches('/home/michael/.venv_no_folder.py'))
+
+    def test_ignore_directory_asterisk(self):
+        matches = _parse_gitignore_string('.venv/*', fake_base_dir='/home/michael')
+        self.assertFalse(matches('/home/michael/.venv'))
+        self.assertTrue(matches('/home/michael/.venv/folder'))
+        self.assertTrue(matches('/home/michael/.venv/file.txt'))
+
+    def test_negation(self):
+        matches = _parse_gitignore_string(
+            '''
+*.ignore
+!keep.ignore
+            ''',
+            fake_base_dir='/home/michael'
+        )
+        self.assertTrue(matches('/home/michael/trash.ignore'))
+        self.assertFalse(matches('/home/michael/keep.ignore'))
+        self.assertTrue(matches('/home/michael/waste.ignore'))
+
+    def test_literal_exclamation_mark(self):
+        matches = _parse_gitignore_string('\\!ignore_me!', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/!ignore_me!'))
+        self.assertFalse(matches('/home/michael/ignore_me!'))
+        self.assertFalse(matches('/home/michael/ignore_me'))
+
+    def test_double_asterisks(self):
+        matches = _parse_gitignore_string('foo/**/Bar', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/foo/hello/Bar'))
+        self.assertTrue(matches('/home/michael/foo/world/Bar'))
+        self.assertTrue(matches('/home/michael/foo/Bar'))
+        self.assertFalse(matches('/home/michael/foo/BarBar'))
+
+    def test_double_asterisk_without_slashes_handled_like_single_asterisk(self):
+        matches = _parse_gitignore_string('a/b**c/d', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/a/bc/d'))
+        self.assertTrue(matches('/home/michael/a/bXc/d'))
+        self.assertTrue(matches('/home/michael/a/bbc/d'))
+        self.assertTrue(matches('/home/michael/a/bcc/d'))
+        self.assertFalse(matches('/home/michael/a/bcd'))
+        self.assertFalse(matches('/home/michael/a/b/c/d'))
+        self.assertFalse(matches('/home/michael/a/bb/cc/d'))
+        self.assertFalse(matches('/home/michael/a/bb/XX/cc/d'))
+
+    def test_more_asterisks_handled_like_single_asterisk(self):
+        matches = _parse_gitignore_string('***a/b', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/XYZa/b'))
+        self.assertFalse(matches('/home/michael/foo/a/b'))
+        matches = _parse_gitignore_string('a/b***', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/a/bXYZ'))
+        self.assertFalse(matches('/home/michael/a/b/foo'))
+
+    def test_directory_only_negation(self):
+        matches = _parse_gitignore_string('''
+data/**
+!data/**/
+!.gitkeep
+!data/01_raw/*
+            ''',
+            fake_base_dir='/home/michael'
+        )
+        self.assertFalse(matches('/home/michael/data/01_raw/'))
+        self.assertFalse(matches('/home/michael/data/01_raw/.gitkeep'))
+        self.assertFalse(matches('/home/michael/data/01_raw/raw_file.csv'))
+        self.assertFalse(matches('/home/michael/data/02_processed/'))
+        self.assertFalse(matches('/home/michael/data/02_processed/.gitkeep'))
+        self.assertTrue(matches('/home/michael/data/02_processed/processed_file.csv'))
+
+    def test_single_asterisk(self):
+        matches = _parse_gitignore_string('*', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/file.txt'))
+        self.assertTrue(matches('/home/michael/directory'))
+        self.assertTrue(matches('/home/michael/directory-trailing/'))
+
+    def test_supports_path_type_argument(self):
+        matches = _parse_gitignore_string('file1\n!file2', fake_base_dir='/home/michael')
+        self.assertTrue(matches(Path('/home/michael/file1')))
+        self.assertFalse(matches(Path('/home/michael/file2')))
+
+    def test_slash_in_range_does_not_match_dirs(self):
+        matches = _parse_gitignore_string('abc[X-Z/]def', fake_base_dir='/home/michael')
+        self.assertFalse(matches('/home/michael/abcdef'))
+        self.assertTrue(matches('/home/michael/abcXdef'))
+        self.assertTrue(matches('/home/michael/abcYdef'))
+        self.assertTrue(matches('/home/michael/abcZdef'))
+        self.assertFalse(matches('/home/michael/abc/def'))
+        self.assertFalse(matches('/home/michael/abcXYZdef'))
+
+    def test_symlink_to_another_directory(self):
+        """Test the behavior of a symlink to another directory.
+
+        The issue https://github.com/mherrmann/gitignore_parser/issues/29 describes how
+        a symlink to another directory caused an exception to be raised during matching.
+
+        This test ensures that the issue is now fixed.
+        """
+        with TemporaryDirectory() as project_dir, TemporaryDirectory() as another_dir:
+            matches = _parse_gitignore_string('link', fake_base_dir=project_dir)
+
+            # Create a symlink to another directory.
+            link = Path(project_dir, 'link')
+            target = Path(another_dir, 'target')
+            link.symlink_to(target)
+
+            # Check the intended behavior according to
+            # https://git-scm.com/docs/gitignore#_notes:
+            # Symbolic links are not followed and are matched as if they were regular
+            # files.
+            self.assertTrue(matches(link))
+
+def _parse_gitignore_string(data: str, fake_base_dir: str = None):
+    with patch('builtins.open', mock_open(read_data=data)):
+        success = parse_gitignore(f'{fake_base_dir}/.gitignore', fake_base_dir)
+        return success
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -4,217 +4,215 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from textwrap import dedent
 from typing import Optional
-from unittest import TestCase, main
 from unittest.mock import mock_open, patch
 
 from fawltydeps.gitignore_parser import parse_gitignore
 
 
-class Test(TestCase):
-    """gitinore_parser test cases."""
+def test_simple():
+    matches = _parse_gitignore_string(
+        "\n".join(["__pycache__/", "*.py[cod]"]),
+        fake_base_dir="/home/michael",
+    )
+    assert not matches("/home/michael/main.py")
+    assert matches("/home/michael/main.pyc")
+    assert matches("/home/michael/dir/main.pyc")
+    assert matches("/home/michael/__pycache__")
 
-    def test_simple(self):
-        matches = _parse_gitignore_string(
-            "\n".join(["__pycache__/", "*.py[cod]"]),
-            fake_base_dir="/home/michael",
-        )
-        self.assertFalse(matches("/home/michael/main.py"))
-        self.assertTrue(matches("/home/michael/main.pyc"))
-        self.assertTrue(matches("/home/michael/dir/main.pyc"))
-        self.assertTrue(matches("/home/michael/__pycache__"))
 
-    def test_incomplete_filename(self):
-        matches = _parse_gitignore_string("o.py", fake_base_dir="/home/michael")
-        self.assertTrue(matches("/home/michael/o.py"))
-        self.assertFalse(matches("/home/michael/foo.py"))
-        self.assertFalse(matches("/home/michael/o.pyc"))
-        self.assertTrue(matches("/home/michael/dir/o.py"))
-        self.assertFalse(matches("/home/michael/dir/foo.py"))
-        self.assertFalse(matches("/home/michael/dir/o.pyc"))
+def test_incomplete_filename():
+    matches = _parse_gitignore_string("o.py", fake_base_dir="/home/michael")
+    assert matches("/home/michael/o.py")
+    assert not matches("/home/michael/foo.py")
+    assert not matches("/home/michael/o.pyc")
+    assert matches("/home/michael/dir/o.py")
+    assert not matches("/home/michael/dir/foo.py")
+    assert not matches("/home/michael/dir/o.pyc")
 
-    def test_wildcard(self):
-        matches = _parse_gitignore_string("hello.*", fake_base_dir="/home/michael")
-        self.assertTrue(matches("/home/michael/hello.txt"))
-        self.assertTrue(matches("/home/michael/hello.foobar/"))
-        self.assertTrue(matches("/home/michael/dir/hello.txt"))
-        self.assertTrue(matches("/home/michael/hello."))
-        self.assertFalse(matches("/home/michael/hello"))
-        self.assertFalse(matches("/home/michael/helloX"))
 
-    def test_anchored_wildcard(self):
-        matches = _parse_gitignore_string("/hello.*", fake_base_dir="/home/michael")
-        self.assertTrue(matches("/home/michael/hello.txt"))
-        self.assertTrue(matches("/home/michael/hello.c"))
-        self.assertFalse(matches("/home/michael/a/hello.java"))
+def test_wildcard():
+    matches = _parse_gitignore_string("hello.*", fake_base_dir="/home/michael")
+    assert matches("/home/michael/hello.txt")
+    assert matches("/home/michael/hello.foobar/")
+    assert matches("/home/michael/dir/hello.txt")
+    assert matches("/home/michael/hello.")
+    assert not matches("/home/michael/hello")
+    assert not matches("/home/michael/helloX")
 
-    def test_trailingspaces(self):
-        matches = _parse_gitignore_string(
-            "\n".join(
-                [
-                    "ignoretrailingspace ",
-                    "notignoredspace\\ ",
-                    "partiallyignoredspace\\  ",
-                    "partiallyignoredspace2 \\  ",
-                    "notignoredmultiplespace\\ \\ \\ ",
-                ]
-            ),
-            fake_base_dir="/home/michael",
-        )
-        self.assertTrue(matches("/home/michael/ignoretrailingspace"))
-        self.assertFalse(matches("/home/michael/ignoretrailingspace "))
-        self.assertTrue(matches("/home/michael/partiallyignoredspace "))
-        self.assertFalse(matches("/home/michael/partiallyignoredspace  "))
-        self.assertFalse(matches("/home/michael/partiallyignoredspace"))
-        self.assertTrue(matches("/home/michael/partiallyignoredspace2  "))
-        self.assertFalse(matches("/home/michael/partiallyignoredspace2   "))
-        self.assertFalse(matches("/home/michael/partiallyignoredspace2 "))
-        self.assertFalse(matches("/home/michael/partiallyignoredspace2"))
-        self.assertTrue(matches("/home/michael/notignoredspace "))
-        self.assertFalse(matches("/home/michael/notignoredspace"))
-        self.assertTrue(matches("/home/michael/notignoredmultiplespace   "))
-        self.assertFalse(matches("/home/michael/notignoredmultiplespace"))
 
-    def test_comment(self):
-        matches = _parse_gitignore_string(
-            "\n".join(["somematch", "#realcomment", "othermatch", "\\#imnocomment"]),
-            fake_base_dir="/home/michael",
-        )
-        self.assertTrue(matches("/home/michael/somematch"))
-        self.assertFalse(matches("/home/michael/#realcomment"))
-        self.assertTrue(matches("/home/michael/othermatch"))
-        self.assertTrue(matches("/home/michael/#imnocomment"))
+def test_anchored_wildcard():
+    matches = _parse_gitignore_string("/hello.*", fake_base_dir="/home/michael")
+    assert matches("/home/michael/hello.txt")
+    assert matches("/home/michael/hello.c")
+    assert not matches("/home/michael/a/hello.java")
 
-    def test_ignore_directory(self):
-        matches = _parse_gitignore_string(".venv/", fake_base_dir="/home/michael")
-        self.assertTrue(matches("/home/michael/.venv"))
-        self.assertTrue(matches("/home/michael/.venv/folder"))
-        self.assertTrue(matches("/home/michael/.venv/file.txt"))
-        self.assertFalse(matches("/home/michael/.venv_other_folder"))
-        self.assertFalse(matches("/home/michael/.venv_no_folder.py"))
 
-    def test_ignore_directory_asterisk(self):
-        matches = _parse_gitignore_string(".venv/*", fake_base_dir="/home/michael")
-        self.assertFalse(matches("/home/michael/.venv"))
-        self.assertTrue(matches("/home/michael/.venv/folder"))
-        self.assertTrue(matches("/home/michael/.venv/file.txt"))
+def test_trailingspaces():
+    patterns = [
+        "ignoretrailingspace ",
+        "notignoredspace\\ ",
+        "partiallyignoredspace\\  ",
+        "partiallyignoredspace2 \\  ",
+        "notignoredmultiplespace\\ \\ \\ ",
+    ]
+    matches = _parse_gitignore_string("\n".join(patterns), fake_base_dir="/home/michael")
+    assert matches("/home/michael/ignoretrailingspace")
+    assert not matches("/home/michael/ignoretrailingspace ")
+    assert matches("/home/michael/partiallyignoredspace ")
+    assert not matches("/home/michael/partiallyignoredspace  ")
+    assert not matches("/home/michael/partiallyignoredspace")
+    assert matches("/home/michael/partiallyignoredspace2  ")
+    assert not matches("/home/michael/partiallyignoredspace2   ")
+    assert not matches("/home/michael/partiallyignoredspace2 ")
+    assert not matches("/home/michael/partiallyignoredspace2")
+    assert matches("/home/michael/notignoredspace ")
+    assert not matches("/home/michael/notignoredspace")
+    assert matches("/home/michael/notignoredmultiplespace   ")
+    assert not matches("/home/michael/notignoredmultiplespace")
 
-    def test_negation(self):
-        matches = _parse_gitignore_string(
-            dedent(
-                """
-                *.ignore
-                !keep.ignore
-                """
-            ),
-            fake_base_dir="/home/michael",
-        )
-        self.assertTrue(matches("/home/michael/trash.ignore"))
-        self.assertFalse(matches("/home/michael/keep.ignore"))
-        self.assertTrue(matches("/home/michael/waste.ignore"))
 
-    def test_literal_exclamation_mark(self):
-        matches = _parse_gitignore_string(
-            "\\!ignore_me!", fake_base_dir="/home/michael"
-        )
-        self.assertTrue(matches("/home/michael/!ignore_me!"))
-        self.assertFalse(matches("/home/michael/ignore_me!"))
-        self.assertFalse(matches("/home/michael/ignore_me"))
+def test_comment():
+    matches = _parse_gitignore_string(
+        "\n".join(["somematch", "#realcomment", "othermatch", "\\#imnocomment"]),
+        fake_base_dir="/home/michael",
+    )
+    assert matches("/home/michael/somematch")
+    assert not matches("/home/michael/#realcomment")
+    assert matches("/home/michael/othermatch")
+    assert matches("/home/michael/#imnocomment")
 
-    def test_double_asterisks(self):
-        matches = _parse_gitignore_string("foo/**/Bar", fake_base_dir="/home/michael")
-        self.assertTrue(matches("/home/michael/foo/hello/Bar"))
-        self.assertTrue(matches("/home/michael/foo/world/Bar"))
-        self.assertTrue(matches("/home/michael/foo/Bar"))
-        self.assertFalse(matches("/home/michael/foo/BarBar"))
 
-    def test_double_asterisk_without_slashes_handled_like_single_asterisk(self):
-        matches = _parse_gitignore_string("a/b**c/d", fake_base_dir="/home/michael")
-        self.assertTrue(matches("/home/michael/a/bc/d"))
-        self.assertTrue(matches("/home/michael/a/bXc/d"))
-        self.assertTrue(matches("/home/michael/a/bbc/d"))
-        self.assertTrue(matches("/home/michael/a/bcc/d"))
-        self.assertFalse(matches("/home/michael/a/bcd"))
-        self.assertFalse(matches("/home/michael/a/b/c/d"))
-        self.assertFalse(matches("/home/michael/a/bb/cc/d"))
-        self.assertFalse(matches("/home/michael/a/bb/XX/cc/d"))
+def test_ignore_directory():
+    matches = _parse_gitignore_string(".venv/", fake_base_dir="/home/michael")
+    assert matches("/home/michael/.venv")
+    assert matches("/home/michael/.venv/folder")
+    assert matches("/home/michael/.venv/file.txt")
+    assert not matches("/home/michael/.venv_other_folder")
+    assert not matches("/home/michael/.venv_no_folder.py")
 
-    def test_more_asterisks_handled_like_single_asterisk(self):
-        matches = _parse_gitignore_string("***a/b", fake_base_dir="/home/michael")
-        self.assertTrue(matches("/home/michael/XYZa/b"))
-        self.assertFalse(matches("/home/michael/foo/a/b"))
-        matches = _parse_gitignore_string("a/b***", fake_base_dir="/home/michael")
-        self.assertTrue(matches("/home/michael/a/bXYZ"))
-        self.assertFalse(matches("/home/michael/a/b/foo"))
 
-    def test_directory_only_negation(self):
-        matches = _parse_gitignore_string(
-            dedent(
-                """
-                data/**
-                !data/**/
-                !.gitkeep
-                !data/01_raw/*
-                """
-            ),
-            fake_base_dir="/home/michael",
-        )
-        self.assertFalse(matches("/home/michael/data/01_raw/"))
-        self.assertFalse(matches("/home/michael/data/01_raw/.gitkeep"))
-        self.assertFalse(matches("/home/michael/data/01_raw/raw_file.csv"))
-        self.assertFalse(matches("/home/michael/data/02_processed/"))
-        self.assertFalse(matches("/home/michael/data/02_processed/.gitkeep"))
-        self.assertTrue(matches("/home/michael/data/02_processed/processed_file.csv"))
+def test_ignore_directory_asterisk():
+    matches = _parse_gitignore_string(".venv/*", fake_base_dir="/home/michael")
+    assert not matches("/home/michael/.venv")
+    assert matches("/home/michael/.venv/folder")
+    assert matches("/home/michael/.venv/file.txt")
 
-    def test_single_asterisk(self):
-        matches = _parse_gitignore_string("*", fake_base_dir="/home/michael")
-        self.assertTrue(matches("/home/michael/file.txt"))
-        self.assertTrue(matches("/home/michael/directory"))
-        self.assertTrue(matches("/home/michael/directory-trailing/"))
 
-    def test_supports_path_type_argument(self):
-        matches = _parse_gitignore_string(
-            "file1\n!file2", fake_base_dir="/home/michael"
-        )
-        self.assertTrue(matches(Path("/home/michael/file1")))
-        self.assertFalse(matches(Path("/home/michael/file2")))
+def test_negation():
+    matches = _parse_gitignore_string(
+        dedent(
+            """
+            *.ignore
+            !keep.ignore
+            """
+        ),
+        fake_base_dir="/home/michael",
+    )
+    assert matches("/home/michael/trash.ignore")
+    assert not matches("/home/michael/keep.ignore")
+    assert matches("/home/michael/waste.ignore")
 
-    def test_slash_in_range_does_not_match_dirs(self):
-        matches = _parse_gitignore_string("abc[X-Z/]def", fake_base_dir="/home/michael")
-        self.assertFalse(matches("/home/michael/abcdef"))
-        self.assertTrue(matches("/home/michael/abcXdef"))
-        self.assertTrue(matches("/home/michael/abcYdef"))
-        self.assertTrue(matches("/home/michael/abcZdef"))
-        self.assertFalse(matches("/home/michael/abc/def"))
-        self.assertFalse(matches("/home/michael/abcXYZdef"))
 
-    def test_symlink_to_another_directory(self):
-        """Test the behavior of a symlink to another directory.
+def test_literal_exclamation_mark():
+    matches = _parse_gitignore_string(
+        "\\!ignore_me!", fake_base_dir="/home/michael"
+    )
+    assert matches("/home/michael/!ignore_me!")
+    assert not matches("/home/michael/ignore_me!")
+    assert not matches("/home/michael/ignore_me")
 
-        The issue https://github.com/mherrmann/gitignore_parser/issues/29 describes how
-        a symlink to another directory caused an exception to be raised during matching.
 
-        This test ensures that the issue is now fixed.
-        """
-        with TemporaryDirectory() as project_dir, TemporaryDirectory() as another_dir:
-            matches = _parse_gitignore_string("link", fake_base_dir=project_dir)
+def test_double_asterisks():
+    matches = _parse_gitignore_string("foo/**/Bar", fake_base_dir="/home/michael")
+    assert matches("/home/michael/foo/hello/Bar")
+    assert matches("/home/michael/foo/world/Bar")
+    assert matches("/home/michael/foo/Bar")
+    assert not matches("/home/michael/foo/BarBar")
 
-            # Create a symlink to another directory.
-            link = Path(project_dir, "link")
-            target = Path(another_dir, "target")
-            link.symlink_to(target)
 
-            # Check the intended behavior according to
-            # https://git-scm.com/docs/gitignore#_notes:
-            # Symbolic links are not followed and are matched as if they were regular
-            # files.
-            self.assertTrue(matches(link))
+def test_double_asterisk_without_slashes_handled_like_single_asterisk():
+    matches = _parse_gitignore_string("a/b**c/d", fake_base_dir="/home/michael")
+    assert matches("/home/michael/a/bc/d")
+    assert matches("/home/michael/a/bXc/d")
+    assert matches("/home/michael/a/bbc/d")
+    assert matches("/home/michael/a/bcc/d")
+    assert not matches("/home/michael/a/bcd")
+    assert not matches("/home/michael/a/b/c/d")
+    assert not matches("/home/michael/a/bb/cc/d")
+    assert not matches("/home/michael/a/bb/XX/cc/d")
+
+
+def test_more_asterisks_handled_like_single_asterisk():
+    matches = _parse_gitignore_string("***a/b", fake_base_dir="/home/michael")
+    assert matches("/home/michael/XYZa/b")
+    assert not matches("/home/michael/foo/a/b")
+    matches = _parse_gitignore_string("a/b***", fake_base_dir="/home/michael")
+    assert matches("/home/michael/a/bXYZ")
+    assert not matches("/home/michael/a/b/foo")
+
+
+def test_directory_only_negation():
+    matches = _parse_gitignore_string(
+        dedent(
+            """
+            data/**
+            !data/**/
+            !.gitkeep
+            !data/01_raw/*
+            """
+        ),
+        fake_base_dir="/home/michael",
+    )
+    assert not matches("/home/michael/data/01_raw/")
+    assert not matches("/home/michael/data/01_raw/.gitkeep")
+    assert not matches("/home/michael/data/01_raw/raw_file.csv")
+    assert not matches("/home/michael/data/02_processed/")
+    assert not matches("/home/michael/data/02_processed/.gitkeep")
+    assert matches("/home/michael/data/02_processed/processed_file.csv")
+
+
+def test_single_asterisk():
+    matches = _parse_gitignore_string("*", fake_base_dir="/home/michael")
+    assert matches("/home/michael/file.txt")
+    assert matches("/home/michael/directory")
+    assert matches("/home/michael/directory-trailing/")
+
+
+def test_supports_path_type_argument():
+    matches = _parse_gitignore_string(
+        "file1\n!file2", fake_base_dir="/home/michael"
+    )
+    assert matches(Path("/home/michael/file1"))
+    assert not matches(Path("/home/michael/file2"))
+
+
+def test_slash_in_range_does_not_match_dirs():
+    matches = _parse_gitignore_string("abc[X-Z/]def", fake_base_dir="/home/michael")
+    assert not matches("/home/michael/abcdef")
+    assert matches("/home/michael/abcXdef")
+    assert matches("/home/michael/abcYdef")
+    assert matches("/home/michael/abcZdef")
+    assert not matches("/home/michael/abc/def")
+    assert not matches("/home/michael/abcXYZdef")
+
+
+def test_symlink_to_another_directory():
+    with TemporaryDirectory() as project_dir, TemporaryDirectory() as another_dir:
+        matches = _parse_gitignore_string("link", fake_base_dir=project_dir)
+
+        # Create a symlink to another directory.
+        link = Path(project_dir, "link")
+        target = Path(another_dir, "target")
+        link.symlink_to(target)
+
+        # Check the intended behavior according to
+        # https://git-scm.com/docs/gitignore#_notes:
+        # Symbolic links are not followed and are matched as if they were
+        # regular files.
+        assert matches(link)
 
 
 def _parse_gitignore_string(data: str, fake_base_dir: Optional[str] = None):
     with patch("builtins.open", mock_open(read_data=data)):
         success = parse_gitignore(f"{fake_base_dir}/.gitignore", fake_base_dir)
         return success
-
-
-if __name__ == "__main__":
-    main()

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Optional
 from unittest import TestCase, main
 from unittest.mock import mock_open, patch
 
@@ -195,7 +196,7 @@ data/**
             self.assertTrue(matches(link))
 
 
-def _parse_gitignore_string(data: str, fake_base_dir: str = None):
+def _parse_gitignore_string(data: str, fake_base_dir: Optional[str] = None):
     with patch("builtins.open", mock_open(read_data=data)):
         success = parse_gitignore(f"{fake_base_dir}/.gitignore", fake_base_dir)
         return success

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -1,3 +1,5 @@
+"""Verify behavior of gitignore_parser."""
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Optional
@@ -8,9 +10,12 @@ from fawltydeps.gitignore_parser import parse_gitignore
 
 
 class Test(TestCase):
+    """gitinore_parser test cases."""
+
     def test_simple(self):
         matches = _parse_gitignore_string(
-            "__pycache__/\n" "*.py[cod]", fake_base_dir="/home/michael"
+            "\n".join(["__pycache__/", "*.py[cod]"]),
+            fake_base_dir="/home/michael",
         )
         self.assertFalse(matches("/home/michael/main.py"))
         self.assertTrue(matches("/home/michael/main.pyc"))
@@ -43,11 +48,15 @@ class Test(TestCase):
 
     def test_trailingspaces(self):
         matches = _parse_gitignore_string(
-            "ignoretrailingspace \n"
-            "notignoredspace\\ \n"
-            "partiallyignoredspace\\  \n"
-            "partiallyignoredspace2 \\  \n"
-            "notignoredmultiplespace\\ \\ \\ ",
+            "\n".join(
+                [
+                    "ignoretrailingspace ",
+                    "notignoredspace\\ ",
+                    "partiallyignoredspace\\  ",
+                    "partiallyignoredspace2 \\  ",
+                    "notignoredmultiplespace\\ \\ \\ ",
+                ]
+            ),
             fake_base_dir="/home/michael",
         )
         self.assertTrue(matches("/home/michael/ignoretrailingspace"))
@@ -66,7 +75,7 @@ class Test(TestCase):
 
     def test_comment(self):
         matches = _parse_gitignore_string(
-            "somematch\n" "#realcomment\n" "othermatch\n" "\\#imnocomment",
+            "\n".join(["somematch", "#realcomment", "othermatch", "\\#imnocomment"]),
             fake_base_dir="/home/michael",
         )
         self.assertTrue(matches("/home/michael/somematch"))

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -218,13 +218,12 @@ test_vectors = [
 
 @pytest.mark.parametrize("vector", [pytest.param(v, id=v.id) for v in test_vectors])
 def test_gitignore_parser(vector: GitignoreParserTestVector):
-    matches = parse_gitignore_lines(
-        vector.patterns, vector.base_dir, Path(vector.base_dir, ".gitignore")
-    )
+    base_dir = Path(vector.base_dir)
+    matches = parse_gitignore_lines(vector.patterns, base_dir, base_dir / ".gitignore")
     for path in vector.does_match:
-        assert matches(path)
+        assert matches(Path(path), isinstance(path, str) and path.endswith("/"))
     for path in vector.doesnt_match:
-        assert not matches(path)
+        assert not matches(Path(path), isinstance(path, str) and path.endswith("/"))
 
 
 def test_symlink_to_another_directory(tmp_path):
@@ -238,4 +237,4 @@ def test_symlink_to_another_directory(tmp_path):
     matches = parse_gitignore_lines(["link"], project_dir, project_dir / ".gitignore")
     # Verify behavior according to https://git-scm.com/docs/gitignore#_notes:
     # Symlinks are not followed and are matched as if they were regular files.
-    assert matches(link)
+    assert matches(link, False)

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from textwrap import dedent
 from typing import Optional
 from unittest import TestCase, main
 from unittest.mock import mock_open, patch
@@ -99,10 +100,12 @@ class Test(TestCase):
 
     def test_negation(self):
         matches = _parse_gitignore_string(
-            """
-*.ignore
-!keep.ignore
-            """,
+            dedent(
+                """
+                *.ignore
+                !keep.ignore
+                """
+            ),
             fake_base_dir="/home/michael",
         )
         self.assertTrue(matches("/home/michael/trash.ignore"))
@@ -145,12 +148,14 @@ class Test(TestCase):
 
     def test_directory_only_negation(self):
         matches = _parse_gitignore_string(
-            """
-data/**
-!data/**/
-!.gitkeep
-!data/01_raw/*
-            """,
+            dedent(
+                """
+                data/**
+                !data/**/
+                !.gitkeep
+                !data/01_raw/*
+                """
+            ),
             fake_base_dir="/home/michael",
         )
         self.assertFalse(matches("/home/michael/data/01_raw/"))

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -17,39 +17,39 @@ def _parse(data: str, fake_base_dir: Optional[str] = None):
 def test_simple():
     matches = _parse(
         "\n".join(["__pycache__/", "*.py[cod]"]),
-        fake_base_dir="/home/michael",
+        fake_base_dir="/some/dir",
     )
-    assert not matches("/home/michael/main.py")
-    assert matches("/home/michael/main.pyc")
-    assert matches("/home/michael/dir/main.pyc")
-    assert matches("/home/michael/__pycache__")
+    assert not matches("/some/dir/main.py")
+    assert matches("/some/dir/main.pyc")
+    assert matches("/some/dir/dir/main.pyc")
+    assert matches("/some/dir/__pycache__")
 
 
 def test_incomplete_filename():
-    matches = _parse("o.py", fake_base_dir="/home/michael")
-    assert matches("/home/michael/o.py")
-    assert not matches("/home/michael/foo.py")
-    assert not matches("/home/michael/o.pyc")
-    assert matches("/home/michael/dir/o.py")
-    assert not matches("/home/michael/dir/foo.py")
-    assert not matches("/home/michael/dir/o.pyc")
+    matches = _parse("o.py", fake_base_dir="/some/dir")
+    assert matches("/some/dir/o.py")
+    assert not matches("/some/dir/foo.py")
+    assert not matches("/some/dir/o.pyc")
+    assert matches("/some/dir/dir/o.py")
+    assert not matches("/some/dir/dir/foo.py")
+    assert not matches("/some/dir/dir/o.pyc")
 
 
 def test_wildcard():
-    matches = _parse("hello.*", fake_base_dir="/home/michael")
-    assert matches("/home/michael/hello.txt")
-    assert matches("/home/michael/hello.foobar/")
-    assert matches("/home/michael/dir/hello.txt")
-    assert matches("/home/michael/hello.")
-    assert not matches("/home/michael/hello")
-    assert not matches("/home/michael/helloX")
+    matches = _parse("hello.*", fake_base_dir="/some/dir")
+    assert matches("/some/dir/hello.txt")
+    assert matches("/some/dir/hello.foobar/")
+    assert matches("/some/dir/dir/hello.txt")
+    assert matches("/some/dir/hello.")
+    assert not matches("/some/dir/hello")
+    assert not matches("/some/dir/helloX")
 
 
 def test_anchored_wildcard():
-    matches = _parse("/hello.*", fake_base_dir="/home/michael")
-    assert matches("/home/michael/hello.txt")
-    assert matches("/home/michael/hello.c")
-    assert not matches("/home/michael/a/hello.java")
+    matches = _parse("/hello.*", fake_base_dir="/some/dir")
+    assert matches("/some/dir/hello.txt")
+    assert matches("/some/dir/hello.c")
+    assert not matches("/some/dir/a/hello.java")
 
 
 def test_trailingspaces():
@@ -60,47 +60,47 @@ def test_trailingspaces():
         "partiallyignoredspace2 \\  ",
         "notignoredmultiplespace\\ \\ \\ ",
     ]
-    matches = _parse("\n".join(patterns), fake_base_dir="/home/michael")
-    assert matches("/home/michael/ignoretrailingspace")
-    assert not matches("/home/michael/ignoretrailingspace ")
-    assert matches("/home/michael/partiallyignoredspace ")
-    assert not matches("/home/michael/partiallyignoredspace  ")
-    assert not matches("/home/michael/partiallyignoredspace")
-    assert matches("/home/michael/partiallyignoredspace2  ")
-    assert not matches("/home/michael/partiallyignoredspace2   ")
-    assert not matches("/home/michael/partiallyignoredspace2 ")
-    assert not matches("/home/michael/partiallyignoredspace2")
-    assert matches("/home/michael/notignoredspace ")
-    assert not matches("/home/michael/notignoredspace")
-    assert matches("/home/michael/notignoredmultiplespace   ")
-    assert not matches("/home/michael/notignoredmultiplespace")
+    matches = _parse("\n".join(patterns), fake_base_dir="/some/dir")
+    assert matches("/some/dir/ignoretrailingspace")
+    assert not matches("/some/dir/ignoretrailingspace ")
+    assert matches("/some/dir/partiallyignoredspace ")
+    assert not matches("/some/dir/partiallyignoredspace  ")
+    assert not matches("/some/dir/partiallyignoredspace")
+    assert matches("/some/dir/partiallyignoredspace2  ")
+    assert not matches("/some/dir/partiallyignoredspace2   ")
+    assert not matches("/some/dir/partiallyignoredspace2 ")
+    assert not matches("/some/dir/partiallyignoredspace2")
+    assert matches("/some/dir/notignoredspace ")
+    assert not matches("/some/dir/notignoredspace")
+    assert matches("/some/dir/notignoredmultiplespace   ")
+    assert not matches("/some/dir/notignoredmultiplespace")
 
 
 def test_comment():
     matches = _parse(
         "\n".join(["somematch", "#realcomment", "othermatch", "\\#imnocomment"]),
-        fake_base_dir="/home/michael",
+        fake_base_dir="/some/dir",
     )
-    assert matches("/home/michael/somematch")
-    assert not matches("/home/michael/#realcomment")
-    assert matches("/home/michael/othermatch")
-    assert matches("/home/michael/#imnocomment")
+    assert matches("/some/dir/somematch")
+    assert not matches("/some/dir/#realcomment")
+    assert matches("/some/dir/othermatch")
+    assert matches("/some/dir/#imnocomment")
 
 
 def test_ignore_directory():
-    matches = _parse(".venv/", fake_base_dir="/home/michael")
-    assert matches("/home/michael/.venv")
-    assert matches("/home/michael/.venv/folder")
-    assert matches("/home/michael/.venv/file.txt")
-    assert not matches("/home/michael/.venv_other_folder")
-    assert not matches("/home/michael/.venv_no_folder.py")
+    matches = _parse(".venv/", fake_base_dir="/some/dir")
+    assert matches("/some/dir/.venv")
+    assert matches("/some/dir/.venv/folder")
+    assert matches("/some/dir/.venv/file.txt")
+    assert not matches("/some/dir/.venv_other_folder")
+    assert not matches("/some/dir/.venv_no_folder.py")
 
 
 def test_ignore_directory_asterisk():
-    matches = _parse(".venv/*", fake_base_dir="/home/michael")
-    assert not matches("/home/michael/.venv")
-    assert matches("/home/michael/.venv/folder")
-    assert matches("/home/michael/.venv/file.txt")
+    matches = _parse(".venv/*", fake_base_dir="/some/dir")
+    assert not matches("/some/dir/.venv")
+    assert matches("/some/dir/.venv/folder")
+    assert matches("/some/dir/.venv/file.txt")
 
 
 def test_negation():
@@ -111,49 +111,49 @@ def test_negation():
             !keep.ignore
             """
         ),
-        fake_base_dir="/home/michael",
+        fake_base_dir="/some/dir",
     )
-    assert matches("/home/michael/trash.ignore")
-    assert not matches("/home/michael/keep.ignore")
-    assert matches("/home/michael/waste.ignore")
+    assert matches("/some/dir/trash.ignore")
+    assert not matches("/some/dir/keep.ignore")
+    assert matches("/some/dir/waste.ignore")
 
 
 def test_literal_exclamation_mark():
     matches = _parse(
-        "\\!ignore_me!", fake_base_dir="/home/michael"
+        "\\!ignore_me!", fake_base_dir="/some/dir"
     )
-    assert matches("/home/michael/!ignore_me!")
-    assert not matches("/home/michael/ignore_me!")
-    assert not matches("/home/michael/ignore_me")
+    assert matches("/some/dir/!ignore_me!")
+    assert not matches("/some/dir/ignore_me!")
+    assert not matches("/some/dir/ignore_me")
 
 
 def test_double_asterisks():
-    matches = _parse("foo/**/Bar", fake_base_dir="/home/michael")
-    assert matches("/home/michael/foo/hello/Bar")
-    assert matches("/home/michael/foo/world/Bar")
-    assert matches("/home/michael/foo/Bar")
-    assert not matches("/home/michael/foo/BarBar")
+    matches = _parse("foo/**/Bar", fake_base_dir="/some/dir")
+    assert matches("/some/dir/foo/hello/Bar")
+    assert matches("/some/dir/foo/world/Bar")
+    assert matches("/some/dir/foo/Bar")
+    assert not matches("/some/dir/foo/BarBar")
 
 
 def test_double_asterisk_without_slashes_handled_like_single_asterisk():
-    matches = _parse("a/b**c/d", fake_base_dir="/home/michael")
-    assert matches("/home/michael/a/bc/d")
-    assert matches("/home/michael/a/bXc/d")
-    assert matches("/home/michael/a/bbc/d")
-    assert matches("/home/michael/a/bcc/d")
-    assert not matches("/home/michael/a/bcd")
-    assert not matches("/home/michael/a/b/c/d")
-    assert not matches("/home/michael/a/bb/cc/d")
-    assert not matches("/home/michael/a/bb/XX/cc/d")
+    matches = _parse("a/b**c/d", fake_base_dir="/some/dir")
+    assert matches("/some/dir/a/bc/d")
+    assert matches("/some/dir/a/bXc/d")
+    assert matches("/some/dir/a/bbc/d")
+    assert matches("/some/dir/a/bcc/d")
+    assert not matches("/some/dir/a/bcd")
+    assert not matches("/some/dir/a/b/c/d")
+    assert not matches("/some/dir/a/bb/cc/d")
+    assert not matches("/some/dir/a/bb/XX/cc/d")
 
 
 def test_more_asterisks_handled_like_single_asterisk():
-    matches = _parse("***a/b", fake_base_dir="/home/michael")
-    assert matches("/home/michael/XYZa/b")
-    assert not matches("/home/michael/foo/a/b")
-    matches = _parse("a/b***", fake_base_dir="/home/michael")
-    assert matches("/home/michael/a/bXYZ")
-    assert not matches("/home/michael/a/b/foo")
+    matches = _parse("***a/b", fake_base_dir="/some/dir")
+    assert matches("/some/dir/XYZa/b")
+    assert not matches("/some/dir/foo/a/b")
+    matches = _parse("a/b***", fake_base_dir="/some/dir")
+    assert matches("/some/dir/a/bXYZ")
+    assert not matches("/some/dir/a/b/foo")
 
 
 def test_directory_only_negation():
@@ -166,39 +166,39 @@ def test_directory_only_negation():
             !data/01_raw/*
             """
         ),
-        fake_base_dir="/home/michael",
+        fake_base_dir="/some/dir",
     )
-    assert not matches("/home/michael/data/01_raw/")
-    assert not matches("/home/michael/data/01_raw/.gitkeep")
-    assert not matches("/home/michael/data/01_raw/raw_file.csv")
-    assert not matches("/home/michael/data/02_processed/")
-    assert not matches("/home/michael/data/02_processed/.gitkeep")
-    assert matches("/home/michael/data/02_processed/processed_file.csv")
+    assert not matches("/some/dir/data/01_raw/")
+    assert not matches("/some/dir/data/01_raw/.gitkeep")
+    assert not matches("/some/dir/data/01_raw/raw_file.csv")
+    assert not matches("/some/dir/data/02_processed/")
+    assert not matches("/some/dir/data/02_processed/.gitkeep")
+    assert matches("/some/dir/data/02_processed/processed_file.csv")
 
 
 def test_single_asterisk():
-    matches = _parse("*", fake_base_dir="/home/michael")
-    assert matches("/home/michael/file.txt")
-    assert matches("/home/michael/directory")
-    assert matches("/home/michael/directory-trailing/")
+    matches = _parse("*", fake_base_dir="/some/dir")
+    assert matches("/some/dir/file.txt")
+    assert matches("/some/dir/directory")
+    assert matches("/some/dir/directory-trailing/")
 
 
 def test_supports_path_type_argument():
     matches = _parse(
-        "file1\n!file2", fake_base_dir="/home/michael"
+        "file1\n!file2", fake_base_dir="/some/dir"
     )
-    assert matches(Path("/home/michael/file1"))
-    assert not matches(Path("/home/michael/file2"))
+    assert matches(Path("/some/dir/file1"))
+    assert not matches(Path("/some/dir/file2"))
 
 
 def test_slash_in_range_does_not_match_dirs():
-    matches = _parse("abc[X-Z/]def", fake_base_dir="/home/michael")
-    assert not matches("/home/michael/abcdef")
-    assert matches("/home/michael/abcXdef")
-    assert matches("/home/michael/abcYdef")
-    assert matches("/home/michael/abcZdef")
-    assert not matches("/home/michael/abc/def")
-    assert not matches("/home/michael/abcXYZdef")
+    matches = _parse("abc[X-Z/]def", fake_base_dir="/some/dir")
+    assert not matches("/some/dir/abcdef")
+    assert matches("/some/dir/abcXdef")
+    assert matches("/some/dir/abcYdef")
+    assert matches("/some/dir/abcZdef")
+    assert not matches("/some/dir/abc/def")
+    assert not matches("/some/dir/abcXYZdef")
 
 
 def test_symlink_to_another_directory(tmp_path):

--- a/tests/test_traverse_project.py
+++ b/tests/test_traverse_project.py
@@ -6,7 +6,7 @@ from typing import Optional, Set, Type
 
 import pytest
 
-from fawltydeps.dir_traversal import ExcludeRuleError, ExcludeRuleMissing
+from fawltydeps.gitignore_parser import RuleError, RuleMissing
 from fawltydeps.settings import ParserChoice, Settings
 from fawltydeps.traverse_project import find_sources
 from fawltydeps.types import (
@@ -517,31 +517,31 @@ find_sources_vectors = [
     # Test invalid 'exclude':
     #
     TraverseProjectVector(
-        "empty_exclude_pattern__raises_ExcludeRuleMissing",
+        "empty_exclude_pattern__raises_RuleMissing",
         "empty",
         code=set(),
         deps=set(),
         pyenvs=set(),
         exclude={"", "\t", "    "},
-        expect_raised=ExcludeRuleMissing,
+        expect_raised=RuleMissing,
     ),
     TraverseProjectVector(
-        "comment_exclude_pattern__raises_ExcludeRuleMissing",
+        "comment_exclude_pattern__raises_RuleMissing",
         "empty",
         code=set(),
         deps=set(),
         pyenvs=set(),
         exclude={"# a comment", "# another comment"},
-        expect_raised=ExcludeRuleMissing,
+        expect_raised=RuleMissing,
     ),
     TraverseProjectVector(
-        "anchored_exclude_pattern_without_basedir__raises_ExcludeRuleError",
+        "anchored_exclude_pattern_without_basedir__raises_RuleError",
         "empty",
         code=set(),
         deps=set(),
         pyenvs=set(),
         exclude={"foo/bar"},
-        expect_raised=ExcludeRuleError,
+        expect_raised=RuleError,
     ),
     TraverseProjectVector(
         "disabling_default_exclude__causes_hidden_files_to_be_found",


### PR DESCRIPTION
For once, I'm _not_ going to suggest reviewing this on a commit-by-commit basis, as there are a lot of small commits here mainly to reassure myself that I'm not breaking anything along the way.

Looking at the total diff will give a better view of the net changes introduced here. Most of the added code is of course the `gitignore_parser` itself and its existing test suite. Both are rewritten fairly heavily in order to fit better into our style.

Still, I feel reasonably safe about these changes given the amount of test coverage we have in total now.
