### PR TITLE
Reintroduce current Python environment as a separate level in our resolver stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ customization options are summarized in the table below:
 | Priority | Mapping strategy        | Options |
 |----------|----------------------|------------|
 | 1        | User-defined mapping | Provide a custom mapping in TOML format via `--custom-mapping-file` or a `[tool.fawltydeps.custom_mapping]` section in `pyproject.toml`. <br /> Default: No custom mapping|
-| 2        | Mapping from installed packages | Point to one or more environments via `--pyenv`.<br />Default: auto-discovery of Python environments under the project’s basepath. If none are found, default to the Python environment in which FawltyDeps itself is installed.|
-| 3a       | Mapping via temporary installation of packages  | Activated with the `--install-deps` option.|
-| 3b       | Identity mapping | Active by default. Deactivated when `--install-deps` is used. |
+| 2        | Mapping from installed packages found inside project | Point to one or more environments with `--pyenv`.<br />Default: auto-discovery of Python environments under the project’s basepath.|
+| 3        | Mapping from packages installed in `sys.path` | Active by default. No CLI option. This finds packages installed in the Python environment in which FawltyDeps itself runs.|
+| 4a       | Mapping via temporary installation of packages  | Activated with the `--install-deps` option.|
+| 4b       | Identity mapping | Active by default. Deactivated when `--install-deps` is used. |
 
 
 #### Local Python environment mapping
@@ -193,18 +194,19 @@ If `--pyenv` is not used, FawltyDeps will look for _Python environments_
 (virtualenvs or similar directories like `.venv` or `__pypackages__`.) inside
 your project (i.e. under `basepath`, if given, or the current directory).
 
-If no Python environments are found within your project, FawltyDeps will fall
-back to looking at your _current Python environment_: This is the environment
-in which FawltyDeps itself is installed.
-
-This works well when you, for example, `pip install fawltydeps` into the same
-virtualenv as your project dependencies.
-
 You can use `--pyenv` multiple times to have FawltyDeps look for packages in
 multiple Python environments. In this case (or when multiple Python environments
 are found inside your project) FawltyDeps will use the union (superset) of all
 imports provided by all matching packages across those Python environments as
 valid import names for that dependency.
+
+#### Current Python environment
+
+In addition to the local Python environments found above, FawltyDeps will also
+look at your _current Python environment_, i.e. the environment in which
+FawltyDeps itself is installed. This works well when you, for example,
+`pip install fawltydeps` into the same virtualenv as your project dependencies,
+no matter where this virtualenv may be located.
 
 #### Identity mapping
 
@@ -364,8 +366,7 @@ Here is a complete list of configuration directives we support:
 - `pyenvs`: Where to look for Python environments (directories like `.venv`,
   `__pypackages__`, or similar) to be used for resolving project dependencies
   into provided import names. Defaults to looking for Python environments under
-  the current directory, i.e. like `pyenvs = ["."]`. If none are found, use the
-  Python environment where FawltyDeps is installed (aka. `sys.path`).
+  the current directory, i.e. like `pyenvs = ["."]`.
 - `ignore_undeclared`: A list of specific dependencies to ignore when reporting
   undeclared dependencies, for example: `["some_module", "some_other_module"]`.
   The default is the empty list: `ignore_undeclared = []`.
@@ -537,10 +538,10 @@ To solve this, FawltyDeps looks at the packages installed in your Python
 environment to correctly map dependencies (package names) into the imports that
 they provide. This is:
 
-- any Python environment found via the `--pyenv` option, or
-- any Python environment found within your project (`basepath` or the current
-  directory).
-- Failing that, FawltyDeps will use the _current Python environment_,
+- any Python environment found via the `--pyenv` option,
+- or if `--pyenv` is not given: any Python environment found within your
+  project (`basepath` or the current directory).
+- In addition, FawltyDeps will use the _current Python environment_,
   i.e. the one in which FawltyDeps itself is running.
 
 As a final resort, when an installed package is not found for a declared

--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -177,8 +177,7 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         help=(
             "Where to search for Python environments that have project"
             " dependencies installed. Defaults to searching under basepaths"
-            " (see above). If no environments are found, fall back to using the"
-            " Python environment where FawltyDeps is installed."
+            " (see above)."
         ),
     )
     parser.add_argument(

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -140,14 +140,14 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
     @calculated_once
     def resolved_deps(self) -> Dict[str, Package]:
         """The resolved mapping of dependency names to provided import names."""
+        pyenv_srcs = {src for src in self.sources if isinstance(src, PyEnvSource)}
         return resolve_dependencies(
             (dep.name for dep in self.declared_deps),
             setup_resolvers(
                 custom_mapping_files=self.settings.custom_mapping_file,
                 custom_mapping=self.settings.custom_mapping,
-                pyenv_srcs={
-                    src for src in self.sources if isinstance(src, PyEnvSource)
-                },
+                pyenv_srcs=pyenv_srcs,
+                use_current_env=not pyenv_srcs,
                 install_deps=self.settings.install_deps,
             ),
         )

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -147,7 +147,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
                 custom_mapping_files=self.settings.custom_mapping_file,
                 custom_mapping=self.settings.custom_mapping,
                 pyenv_srcs=pyenv_srcs,
-                use_current_env=not pyenv_srcs,
+                use_current_env=True,
                 install_deps=self.settings.install_deps,
             ),
         )

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -505,7 +505,10 @@ def setup_resolvers(
         mapping_paths=custom_mapping_files or set(), custom_mapping=custom_mapping
     )
 
-    yield LocalPackageResolver(pyenv_srcs, use_current_env)
+    yield LocalPackageResolver(pyenv_srcs, False)
+
+    if use_current_env:
+        yield LocalPackageResolver(frozenset(), True)
 
     if install_deps:
         yield TemporaryPipInstallResolver()

--- a/noxfile.py
+++ b/noxfile.py
@@ -88,7 +88,7 @@ def self_test(session):
     install_groups(session, include=["nox", "test", "lint", "format", "dev"])
     # For --pyenv, use Nox's virtualenv, or fall back to current virtualenv
     venv_path = getattr(session.virtualenv, "location", sys.prefix)
-    session.run("fawltydeps", f"--pyenv={venv_path}")
+    session.run("fawltydeps")
 
 
 @nox.session(python=python_versions)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -949,7 +949,7 @@ def test_check_json__no_pyenvs_found__falls_back_to_current_env(fake_project):
             "pip-requirements-parser": {
                 "package_name": "pip_requirements_parser",
                 "import_names": ["packaging_legacy_version", "pip_requirements_parser"],
-                "resolved_with": "LocalPackageResolver",
+                "resolved_with": "SysPathPackageResolver",
                 "debug_info": {
                     f"{site_packages}": [
                         "packaging_legacy_version",

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -9,6 +9,7 @@ from fawltydeps.packages import (
     IdentityMapping,
     LocalPackageResolver,
     Package,
+    SysPathPackageResolver,
     UserDefinedMapping,
     resolve_dependencies,
     setup_resolvers,
@@ -278,12 +279,12 @@ def test_user_defined_mapping__no_input__returns_empty_mapping():
         ),
     ],
 )
-def test_LocalPackageResolver_lookup_packages(
+def test_SysPathPackageResolver_lookup_packages(
     isolate_default_resolver, dep_name, expect_import_names
 ):
     isolate_default_resolver(default_sys_path_env_for_tests)
-    lpl = LocalPackageResolver(use_current_env=True)
-    actual = lpl.lookup_packages({dep_name})
+    sys_path = SysPathPackageResolver()
+    actual = sys_path.lookup_packages({dep_name})
     if expect_import_names is None:
         assert actual == {}
     else:
@@ -307,7 +308,7 @@ def test_resolve_dependencies__informs_once_when_id_mapping_is_used(
     dep_names = ["some-foo", "pip", "some-foo"]
     isolate_default_resolver(default_sys_path_env_for_tests)
     expect = {
-        "pip": Package("pip", {"pip"}, LocalPackageResolver),
+        "pip": Package("pip", {"pip"}, SysPathPackageResolver),
         "some-foo": Package("some-foo", {"some_foo"}, IdentityMapping),
     }
     expect_log = [

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -282,7 +282,7 @@ def test_LocalPackageResolver_lookup_packages(
     isolate_default_resolver, dep_name, expect_import_names
 ):
     isolate_default_resolver(default_sys_path_env_for_tests)
-    lpl = LocalPackageResolver()
+    lpl = LocalPackageResolver(use_current_env=True)
     actual = lpl.lookup_packages({dep_name})
     if expect_import_names is None:
         assert actual == {}
@@ -296,7 +296,7 @@ def test_resolve_dependencies(vector, isolate_default_resolver):
     dep_names = [dd.name for dd in vector.declared_deps]
     isolate_default_resolver(default_sys_path_env_for_tests)
     actual = ignore_package_debug_info(
-        resolve_dependencies(dep_names, setup_resolvers())
+        resolve_dependencies(dep_names, setup_resolvers(use_current_env=True))
     )
     assert actual == vector.expect_resolved_deps
 
@@ -319,7 +319,7 @@ def test_resolve_dependencies__informs_once_when_id_mapping_is_used(
     ]
     caplog.set_level(logging.INFO)
     actual = ignore_package_debug_info(
-        resolve_dependencies(dep_names, setup_resolvers())
+        resolve_dependencies(dep_names, setup_resolvers(use_current_env=True))
     )
     assert actual == expect
     assert caplog.record_tuples == expect_log

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -10,8 +10,8 @@ from hypothesis import strategies as st
 
 from fawltydeps.packages import (
     IdentityMapping,
-    LocalPackageResolver,
     Package,
+    SysPathPackageResolver,
     TemporaryPipInstallResolver,
     UserDefinedMapping,
     resolve_dependencies,
@@ -86,7 +86,7 @@ def generate_expected_resolved_deps(
     ret = {}
     ret.update(
         {
-            dep: Package(dep, imports, LocalPackageResolver)
+            dep: Package(dep, imports, SysPathPackageResolver)
             for dep, imports in locally_installed_deps.items()
         }
     )

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -193,6 +193,7 @@ def test_resolve_dependencies__generates_expected_mappings(
                 if custom_mapping_file
                 else None,
                 custom_mapping=user_config_mapping,
+                use_current_env=True,
                 install_deps=install_deps,
             ),
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
 from fawltydeps.main import main
-from fawltydeps.packages import IdentityMapping, LocalPackageResolver, Package
+from fawltydeps.packages import IdentityMapping, Package, SysPathPackageResolver
 from fawltydeps.types import (
     DeclaredDependency,
     Location,
@@ -79,7 +79,7 @@ def resolved_factory(*deps: str) -> Dict[str, Package]:
     def make_package(dep: str) -> Package:
         imports = default_sys_path_env_for_tests.get(dep, None)
         if imports is not None:  # exists in local env
-            return Package(dep, imports, LocalPackageResolver)
+            return Package(dep, imports, SysPathPackageResolver)
         # fall back to identity mapping
         return Package(dep, {dep}, IdentityMapping)
 
@@ -285,8 +285,8 @@ test_vectors = [
             DeclaredDependency(name="pip", source=Location(Path("requirements2.txt"))),
         ],
         expect_resolved_deps={
-            "Pip": Package("pip", {"pip"}, LocalPackageResolver),
-            "pip": Package("pip", {"pip"}, LocalPackageResolver),
+            "Pip": Package("pip", {"pip"}, SysPathPackageResolver),
+            "pip": Package("pip", {"pip"}, SysPathPackageResolver),
         },
         expect_unused_deps=[
             UnusedDependency("Pip", [Location(Path("requirements1.txt"))]),


### PR DESCRIPTION
Fixes #392.

We foresee no harm or significant cost by simply using the current Python environment as a separate step in FawltyDeps' resolver stack.

The step is introduced _after_ any other local environments (found inside the project), but before we either fall back to then expensive `TemporaryPipInstallResolver`, or the suboptimal `IdentityMapping`.

As explained in the third commit message, this is somewhat of a return to our roots:
> In fact, this is partially a return to our pre v0.7 behavior where we would always (then: only) find packages in `sys.path`. Since v0.7 we allowed `--pyenv` to override this, and since v0.12, we also started searching for pyenvs under `--pyenv` or `basepaths` given on the command line. The result of this is that by now, the current environment is only consulted in the fallback where no other environment is possibly found.

Commits:
- Preparation:
  - `packages`: Expose decision to use current env to resolve packages
  - `packages`: Start separating handling of project pyenvs from current env
- Fix:
  - Always include current env in the package resolver stack
- Cleanup:
  - `packages`: Split `SysPathPackageResolver` out of `LocalPackageResolver`
