### PR TITLE
MacOS and Windows support

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        os: [ubuntu-22.04]
+        os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/self_test.yaml
+++ b/.github/workflows/self_test.yaml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-22.04]
+        os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -149,7 +149,7 @@ def parse_setup_cfg(path: Path) -> Iterator[DeclaredDependency]:
         # TODO: try leveraging RequirementsFile.from_string once
         #       pip-requirements-parser updates.
         # See:  https://github.com/nexB/pip-requirements-parser/pull/17
-        with NamedTemporaryFile(mode="wt") as tmp:
+        with NamedTemporaryFile(mode="wt", delete=False) as tmp:
             tmp.write(value)
             tmp.flush()
             for dep in parse_requirements_txt(Path(tmp.name)):

--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -152,7 +152,7 @@ def parse_setup_cfg(path: Path) -> Iterator[DeclaredDependency]:
         # See:  https://github.com/nexB/pip-requirements-parser/pull/17
 
         # https://github.com/nexB/pip-requirements-parser/pull/19#discussion_r1379279880
-        temp_file = NamedTemporaryFile( # pylint: disable=consider-using-with
+        temp_file = NamedTemporaryFile(  # pylint: disable=consider-using-with
             "wt",
             delete=False,
             # we prefer utf8 encoded strings, but ...

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -433,11 +433,10 @@ class TemporaryPipInstallResolver(BasePackageResolver):
             text=True,
             check=False,
         )
-        pip_path = (
-            venv_dir / "Scripts" / "pip.exe"
-            if platform.system() == "Windows"
-            else venv_dir / "bin" / "pip"
-        )
+        if sys.platform.startswith("win"):  # Windows
+            pip_path = venv_dir / "Scripts" / "pip.exe"
+        else:  # Assume POSIX
+            pip_path = venv_dir / "bin" / "pip"
 
         argv = [
             f"{pip_path}",

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -1,6 +1,7 @@
 """Encapsulate the lookup of packages and their provided import names."""
 
 import logging
+import os
 import platform
 import subprocess
 import sys
@@ -340,6 +341,15 @@ class LocalPackageResolver(InstalledPackageResolver):
         # Workaround for projects using PEP582:
         if path.name == "__pypackages__":
             for site_packages in path.glob("?.*/lib"):
+                if site_packages.is_dir():
+                    yield site_packages
+                    found = True
+            if found:
+                return
+
+        # Check for packages on Windows
+        if platform.system() == "Windows":
+            for site_packages in path.glob(os.path.join("Lib", "site-packages")):
                 if site_packages.is_dir():
                     yield site_packages
                     found = True

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import platform
 import subprocess
 import sys
 import tempfile
@@ -348,7 +347,7 @@ class LocalPackageResolver(InstalledPackageResolver):
                 return
 
         # Check for packages on Windows
-        if platform.system() == "Windows":
+        if sys.platform.startswith("win"):
             for site_packages in path.glob(os.path.join("Lib", "site-packages")):
                 if site_packages.is_dir():
                     yield site_packages

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -1,6 +1,7 @@
 """Encapsulate the lookup of packages and their provided import names."""
 
 import logging
+import platform
 import subprocess
 import sys
 import tempfile
@@ -422,8 +423,14 @@ class TemporaryPipInstallResolver(BasePackageResolver):
             text=True,
             check=False,
         )
+        pip_path = (
+            venv_dir / "Scripts" / "pip.exe"
+            if platform.system() == "Windows"
+            else venv_dir / "bin" / "pip"
+        )
+
         argv = [
-            f"{venv_dir}/bin/pip",
+            f"{pip_path}",
             "install",
             "--no-deps",
             "--quiet",

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -1,7 +1,6 @@
 """Common types used across FawltyDeps."""
 
 import os
-import platform
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass, field, replace
@@ -158,7 +157,7 @@ class PyEnvSource(Source):
             return  # also ok
 
         # Support Windows projects
-        if platform.system() == "Windows" and self.path.match(
+        if sys.platform.startswith("win") and self.path.match(
             os.path.join("Lib", "site-packages")
         ):
             return  # also ok

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -1,5 +1,7 @@
 """Common types used across FawltyDeps."""
 
+import os
+import platform
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass, field, replace
@@ -153,6 +155,12 @@ class PyEnvSource(Source):
                 return  # all ok
         # Also support projects using __pypackages__ from PEP582:
         elif self.path.match("__pypackages__/?.*/lib"):
+            return  # also ok
+
+        # Support Windows projects
+        if platform.system() == "Windows" and self.path.match(
+            os.path.join("Lib", "site-packages")
+        ):
             return  # also ok
 
         raise ValueError(f"{self.path} is not a valid dir for Python packages!")

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -1,6 +1,5 @@
 """Common types used across FawltyDeps."""
 
-import os
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass, field, replace

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -100,7 +100,7 @@ class CodeSource(Source):
 
     def render(self, detailed: bool) -> str:
         if detailed and self.base_dir is not None:
-            return f"{self.path} (using {self.base_dir}/ as base for 1st-party imports)"
+            return f"{self.path} (using {self.base_dir} as base for 1st-party imports)"
         return f"{self.path}"
 
 

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -148,18 +148,20 @@ class PyEnvSource(Source):
     def __post_init__(self) -> None:
         super().__post_init__()
         assert self.path.is_dir()  # sanity check
-        # Support vitualenvs, poetry2nix envs, system-wide installs, etc.
-        if self.path.match("lib/python?.*/site-packages"):
-            if (self.path.parent.parent.parent / "bin/python").is_file():
-                return  # all ok
-        # Also support projects using __pypackages__ from PEP582:
-        elif self.path.match("__pypackages__/?.*/lib"):
-            return  # also ok
 
         # Support Windows projects
-        if sys.platform.startswith("win") and self.path.match(
-            os.path.join("Lib", "site-packages")
-        ):
+        if sys.platform.startswith("win"):
+            if self.path.match(str(Path("Lib", "site-packages"))):
+                if (self.path.parent.parent / "Scripts" / "python.exe").is_file():
+                    return  # also ok
+        # Support vitualenvs, poetry2nix envs, system-wide installs, etc.
+        else:
+            if self.path.match("lib/python?.*/site-packages"):
+                if (self.path.parent.parent.parent / "bin/python").is_file():
+                    return  # all ok
+
+        # Also support projects using __pypackages__ from PEP582:
+        if self.path.match("__pypackages__/?.*/lib"):
             return  # also ok
 
         raise ValueError(f"{self.path} is not a valid dir for Python packages!")

--- a/fawltydeps/utils.py
+++ b/fawltydeps/utils.py
@@ -1,6 +1,7 @@
 """Common utilities"""
 
 import logging
+import sys
 from dataclasses import is_dataclass
 from functools import wraps
 from pathlib import Path
@@ -73,3 +74,14 @@ def calculated_once(method: Callable[[Instance], T]) -> Callable[[Instance], T]:
         return calculated
 
     return wrapper
+
+
+def site_packages(venv_dir: Path = Path()) -> Path:
+    """Return the site-packages directory of a virtual environment.
+    Works for both, Windows and POSIX."""
+    # Windows
+    if sys.platform.startswith("win"):
+        return venv_dir / "Lib" / "site-packages"
+    # Assume POSIX
+    major, minor = sys.version_info[:2]
+    return venv_dir / f"lib/python{major}.{minor}/site-packages"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ profile = "black"
 main.jobs = 4
 main.py-version = "3.7"
 reports.output-format = "colorized"
-"messages control".disable = "fixme,logging-fstring-interpolation,unspecified-encoding,too-few-public-methods,consider-using-in,duplicate-code"
+"messages control".disable = "fixme,logging-fstring-interpolation,unspecified-encoding,too-few-public-methods,consider-using-in,duplicate-code,too-many-locals,too-many-branches"
 
 [tool.mypy]
 files = ['*.py', 'fawltydeps/*.py', 'tests/*.py']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 """Fixtures for tests"""
-import platform
 import sys
 import venv
 from pathlib import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import pytest
 from fawltydeps.types import TomlData
 
 from .project_helpers import TarballPackage
+from .utils import site_packages
 
 
 @pytest.fixture
@@ -53,15 +54,7 @@ def fake_venv(tmp_path):
             venv_dir.parent.mkdir(parents=True, exist_ok=True)
         venv.create(venv_dir, with_pip=False)
 
-        # Create fake packages
-        major, minor = py_version
-
-        def _env_site_packages():
-            if platform.system() == "Windows":
-                return venv_dir / "Lib" / "site-packages"
-            return venv_dir / "lib" / f"python{major}.{minor}" / "site-packages"
-
-        site_dir = _env_site_packages()
+        site_dir = site_packages(venv_dir)
         assert site_dir.is_dir()
         for package_name, import_names in fake_packages.items():
             # Create just enough files under site_dir to fool importlib_metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for tests"""
+import platform
 import sys
 import venv
 from pathlib import Path
@@ -54,7 +55,13 @@ def fake_venv(tmp_path):
 
         # Create fake packages
         major, minor = py_version
-        site_dir = venv_dir / f"lib/python{major}.{minor}/site-packages"
+
+        def _env_site_packages():
+            if platform.system() == "Windows":
+                return venv_dir / "Lib" / "site-packages"
+            return venv_dir / "lib" / f"python{major}.{minor}" / "site-packages"
+
+        site_dir = _env_site_packages()
         assert site_dir.is_dir()
         for package_name, import_names in fake_packages.items():
             # Create just enough files under site_dir to fool importlib_metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,9 @@ from typing import Callable, Dict, List, Optional, Set, Tuple, Union
 import pytest
 
 from fawltydeps.types import TomlData
+from fawltydeps.utils import site_packages
 
 from .project_helpers import TarballPackage
-from .utils import site_packages
 
 
 @pytest.fixture

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -101,7 +101,7 @@ class TarballPackage:
 
     @property
     def cache_key(self) -> str:
-        return f"fawltydeps/{self.tarball_name()}"
+        return os.path.join("fawltydeps", f"{self.tarball_name()}")
 
     def tarball_path(self, cache: pytest.Cache) -> Path:
         return self.cache_dir(cache) / self.tarball_name()
@@ -166,7 +166,7 @@ class CachedExperimentVenv:
         script or the requirements to create that venv change.
         """
         # We cache venv dirs using the hash from create_venv_hash
-        cached_str = cache.get(f"fawltydeps/{self.venv_hash()}", None)
+        cached_str = cache.get(os.path.join("fawltydeps", f"{self.venv_hash()}"), None)
         if cached_str is not None and Path(cached_str, ".installed").is_file():
             return Path(cached_str)  # already cached
 
@@ -174,6 +174,7 @@ class CachedExperimentVenv:
         venv_dir = Path(cache.mkdir(f"fawltydeps_venv_{self.venv_hash()}"))
         logger.info(f"Creating venv at {venv_dir}...")
         venv_script = self.venv_script_lines(venv_dir)
+
         subprocess.run(
             " && ".join(venv_script),
             check=True,  # fail if any of the commands fail
@@ -181,7 +182,7 @@ class CachedExperimentVenv:
         )
         # Make sure the venv has been installed
         assert (venv_dir / ".installed").is_file()
-        cache.set(f"fawltydeps/{self.venv_hash()}", str(venv_dir))
+        cache.set(os.path.join("fawltydeps", f"{self.venv_hash()}"), str(venv_dir))
         return venv_dir
 
 

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -102,7 +102,7 @@ class TarballPackage:
 
     @property
     def cache_key(self) -> str:
-        return os.path.join("fawltydeps", f"{self.tarball_name()}")
+        return str(Path("fawltydeps", self.tarball_name()))
 
     def tarball_path(self, cache: pytest.Cache) -> Path:
         return self.cache_dir(cache) / self.tarball_name()
@@ -186,7 +186,7 @@ class CachedExperimentVenv:
         script or the requirements to create that venv change.
         """
         # We cache venv dirs using the hash from create_venv_hash
-        cached_str = cache.get(os.path.join("fawltydeps", f"{self.venv_hash()}"), None)
+        cached_str = cache.get(str(Path("fawltydeps", self.venv_hash())), None)
         if cached_str is not None and Path(cached_str, ".installed").is_file():
             return Path(cached_str)  # already cached
 
@@ -202,7 +202,7 @@ class CachedExperimentVenv:
         )
         # Make sure the venv has been installed
         assert (venv_dir / ".installed").is_file()
-        cache.set(os.path.join("fawltydeps", f"{self.venv_hash()}"), str(venv_dir))
+        cache.set(str(Path("fawltydeps", self.venv_hash())), str(venv_dir))
         return venv_dir
 
 

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -1,6 +1,7 @@
 """Common helpers shared between test_real_project and test_sample_projects."""
 import hashlib
 import logging
+import os
 import shlex
 import subprocess
 import sys
@@ -150,7 +151,7 @@ class CachedExperimentVenv:
         The Python version currently used to run the tests is used to compute
         the hash and create the venv.
         """
-        dummy_script = self.venv_script_lines(Path("/dev/null"))
+        dummy_script = self.venv_script_lines(Path(os.devnull))
         py_version = f"{sys.version_info.major},{sys.version_info.minor}"
         script_and_version_bytes = ("".join(dummy_script) + py_version).encode()
         return hashlib.sha256(script_and_version_bytes).hexdigest()

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -2,7 +2,6 @@
 import hashlib
 import logging
 import os
-import platform
 import shlex
 import subprocess
 import sys
@@ -128,7 +127,7 @@ class CachedExperimentVenv:
     requirements: List[str]  # PEP 508 requirements, passed to 'pip install'
 
     def venv_script_lines(self, venv_path: Path) -> List[str]:
-        if platform.system() == "Windows":
+        if sys.platform.startswith("win"):
             pip_path = venv_path / "Scripts" / "pip.exe"
             python_path = venv_path / "Scripts" / "python.exe"
             return (

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -296,7 +296,6 @@ class BaseExperiment(ABC):
 
     def get_venv_dir(self, cache: pytest.Cache) -> Path:
         """Get this venv's dir and create it if necessary."""
-        print(f"EXPERIMENT REQUIREMENTS: {self.requirements}")
         return CachedExperimentVenv(self.requirements)(cache)
 
 

--- a/tests/real_projects/python-algorithms.toml
+++ b/tests/real_projects/python-algorithms.toml
@@ -123,7 +123,7 @@ requirements = [
     "scikit-learn",
     "statsmodels",
     "sympy",
-    "tensorflow; python_version < \"3.11\"",
+    "tensorflow; python_version < '3.11'",
     "texttable",
     "tweepy",
     "xgboost",

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -452,7 +452,9 @@ def test_list_sources__in_varied_project__lists_all_files(fake_project):
             "pyproject.toml",
             "setup.py",
             "setup.cfg",
-            f"my_venv/lib/python{major}.{minor}/site-packages",
+            os.path.join("my_venv", "Lib", "site-packages")
+            if platform.system() == "Windows"
+            else f"my_venv/lib/python{major}.{minor}/site-packages",
         ]
     ]
     assert_unordered_equivalence(output.splitlines()[:-2], expect)
@@ -497,8 +499,19 @@ def test_list_sources_detailed__in_varied_project__lists_all_files(fake_project)
     ]
     major, minor = sys.version_info[:2]
     expect_pyenv_lines = [
-        f"  {tmp_path}/my_venv/lib/python{major}.{minor}/site-packages "
-        + "(as a source of Python packages)",
+        (
+            "  " + str(tmp_path / "my_venv" / "Lib" / "site-packages")
+            if platform.system() == "Windows"
+            else "  "
+            + str(
+                tmp_path
+                / "my_venv"
+                / "lib"
+                / f"python{major}.{minor}"
+                / "site-packages"
+            )
+        )
+        + " (as a source of Python packages)",
     ]
     expect = [
         "Sources of Python code:",
@@ -688,7 +701,11 @@ def test_check_json__simple_project__can_report_both_undeclared_and_unused(
             },
             {
                 "source_type": "PyEnvSource",
-                "path": f"{tmp_path}/my_venv/lib/python{major}.{minor}/site-packages",
+                "path": (
+                    f"{tmp_path / 'my_venv' / 'Lib' / 'site-packages'}"
+                    if platform.system() == "Windows"
+                    else f"{tmp_path}/my_venv/lib/python{major}.{minor}/site-packages"
+                ),
             },
         ],
         "imports": [

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -492,8 +492,8 @@ def test_list_sources_detailed__in_varied_project__lists_all_files(fake_project)
         for filename in [
             "code.py",
             "setup.py",  # This is both a CodeSource and an DepsSource!
-            os.path.join("subdir", "notebook.ipynb"),
-            os.path.join("subdir", "other.py"),
+            str(Path("subdir", "notebook.ipynb")),
+            str(Path("subdir", "other.py")),
         ]
     ]
     expect_deps_lines = [

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -552,7 +552,7 @@ def test_list_sources_detailed__from_both_python_file_and_stdin(fake_project):
             f"  {tmp_path / 'code.py'} (using {tmp_path} as base for 1st-party imports)",
         ],
     ]
-    assert output.splitlines() == expect
+    assert output.splitlines() == expect[0] or output.splitlines() == expect[1]
     assert returncode == 0
 
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -8,7 +8,6 @@ core exhaustively (which is what the other unit tests are for.
 import json
 import logging
 import os
-import sys
 from dataclasses import dataclass, field
 from itertools import dropwhile
 from pathlib import Path

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -7,7 +7,6 @@ core exhaustively (which is what the other unit tests are for.
 
 import json
 import logging
-import os
 from dataclasses import dataclass, field
 from itertools import dropwhile
 from pathlib import Path
@@ -20,6 +19,7 @@ from importlib_metadata import files as package_files
 from fawltydeps.main import UNUSED_DEPS_OUTPUT_PREFIX, VERBOSE_PROMPT, Analysis, version
 from fawltydeps.settings import DEFAULT_IGNORE_UNUSED
 from fawltydeps.types import Location, UnusedDependency
+from fawltydeps.utils import site_packages
 
 from .test_extract_imports_simple import generate_notebook
 from .utils import (
@@ -27,7 +27,6 @@ from .utils import (
     dedent_bytes,
     run_fawltydeps_function,
     run_fawltydeps_subprocess,
-    site_packages,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -8,6 +8,7 @@ core exhaustively (which is what the other unit tests are for.
 import json
 import logging
 import os
+from pathlib import Path
 import platform
 import sys
 from dataclasses import dataclass, field
@@ -437,8 +438,8 @@ def test_list_sources__in_varied_project__lists_all_files(fake_project):
     tmp_path = fake_project(
         files_with_imports={
             "code.py": ["foo"],
-            os.path.join("subdir", "other.py"): ["foo"],
-            os.path.join("subdir", "notebook.ipynb"): ["foo"],
+            str(Path("subdir", "other.py")): ["foo"],
+            str(Path("subdir", "notebook.ipynb")): ["foo"],
         },
         files_with_declared_deps={
             "requirements.txt": ["foo"],
@@ -590,7 +591,7 @@ project_tests_samples = [
         expect_output=[
             "These imports appear to be undeclared dependencies:",
             "- 'requests' imported at:",
-            f"    {os.path.join('{path}', 'code.py')}:1",
+            f"    {Path('{path}', 'code.py')}:1",
         ],
         expect_returncode=3,
     ),
@@ -602,7 +603,7 @@ project_tests_samples = [
         expect_output=[
             "These dependencies appear to be unused (i.e. not imported):",
             "- 'pandas' declared in:",
-            f"    {os.path.join('{path}', 'requirements.txt')}",
+            f"    {Path('{path}', 'requirements.txt')}",
         ],
         expect_returncode=4,
     ),
@@ -614,11 +615,11 @@ project_tests_samples = [
         expect_output=[
             "These imports appear to be undeclared dependencies:",
             "- 'requests' imported at:",
-            f"    {os.path.join('{path}', 'code.py')}:1",
+            f"    {Path('{path}', 'code.py')}:1",
             "",
             "These dependencies appear to be unused (i.e. not imported):",
             "- 'pandas' declared in:",
-            f"    {os.path.join('{path}', 'requirements.txt')}",
+            f"    {Path('{path}', 'requirements.txt')}",
         ],
         expect_returncode=3,  # undeclared is more important than unused
     ),
@@ -639,7 +640,7 @@ project_tests_samples = [
         expect_logs=[
             "INFO:fawltydeps.extract_imports:Finding Python files under {path}",
             "INFO:fawltydeps.extract_imports:Parsing Python file "
-            f"{os.path.join('{path}', 'code.py')}",
+            f"{Path('{path}', 'code.py')}",
             "INFO:fawltydeps.packages:'pandas' was not resolved."
             " Assuming it can be imported as 'pandas'.",
         ],
@@ -653,11 +654,11 @@ project_tests_samples = [
         expect_output=[
             "These imports appear to be undeclared dependencies:",
             "- 'requests' imported at:",
-            f"    {os.path.join('{path}', 'code.py')}:1",
+            f"    {Path('{path}', 'code.py')}:1",
             "",
             "These dependencies appear to be unused (i.e. not imported):",
             "- 'pandas' declared in:",
-            f"    {os.path.join('{path}', 'requirements.txt')}",
+            f"    {Path('{path}', 'requirements.txt')}",
         ],
         expect_returncode=3,  # undeclared is more important than unused
     ),

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -28,6 +28,7 @@ from .utils import (
     dedent_bytes,
     run_fawltydeps_function,
     run_fawltydeps_subprocess,
+    site_packages,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,15 +55,6 @@ def make_json_settings_dict(**kwargs):
     assert all(k in settings for k in kwargs)
     settings.update(kwargs)
     return settings
-
-
-def site_packages(venv_dir: Path) -> Path:
-    # Windows
-    if sys.platform.startswith("win"):
-        return venv_dir / "Lib" / "site-packages"
-    # Assume POSIX
-    major, minor = sys.version_info[:2]
-    return venv_dir / f"lib/python{major}.{minor}/site-packages"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cmdline_options.py
+++ b/tests/test_cmdline_options.py
@@ -192,7 +192,7 @@ def test_options_interactions__correct_options__does_not_abort(cli_arguments):
     )
     args = basepath + drawn_args
 
-    with open("/dev/null", "w") as f_out:
+    with open(os.devnull, "w") as f_out:
         exit_code = main(cmdline_args=args, stdin=io.StringIO(to_stdin), stdout=f_out)
 
     assert exit_code in {0, 3, 4}

--- a/tests/test_cmdline_options.py
+++ b/tests/test_cmdline_options.py
@@ -16,6 +16,7 @@ The strategy construction can be viewed as a reference
 to how the CLI options are expected to be used.
 """
 import io
+import os
 import string
 from functools import reduce
 from pathlib import Path
@@ -23,7 +24,7 @@ from textwrap import dedent
 from typing import List
 
 import hypothesis.strategies as st
-from hypothesis import given
+from hypothesis import given, settings
 
 from fawltydeps.main import main
 
@@ -181,6 +182,10 @@ def cli_arguments_combinations(draw):
 
 
 @given(cli_arguments=cli_arguments_combinations())
+@settings(
+    deadline=500,
+    max_examples=100,
+)
 def test_options_interactions__correct_options__does_not_abort(cli_arguments):
     """Check if a combination of valid options
 

--- a/tests/test_deps_parser_determination.py
+++ b/tests/test_deps_parser_determination.py
@@ -1,7 +1,6 @@
 """ Test the determination of strategy to parse dependency declarations. """
 
 import logging
-import os
 import shutil
 from pathlib import Path
 
@@ -30,20 +29,20 @@ from .utils import assert_unordered_equivalence, collect_dep_names
             ("setup.cfg", ParserChoice.SETUP_CFG),
             ("pyproject.toml", ParserChoice.PYPROJECT_TOML),
             ("anything_else", None),
-            (os.path.join("sub", "requirements.txt"), ParserChoice.REQUIREMENTS_TXT),
-            (os.path.join("sub", "setup.py"), ParserChoice.SETUP_PY),
-            (os.path.join("sub", "setup.cfg"), ParserChoice.SETUP_CFG),
-            (os.path.join("sub", "pyproject.toml"), ParserChoice.PYPROJECT_TOML),
-            (os.path.join("sub", "anything_else"), None),
-            (os.path.join("abs", "requirements.txt"), ParserChoice.REQUIREMENTS_TXT),
-            (os.path.join("abs", "setup.py"), ParserChoice.SETUP_PY),
-            (os.path.join("abs", "setup.cfg"), ParserChoice.SETUP_CFG),
-            (os.path.join("abs", "pyproject.toml"), ParserChoice.PYPROJECT_TOML),
-            (os.path.join("abs", "anything_else"), None),
-            (os.path.join("requirements.txt", "wat"), None),
-            (os.path.join("setup.py", "wat"), None),
-            (os.path.join("setup.cfg", "wat"), None),
-            (os.path.join("pyproject.toml", "wat"), None),
+            (str(Path("sub", "requirements.txt")), ParserChoice.REQUIREMENTS_TXT),
+            (str(Path("sub", "setup.py")), ParserChoice.SETUP_PY),
+            (str(Path("sub", "setup.cfg")), ParserChoice.SETUP_CFG),
+            (str(Path("sub", "pyproject.toml")), ParserChoice.PYPROJECT_TOML),
+            (str(Path("sub", "anything_else")), None),
+            (str(Path("abs", "requirements.txt")), ParserChoice.REQUIREMENTS_TXT),
+            (str(Path("abs", "setup.py")), ParserChoice.SETUP_PY),
+            (str(Path("abs", "setup.cfg")), ParserChoice.SETUP_CFG),
+            (str(Path("abs", "pyproject.toml")), ParserChoice.PYPROJECT_TOML),
+            (str(Path("abs", "anything_else")), None),
+            (str(Path("requirements.txt", "wat")), None),
+            (str(Path("setup.py", "wat")), None),
+            (str(Path("setup.cfg", "wat")), None),
+            (str(Path("pyproject.toml", "wat")), None),
             ("requirements-dev.txt", ParserChoice.REQUIREMENTS_TXT),
             ("test-requirements.txt", ParserChoice.REQUIREMENTS_TXT),
             ("extra-requirements-dev.txt", ParserChoice.REQUIREMENTS_TXT),

--- a/tests/test_deps_parser_determination.py
+++ b/tests/test_deps_parser_determination.py
@@ -1,6 +1,7 @@
 """ Test the determination of strategy to parse dependency declarations. """
 
 import logging
+import os
 import shutil
 from pathlib import Path
 
@@ -29,20 +30,20 @@ from .utils import assert_unordered_equivalence, collect_dep_names
             ("setup.cfg", ParserChoice.SETUP_CFG),
             ("pyproject.toml", ParserChoice.PYPROJECT_TOML),
             ("anything_else", None),
-            ("sub/requirements.txt", ParserChoice.REQUIREMENTS_TXT),
-            ("sub/setup.py", ParserChoice.SETUP_PY),
-            ("sub/setup.cfg", ParserChoice.SETUP_CFG),
-            ("sub/pyproject.toml", ParserChoice.PYPROJECT_TOML),
-            ("sub/anything_else", None),
-            ("/abs/requirements.txt", ParserChoice.REQUIREMENTS_TXT),
-            ("/abs/setup.py", ParserChoice.SETUP_PY),
-            ("/abs/setup.cfg", ParserChoice.SETUP_CFG),
-            ("/abs/pyproject.toml", ParserChoice.PYPROJECT_TOML),
-            ("/abs/anything_else", None),
-            ("requirements.txt/wat", None),
-            ("setup.py/wat", None),
-            ("setup.cfg/wat", None),
-            ("pyproject.toml/wat", None),
+            (os.path.join("sub", "requirements.txt"), ParserChoice.REQUIREMENTS_TXT),
+            (os.path.join("sub", "setup.py"), ParserChoice.SETUP_PY),
+            (os.path.join("sub", "setup.cfg"), ParserChoice.SETUP_CFG),
+            (os.path.join("sub", "pyproject.toml"), ParserChoice.PYPROJECT_TOML),
+            (os.path.join("sub", "anything_else"), None),
+            (os.path.join("abs", "requirements.txt"), ParserChoice.REQUIREMENTS_TXT),
+            (os.path.join("abs", "setup.py"), ParserChoice.SETUP_PY),
+            (os.path.join("abs", "setup.cfg"), ParserChoice.SETUP_CFG),
+            (os.path.join("abs", "pyproject.toml"), ParserChoice.PYPROJECT_TOML),
+            (os.path.join("abs", "anything_else"), None),
+            (os.path.join("requirements.txt", "wat"), None),
+            (os.path.join("setup.py", "wat"), None),
+            (os.path.join("setup.cfg", "wat"), None),
+            (os.path.join("pyproject.toml", "wat"), None),
             ("requirements-dev.txt", ParserChoice.REQUIREMENTS_TXT),
             ("test-requirements.txt", ParserChoice.REQUIREMENTS_TXT),
             ("extra-requirements-dev.txt", ParserChoice.REQUIREMENTS_TXT),

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -1,5 +1,6 @@
 """Test core functionality of DirectoryTraversal class."""
 import os
+import platform
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -272,7 +273,22 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
 
 
 @pytest.mark.parametrize(
-    "vector", [pytest.param(v, id=v.id) for v in directory_traversal_vectors]
+    "vector",
+    [
+        pytest.param(
+            v,
+            id=v.id,
+            marks=pytest.mark.skipif(
+                platform.system() == "Windows"
+                and any(
+                    isinstance(entry, (RelativeSymlink, AbsoluteSymlink))
+                    for entry in v.given
+                ),
+                reason="Symlinks on Windows may be created only by administrators",
+            ),
+        )
+        for v in directory_traversal_vectors
+    ],
 )
 def test_DirectoryTraversal(vector: DirectoryTraversalVector, tmp_path):
     for entry in vector.given:

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -280,7 +280,7 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
             v,
             id=v.id,
             marks=pytest.mark.skipif(
-                platform.system() == "Windows"
+                sys.platform.startswith("win")
                 and any(
                     isinstance(entry, (RelativeSymlink, AbsoluteSymlink))
                     for entry in v.given

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -1,9 +1,10 @@
 """Test core functionality of DirectoryTraversal class."""
 import os
-import platform
+import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
+import sys
 from typing import Generic, List, Optional, Tuple, TypeVar, Union
 
 import pytest

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -168,11 +168,11 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
         expect=[
             ExpectedTraverseStep(".", subdirs=["a"]),
             ExpectedTraverseStep("a", subdirs=["b"], attached=[456]),
-            ExpectedTraverseStep(os.path.join("a", "b"), subdirs=["c"], attached=[456]),
+            ExpectedTraverseStep(str(Path("a", "b")), subdirs=["c"], attached=[456]),
             ExpectedTraverseStep(
-                os.path.join("a", "b", "c"), subdirs=["d"], attached=[456, 123]
+                str(Path("a", "b", "c")), subdirs=["d"], attached=[456, 123]
             ),
-            ExpectedTraverseStep(os.path.join("a", "b", "c", "d"), attached=[456, 123]),
+            ExpectedTraverseStep(str(Path("a", "b", "c", "d")), attached=[456, 123]),
         ],
     ),
     DirectoryTraversalVector(

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -209,14 +209,14 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
                 ExpectedTraverseStep(".", subdirs=["sub1", "sub2"]),
                 ExpectedTraverseStep("sub1", subdirs=["rel_link_sub2"]),
                 ExpectedTraverseStep(
-                    os.path.join("sub1", "rel_link_sub2"), subdirs=["abs_link_sub1"]
+                    str(Path("sub1", "rel_link_sub2")), subdirs=["abs_link_sub1"]
                 ),
             ],
             [
                 ExpectedTraverseStep(".", subdirs=["sub1", "sub2"]),
                 ExpectedTraverseStep("sub2", subdirs=["abs_link_sub1"]),
                 ExpectedTraverseStep(
-                    os.path.join("sub2", "abs_link_sub1"), subdirs=["rel_link_sub2"]
+                    str(Path("sub2", "abs_link_sub1")), subdirs=["rel_link_sub2"]
                 ),
             ],
         ],
@@ -232,7 +232,7 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
         add=[AddCall(path="here")],
         expect=[
             ExpectedTraverseStep("here", subdirs=["symlink"]),
-            ExpectedTraverseStep(os.path.join("here", "symlink"), files=["file"]),
+            ExpectedTraverseStep(str(Path("here", "symlink")), files=["file"]),
         ],
     ),
     DirectoryTraversalVector(
@@ -244,7 +244,7 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
         add=[AddCall(path="here")],
         expect=[
             ExpectedTraverseStep("here", subdirs=["symlink"]),
-            ExpectedTraverseStep(os.path.join("here", "symlink"), files=["file"]),
+            ExpectedTraverseStep(str(Path("here", "symlink")), files=["file"]),
         ],
     ),
     DirectoryTraversalVector(

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -1,5 +1,4 @@
 """Test core functionality of DirectoryTraversal class."""
-import os
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -183,8 +182,8 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
     DirectoryTraversalVector(
         "symlinks_to_parent__are_not_traversed",
         given=[
-            RelativeSymlink(os.path.join("sub", "rel_parent"), ".."),
-            AbsoluteSymlink(os.path.join("sub", "abs_parent"), "."),
+            RelativeSymlink(str(Path("sub", "rel_parent")), ".."),
+            AbsoluteSymlink(str(Path("sub", "abs_parent")), "."),
         ],
         expect=[
             ExpectedTraverseStep(".", subdirs=["sub"]),
@@ -195,9 +194,9 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
         "mutual_symlinks__are_traversed_once",
         given=[
             RelativeSymlink(
-                os.path.join("sub1", "rel_link_sub2"), os.path.join("..", "sub2")
+                str(Path("sub1", "rel_link_sub2")), str(Path("..", "sub2"))
             ),
-            AbsoluteSymlink(os.path.join("sub2", "abs_link_sub1"), "sub1"),
+            AbsoluteSymlink(str(Path("sub2", "abs_link_sub1")), "sub1"),
         ],
         expect_alternatives=[
             [
@@ -224,10 +223,8 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
     DirectoryTraversalVector(
         "relative_symlink_to_dir_elsewhere__is_traversed",
         given=[
-            File(os.path.join("elsewhere", "file")),
-            RelativeSymlink(
-                os.path.join("here", "symlink"), os.path.join("..", "elsewhere")
-            ),
+            File(str(Path("elsewhere", "file"))),
+            RelativeSymlink(str(Path("here", "symlink")), str(Path("..", "elsewhere"))),
         ],
         add=[AddCall(path="here")],
         expect=[
@@ -238,8 +235,8 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
     DirectoryTraversalVector(
         "absolute_symlink_to_dir_elsewhere__is_traversed",
         given=[
-            File(os.path.join("elsewhere", "file")),
-            AbsoluteSymlink(os.path.join("here", "symlink"), "elsewhere"),
+            File(str(Path("elsewhere", "file"))),
+            AbsoluteSymlink(str(Path("here", "symlink")), "elsewhere"),
         ],
         add=[AddCall(path="here")],
         expect=[

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -4,7 +4,6 @@ import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-import sys
 from typing import Generic, List, Optional, Tuple, TypeVar, Union
 
 import pytest

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -1,6 +1,4 @@
 """Verify behavior of package module looking at a given Python environment."""
-import os
-import platform
 import sys
 import venv
 from pathlib import Path
@@ -17,6 +15,8 @@ from fawltydeps.packages import (
     resolve_dependencies,
     setup_resolvers,
 )
+
+from .utils import site_packages
 
 major, minor = sys.version_info[:2]
 
@@ -45,7 +45,7 @@ pep582_subdirs = [
 windows_subdirs = [
     "",
     "Lib",
-    os.path.join("Lib", "site-packages"),
+    str(Path("Lib", "site-packages")),
 ]
 
 
@@ -166,11 +166,7 @@ def test_local_env__default_venv__contains_pip(tmp_path):
     # "pip" package is installed, and that it provides a "pip" import name.
     venv.create(tmp_path, with_pip=True)
     lpl = LocalPackageResolver(pyenv_sources(tmp_path))
-    expect_location = (
-        tmp_path / "Lib" / "site-packages"
-        if platform.system() == "Windows"
-        else tmp_path / f"lib/python{major}.{minor}/site-packages"
-    )
+    expect_location = site_packages(tmp_path)
     assert "pip" in lpl.packages
     pip = lpl.packages["pip"]
     assert pip.package_name == "pip"

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -15,8 +15,7 @@ from fawltydeps.packages import (
     resolve_dependencies,
     setup_resolvers,
 )
-
-from .utils import site_packages
+from fawltydeps.utils import site_packages
 
 major, minor = sys.version_info[:2]
 

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -1,4 +1,6 @@
 """Verify behavior of package module looking at a given Python environment."""
+import os
+import platform
 import sys
 import venv
 from pathlib import Path
@@ -46,6 +48,23 @@ windows_subdirs = [
     os.path.join("Lib", "site-packages"),
 ]
 
+
+@pytest.mark.skipif(
+    platform.system() != "Windows", reason="Not relevant to Windows virtual environment"
+)
+@pytest.mark.parametrize(
+    "subdir", [pytest.param(d, id=f"venv:{d}") for d in windows_subdirs]
+)
+def test_find_package_dirs__various_paths_in_venv_windows(tmp_path, subdir):
+    venv.create(tmp_path, with_pip=False)
+    path = tmp_path / subdir
+    expect = {tmp_path / "Lib" / "site-packages"}
+    assert set(LocalPackageResolver.find_package_dirs(path)) == expect
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Not relevant to Windows virtual environment"
+)
 @pytest.mark.parametrize(
     "subdir", [pytest.param(d, id=f"venv:{d}") for d in env_subdirs]
 )
@@ -56,6 +75,9 @@ def test_find_package_dirs__various_paths_in_venv(tmp_path, subdir):
     assert set(LocalPackageResolver.find_package_dirs(path)) == expect
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Not relevant to Windows virtual environment"
+)
 @pytest.mark.parametrize(
     "subdir", [pytest.param(d, id=f"poetry2nix:{d}") for d in env_subdirs]
 )
@@ -72,6 +94,9 @@ def test_find_package_dirs__various_paths_in_poetry2nix_env(write_tmp_files, sub
     assert set(LocalPackageResolver.find_package_dirs(path)) == expect
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Not relevant to Windows virtual environment"
+)
 @pytest.mark.parametrize(
     "subdir", [pytest.param(d, id=f"pep582:{d}") for d in pep582_subdirs]
 )
@@ -87,6 +112,9 @@ def test_find_package_dirs__various_paths_in_pypackages(write_tmp_files, subdir)
     assert set(LocalPackageResolver.find_package_dirs(path)) == expect
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Not relevant to Windows virtual environment"
+)
 @pytest.mark.parametrize(
     "subdir",
     [pytest.param(d, id=f"pep582:{d}") for d in pep582_subdirs]

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -37,6 +37,14 @@ pep582_subdirs = [
     f"__pypackages__/{major}.{minor}/lib",
 ]
 
+# When the user gives us a --pyenv arg that points to a Python virtualenv
+# on Windows, what are the the possible paths inside that Python environment
+# that they might point at (and that we should accept)?
+windows_subdirs = [
+    "",
+    "Lib",
+    os.path.join("Lib", "site-packages"),
+]
 
 @pytest.mark.parametrize(
     "subdir", [pytest.param(d, id=f"venv:{d}") for d in env_subdirs]
@@ -128,7 +136,11 @@ def test_local_env__default_venv__contains_pip(tmp_path):
     # "pip" package is installed, and that it provides a "pip" import name.
     venv.create(tmp_path, with_pip=True)
     lpl = LocalPackageResolver(pyenv_sources(tmp_path))
-    expect_location = tmp_path / f"lib/python{major}.{minor}/site-packages"
+    expect_location = (
+        tmp_path / "Lib" / "site-packages"
+        if platform.system() == "Windows"
+        else tmp_path / f"lib/python{major}.{minor}/site-packages"
+    )
     assert "pip" in lpl.packages
     pip = lpl.packages["pip"]
     assert pip.package_name == "pip"

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -50,7 +50,8 @@ windows_subdirs = [
 
 
 @pytest.mark.skipif(
-    platform.system() != "Windows", reason="Not relevant to Windows virtual environment"
+    not sys.platform.startswith("win"),
+    reason="Only relevant to Windows virtual environment",
 )
 @pytest.mark.parametrize(
     "subdir", [pytest.param(d, id=f"venv:{d}") for d in windows_subdirs]
@@ -63,7 +64,8 @@ def test_find_package_dirs__various_paths_in_venv_windows(tmp_path, subdir):
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Not relevant to Windows virtual environment"
+    sys.platform.startswith("win"),
+    reason="Not relevant to Windows virtual environment",
 )
 @pytest.mark.parametrize(
     "subdir", [pytest.param(d, id=f"venv:{d}") for d in env_subdirs]
@@ -76,7 +78,7 @@ def test_find_package_dirs__various_paths_in_venv(tmp_path, subdir):
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Not relevant to Windows virtual environment"
+    sys.platform.startswith("win"), reason="Not relevant to Windows virtual environment"
 )
 @pytest.mark.parametrize(
     "subdir", [pytest.param(d, id=f"poetry2nix:{d}") for d in env_subdirs]
@@ -95,7 +97,7 @@ def test_find_package_dirs__various_paths_in_poetry2nix_env(write_tmp_files, sub
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Not relevant to Windows virtual environment"
+    sys.platform.startswith("win"), reason="Not relevant to Windows virtual environment"
 )
 @pytest.mark.parametrize(
     "subdir", [pytest.param(d, id=f"pep582:{d}") for d in pep582_subdirs]
@@ -113,7 +115,7 @@ def test_find_package_dirs__various_paths_in_pypackages(write_tmp_files, subdir)
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Not relevant to Windows virtual environment"
+    sys.platform.startswith("win"), reason="Not relevant to Windows virtual environment"
 )
 @pytest.mark.parametrize(
     "subdir",

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -45,7 +45,7 @@ pep582_subdirs = [
 windows_subdirs = [
     "",
     "Lib",
-    str(Path("Lib", "site-packages")),
+    str(site_packages()),
 ]
 
 
@@ -59,7 +59,7 @@ windows_subdirs = [
 def test_find_package_dirs__various_paths_in_venv_windows(tmp_path, subdir):
     venv.create(tmp_path, with_pip=False)
     path = tmp_path / subdir
-    expect = {tmp_path / "Lib" / "site-packages"}
+    expect = {site_packages(tmp_path)}
     assert set(LocalPackageResolver.find_package_dirs(path)) == expect
 
 

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -7,7 +7,9 @@ should find/report.
 """
 import json
 import logging
+import os
 import subprocess
+import sys
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -51,7 +53,7 @@ def verify_requirements(venv_path: Path, requirements: List[str]) -> None:
 def run_fawltydeps_json(
     *args: str, venv_dir: Optional[Path], cwd: Optional[Path] = None
 ) -> JsonData:
-    argv = ["fawltydeps", "--config-file=/dev/null", "--json"]
+    argv = [sys.executable, "-m", "fawltydeps", f"--config-file={os.devnull}", "--json"]
     if venv_dir is not None:
         argv += [f"--pyenv={venv_dir}"]
     proc = subprocess.run(

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -173,7 +173,8 @@ class ThirdPartyProject(BaseProject):
 
 @pytest.mark.skipif(
     sys.platform.startswith("win"),
-    reason="Real projects test are not supported on Windows due to the test environment complications.",
+    reason="Real projects test are not supported on Windows"
+    " due to the test environment complications.",
 )
 @pytest.mark.parametrize(
     "project, experiment",

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -172,6 +172,10 @@ class ThirdPartyProject(BaseProject):
         return Path(cache.mkdir(f"fawltydeps_{self.tarball.sha256}"))
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Real projects test are not supported on Windows due to the test environment complications.",
+)
 @pytest.mark.parametrize(
     "project, experiment",
     [

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -189,7 +189,7 @@ def test_real_project(request, project, experiment):
 
     print(f"Testing real project {project.name!r} under {project_dir}")
     print(f"Project description: {project.description}")
-    print(f"Virtual environment of the project {project.name!r} under {venv_dir}")
+    print(f"Virtual environment under {venv_dir}")
     print()
     print(f"Running real project experiment: {experiment.name}")
     print(f"Experiment description: {experiment.description}")

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -185,6 +185,7 @@ def test_real_project(request, project, experiment):
 
     print(f"Testing real project {project.name!r} under {project_dir}")
     print(f"Project description: {project.description}")
+    print(f"Virtual environment of the project {project.name!r} under {venv_dir}")
     print()
     print(f"Running real project experiment: {experiment.name}")
     print(f"Experiment description: {experiment.description}")

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -8,6 +8,7 @@ should find/report.
 import json
 import logging
 import os
+import platform
 import subprocess
 import sys
 import tarfile
@@ -177,6 +178,7 @@ class ThirdPartyProject(BaseProject):
         pytest.param(project, experiment, id=experiment.name)
         for project in ThirdPartyProject.collect()
         for experiment in project.experiments
+        if not platform.system() == "Windows"
     ],
 )
 def test_real_project(request, project, experiment):

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -8,7 +8,6 @@ should find/report.
 import json
 import logging
 import os
-import platform
 import subprocess
 import sys
 import tarfile
@@ -182,7 +181,6 @@ class ThirdPartyProject(BaseProject):
         pytest.param(project, experiment, id=experiment.name)
         for project in ThirdPartyProject.collect()
         for experiment in project.experiments
-        if not platform.system() == "Windows"
     ],
 )
 def test_real_project(request, project, experiment):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,7 @@
 """Verify behavior of packages resolver"""
 
 import sys
+import time
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
@@ -127,7 +128,7 @@ def generate_expected_resolved_deps(
 )
 @settings(
     suppress_health_check=[HealthCheck.function_scoped_fixture],
-    deadline=5000,
+    deadline=None,
     max_examples=50,
 )
 def test_resolve_dependencies__generates_expected_mappings(
@@ -139,6 +140,7 @@ def test_resolve_dependencies__generates_expected_mappings(
     install_deps,
     request,
 ):
+    start_time = time.time()
 
     user_deps, user_file_mapping, user_config_mapping = user_mapping
 
@@ -199,5 +201,13 @@ def test_resolve_dependencies__generates_expected_mappings(
         )
     finally:
         TemporaryPipInstallResolver.cached_venv = None
+
+    end_time = time.time()
+    elapsed_time = end_time - start_time
+
+    deadline = 5000 if not install_deps else None
+
+    if deadline:
+        assert elapsed_time <= deadline, f"Test exceeded deadline of {deadline} ms"
 
     assert ignore_package_debug_info(actual) == ignore_package_debug_info(expected)

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -19,6 +19,7 @@ tests/sample_projects
     ├── expected.toml (mandatory)
     └── ... (regular Python project)
 """
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, List, Optional
@@ -106,6 +107,7 @@ class SampleProject(BaseProject):
             yield cls(path=subdir, **cls._init_args_from_toml(toml_data, Experiment))
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="TODO: fix on Windows #410")
 @pytest.mark.parametrize(
     "project, experiment",
     [

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,7 @@
 """Test how settings cascade/combine across command-line, config file, etc."""
 import argparse
 import logging
+import platform
 import random
 import string
 import sys
@@ -477,7 +478,12 @@ def test_settings__missing_config_file__uses_defaults_and_warns(tmp_path, caplog
     settings = Settings.config(config_file=missing_file)()
     assert settings.dict() == make_settings_dict()
     assert "Failed to load configuration file:" in caplog.text
-    assert str(missing_file) in caplog.text
+    # On Windows path escape sequences are doubled in repr()
+    assert (
+        repr(str(missing_file))
+        if platform.system() == "Windows"
+        else str(missing_file) in caplog.text
+    )
 
 
 def to_path_set(ps: Iterable[str]) -> Set[Path]:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,6 @@
 """Test how settings cascade/combine across command-line, config file, etc."""
 import argparse
 import logging
-import platform
 import random
 import string
 import sys

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -477,12 +477,11 @@ def test_settings__missing_config_file__uses_defaults_and_warns(tmp_path, caplog
     settings = Settings.config(config_file=missing_file)()
     assert settings.dict() == make_settings_dict()
     assert "Failed to load configuration file:" in caplog.text
+    missing_file_str = str(missing_file)
     # On Windows path escape sequences are doubled in repr()
-    assert (
-        repr(str(missing_file))
-        if platform.system() == "Windows"
-        else str(missing_file) in caplog.text
-    )
+    if sys.platform.startswith("win"):
+        missing_file_str = repr(missing_file_str)
+    assert missing_file_str in caplog.text
 
 
 def to_path_set(ps: Iterable[str]) -> Set[Path]:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -84,11 +84,16 @@ def setup_env(monkeypatch):
     return _inner
 
 
+def paths_sets_equal(a: Set[str], b: Set[str]) -> bool:
+    """Compare two sets of strings as if they were sets of paths."""
+    return {Path(element) for element in a} == {Path(element) for element in b}
+
+
 safe_string = strategies.text(alphabet=string.ascii_letters + string.digits, min_size=1)
 nonempty_string_set = strategies.sets(safe_string, min_size=1)
 four_different_string_groups = strategies.tuples(
     *([nonempty_string_set] * 4),
-).filter(lambda ss: all(a != b for a, b in combinations(ss, 2)))
+).filter(lambda ss: all(not paths_sets_equal(a, b) for a, b in combinations(ss, 2)))
 
 
 @given(code_deps_pyenvs_base=four_different_string_groups)

--- a/tests/test_traverse_project.py
+++ b/tests/test_traverse_project.py
@@ -1,5 +1,6 @@
 """Test that we can traverse a project to find our inputs."""
 import dataclasses
+import sys
 from pathlib import Path
 from typing import Optional, Set, Type
 
@@ -455,6 +456,7 @@ find_sources_vectors = [
 ]
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="TODO: fix on Windows #410")
 @pytest.mark.parametrize(
     "vector", [pytest.param(v, id=v.id) for v in find_sources_vectors]
 )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,7 +4,6 @@ import os
 import sys
 from dataclasses import FrozenInstanceError
 from pathlib import Path
-import sys
 
 import pytest
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,6 @@
 """Verify behavior of our basic types."""
 
+import os
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 
@@ -10,19 +11,31 @@ from fawltydeps.types import DeclaredDependency, Location, ParsedImport
 testdata = {  # Test ID -> (Location args, expected string representation, sort order)
     # First arg must be a Path, or "<stdin>"
     "nothing": (("<stdin>",), "<stdin>", 111),
-    "abs_path": ((Path("/foo/bar"),), "/foo/bar", 211),
+    "abs_path": ((Path("/foo/bar"),), os.path.join(os.sep, "foo", "bar"), 211),
     "rel_path": ((Path("foo"),), "foo", 311),
     # Second arg refers to notebook cell, and is rendered in [square brackets]
     "no_path_cell": (("<stdin>", 1), "<stdin>[1]", 121),
-    "abs_path_cell": ((Path("/foo/bar"), 2), "/foo/bar[2]", 221),
+    "abs_path_cell": (
+        (Path("/foo/bar"), 2),
+        os.path.join(os.sep, "foo", "bar[2]"),
+        221,
+    ),
     "rel_path_cell": ((Path("foo"), 3), "foo[3]", 321),
     # Third arg is line number, and is prefixed by colon
     "no_path_cell_line": (("<stdin>", 1, 2), "<stdin>[1]:2", 122),
-    "abs_path_cell_line": ((Path("/foo/bar"), 2, 3), "/foo/bar[2]:3", 222),
+    "abs_path_cell_line": (
+        (Path("/foo/bar"), 2, 3),
+        os.path.join(os.sep, "foo", "bar[2]:3"),
+        222,
+    ),
     "rel_path_cell_line": ((Path("foo"), 3, 4), "foo[3]:4", 322),
     # Cell number is omitted for non-notebooks.
     "no_path_line": (("<stdin>", None, 2), "<stdin>:2", 112),
-    "abs_path_line": ((Path("/foo/bar"), None, 3), "/foo/bar:3", 212),
+    "abs_path_line": (
+        (Path("/foo/bar"), None, 3),
+        os.path.join(os.sep, "foo", "bar:3"),
+        212,
+    ),
     "rel_path_line": ((Path("foo"), None, 4), "foo:4", 312),
 }
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,6 +4,7 @@ import os
 import sys
 from dataclasses import FrozenInstanceError
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -38,11 +39,23 @@ testdata = {  # Test ID -> (Location args, expected string representation, sort 
         212,
     ),
     "rel_path_line": ((Path("foo"), None, 4), "foo:4", 312),
+    "abs_path_drive_prefix": ((Path("C:/foo/bar"),), "C:\\foo\\bar", 222),
 }
 
 
 @pytest.mark.parametrize(
-    "args,string,_", [pytest.param(*data, id=key) for key, data in testdata.items()]
+    "args,string,_",
+    [
+        pytest.param(
+            *data,
+            id=key,
+            marks=pytest.mark.skipif(
+                key == "abs_path_drive_prefix" and not sys.platform.startswith("win"),
+                reason="Drive prefix is used in Windows systems only.",
+            ),
+        )
+        for key, data in testdata.items()
+    ],
 )
 def test_location__str(args, string, _):
     assert str(Location(*args)) == string

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -12,13 +12,13 @@ from fawltydeps.types import DeclaredDependency, Location, ParsedImport
 testdata = {  # Test ID -> (Location args, expected string representation, sort order)
     # First arg must be a Path, or "<stdin>"
     "nothing": (("<stdin>",), "<stdin>", 111),
-    "abs_path": ((Path("/foo/bar"),), os.path.join(os.sep, "foo", "bar"), 211),
+    "abs_path": ((Path("/foo/bar"),), "/foo/bar", 211),
     "rel_path": ((Path("foo"),), "foo", 311),
     # Second arg refers to notebook cell, and is rendered in [square brackets]
     "no_path_cell": (("<stdin>", 1), "<stdin>[1]", 121),
     "abs_path_cell": (
         (Path("/foo/bar"), 2),
-        os.path.join(os.sep, "foo", "bar[2]"),
+        "/foo/bar[2]",
         221,
     ),
     "rel_path_cell": ((Path("foo"), 3), "foo[3]", 321),
@@ -26,7 +26,7 @@ testdata = {  # Test ID -> (Location args, expected string representation, sort 
     "no_path_cell_line": (("<stdin>", 1, 2), "<stdin>[1]:2", 122),
     "abs_path_cell_line": (
         (Path("/foo/bar"), 2, 3),
-        os.path.join(os.sep, "foo", "bar[2]:3"),
+        "/foo/bar[2]:3",
         222,
     ),
     "rel_path_cell_line": ((Path("foo"), 3, 4), "foo[3]:4", 322),
@@ -34,7 +34,7 @@ testdata = {  # Test ID -> (Location args, expected string representation, sort 
     "no_path_line": (("<stdin>", None, 2), "<stdin>:2", 112),
     "abs_path_line": (
         (Path("/foo/bar"), None, 3),
-        os.path.join(os.sep, "foo", "bar:3"),
+        "/foo/bar:3",
         212,
     ),
     "rel_path_line": ((Path("foo"), None, 4), "foo:4", 312),
@@ -57,7 +57,7 @@ testdata = {  # Test ID -> (Location args, expected string representation, sort 
     ],
 )
 def test_location__str(args, string, _):
-    assert str(Location(*args)) == string
+    assert str(Location(*args)) == string.replace("/", os.sep)
 
 
 def test_location__sorting():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,7 @@
 """Verify behavior of our basic types."""
 
 import os
+import sys
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,6 +26,15 @@ SAMPLE_PROJECTS_DIR = Path(__file__).with_name("sample_projects")
 logger = logging.getLogger(__name__)
 
 
+def site_packages(venv_dir: Path) -> Path:
+    # Windows
+    if sys.platform.startswith("win"):
+        return venv_dir / "Lib" / "site-packages"
+    # Assume POSIX
+    major, minor = sys.version_info[:2]
+    return venv_dir / f"lib/python{major}.{minor}/site-packages"
+
+
 def dedent_bytes(data: bytes) -> bytes:
     """Like textwrap.dedent(), but for bytes instead of str."""
     text = data.decode(encoding="utf-8", errors="surrogateescape")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ import io
 import logging
 import os
 import subprocess
+import sys
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from pprint import pformat
@@ -106,13 +107,14 @@ def unused_factory(*deps: str) -> List[UnusedDependency]:
 
 def run_fawltydeps_subprocess(
     *args: str,
-    config_file: Path = Path("/dev/null"),
+    config_file: Path = Path(os.devnull),
     to_stdin: Optional[str] = None,
     cwd: Optional[Path] = None,
 ) -> Tuple[str, str, int]:
     """Run FawltyDeps as a subprocess. Designed for integration tests."""
     proc = subprocess.run(
-        ["fawltydeps", f"--config-file={config_file}"] + list(args),
+        [sys.executable, "-m", "fawltydeps", f"--config-file={config_file}"]
+        + list(args),
         input=to_stdin,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -131,7 +133,7 @@ def run_fawltydeps_subprocess(
 
 def run_fawltydeps_function(
     *args: str,
-    config_file: Path = Path("/dev/null"),
+    config_file: Path = Path(os.devnull),
     to_stdin: Optional[Union[str, bytes]] = None,
     basepath: Optional[Path] = None,
 ) -> Tuple[str, int]:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,7 +26,7 @@ SAMPLE_PROJECTS_DIR = Path(__file__).with_name("sample_projects")
 logger = logging.getLogger(__name__)
 
 
-def site_packages(venv_dir: Path) -> Path:
+def site_packages(venv_dir: Path = Path()) -> Path:
     # Windows
     if sys.platform.startswith("win"):
         return venv_dir / "Lib" / "site-packages"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,15 +26,6 @@ SAMPLE_PROJECTS_DIR = Path(__file__).with_name("sample_projects")
 logger = logging.getLogger(__name__)
 
 
-def site_packages(venv_dir: Path = Path()) -> Path:
-    # Windows
-    if sys.platform.startswith("win"):
-        return venv_dir / "Lib" / "site-packages"
-    # Assume POSIX
-    major, minor = sys.version_info[:2]
-    return venv_dir / f"lib/python{major}.{minor}/site-packages"
-
-
 def dedent_bytes(data: bytes) -> bytes:
     """Like textwrap.dedent(), but for bytes instead of str."""
     text = data.decode(encoding="utf-8", errors="surrogateescape")


### PR DESCRIPTION
## Support for MacOS

To support MacOS it is enough to add `macos-latest` to the test matrix and allow for longer runs for tests that use `--install-deps` option. 

## Support for Windows
 To support Windows we needed to:
- change all paths to be system-agnostic (5843d1efced695bf374b82fe3f385a1bdb97a8f4)
- change paths that referred to python executable, pip executable and site packages to work on all systems (36e957a174ff5bd68fc48dcefac43447380bdbe9, 8c4ecb984d9bf5ebe6d57991aee1f2bc4f76714e, d68917162b5f58a49c678122f824f80c2755e43d)
- Adjust command line script that creates virtual environments for tests (73e1819a38b83a2e51728bf5832df53c8e047ffd)
- Skip irrelevant tests (442db9696631777e3c93f56823f27b9d4abf9525, 3b5e3b6870e5ee9d827bd9f5b00676d58452af37)
- skip real-project tests as the test setup does not work well with Windows and we may consider adjusting the tests  (03fcd441b444c735d173c024046a1a934ded26fb)
- few other minor tweaks.


## Issues
In the process of adjusting the code to support Windows, we discovered, that the `real_projects` tests setup is not suited for Windows. The fact that we use a separate virtual environment, which we construct from the command line makes it hard to work with Windows. 

You may see example of such problem [in this CI run](https://github.com/tweag/FawltyDeps/actions/runs/7263529972/job/19789047009?pr=397). In this case, project [The Algorithms-Python](https://github.com/TheAlgorithms/Python) uses conditional requirement:
```
    "tensorflow; python_version < '3.11'",
```
This falls into undeclared dependencies on Windows for Python <=3.10. This behavior should be investigated in a separate ticket.