### PR TITLE
Fixes for various `--exclude` usability issues

### DIFF
--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -163,7 +163,7 @@ class DirectoryTraversal(Generic[T]):
 
     def _do_exclude(self, path: Path, is_dir: bool) -> bool:
         """Check if given path is excluded by any of our exclude rules."""
-        return match_rules(self.exclude_rules, path.resolve(), is_dir)
+        return match_rules(self.exclude_rules, path, is_dir)
 
     def traverse(self) -> Iterator[TraversalStep[T]]:
         """Perform the traversal of the added directories.

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -161,7 +161,7 @@ class DirectoryTraversal(Generic[T]):
         logger.debug(f"Adding rule {rule!r} @ {rule.base_dir!r}")
         self.exclude_rules.append(rule)
 
-    def _do_exclude(self, path: Path, is_dir: bool) -> bool:
+    def is_excluded(self, path: Path, is_dir: bool) -> bool:
         """Check if given path is excluded by any of our exclude rules."""
         return match_rules(self.exclude_rules, path, is_dir)
 
@@ -225,14 +225,14 @@ class DirectoryTraversal(Generic[T]):
                 exclude_subdirs = {
                     path
                     for path in subdir_paths
-                    if self._do_exclude(path, True)
+                    if self.is_excluded(path, True)
                     and (DirId.from_path(path) not in remaining.values())
                 }
                 for subdir in exclude_subdirs:
                     logger.debug(f"    skip traversing excluded subdir {subdir}")
                     self.skip_dir(subdir)
                 exclude_files = {
-                    path for path in file_paths if self._do_exclude(path, False)
+                    path for path in file_paths if self.is_excluded(path, False)
                 }
 
                 # At this yield, the caller takes over control, and may modify

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -186,7 +186,7 @@ class Rule(NamedTuple):
 
         return cls(
             pattern=orig_pattern,
-            regex=fnmatch_pathname_to_regex(pattern, dir_only, negated, anchored),
+            regex=fnmatch_pathname_to_regex(pattern, anchored),
             negated=negated,
             dir_only=dir_only,
             anchored=anchored,
@@ -225,9 +225,7 @@ NONSEP = rf"[^{'|'.join(SEPS)}]"
 
 # Frustratingly, python's fnmatch doesn't provide the FNM_PATHNAME option that
 # .gitignore's behavior depends on, so convert the pattern to a regex instead.
-def fnmatch_pathname_to_regex(
-    pattern: str, dir_only: bool, negated: bool, anchored: bool = False
-) -> CompiledRegex:  # pylint: disable=unsubscriptable-object
+def fnmatch_pathname_to_regex(pattern: str, anchored: bool = False) -> CompiledRegex:
     """Convert the given fnmatch-style pattern to the equivalent regex.
 
     Implements fnmatch style-behavior, as though with FNM_PATHNAME flagged;
@@ -273,11 +271,6 @@ def fnmatch_pathname_to_regex(
         result.insert(0, "^")
     else:
         result.insert(0, f"(^|{SEPS_GROUP})")
-    if not dir_only:
-        result.append("$")
-    elif dir_only and negated:
-        result.append("/$")
-    else:
-        result.append("($|\\/)")
+    result.append("$")
 
     return re.compile("".join(result))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,18 @@ from .project_helpers import TarballPackage
 
 
 @pytest.fixture
+def inside_tmp_path(monkeypatch, tmp_path):
+    """Convenience fixture to run a test with CWD set to tmp_path.
+
+    This allows a test to run as if FalwtyDeps was invoked inside the temporary
+    scratch directory. Allows testing of relative paths (inside tmp_path) that
+    are closer to how most users run FawltyDeps inside their own projects.
+    """
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
 def local_pypi(request, monkeypatch):
     cache_dir = TarballPackage.cache_dir(request.config.cache)
     TarballPackage.get_tarballs(request.config.cache)

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from dataclasses import fields as dataclass_fields
 from pathlib import Path
+from textwrap import dedent
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Set, Type
 from urllib.parse import urlparse
 from urllib.request import urlretrieve
@@ -281,9 +282,10 @@ class BaseExperiment(ABC):
     @staticmethod
     def _init_args_from_toml(name: str, data: TomlData) -> Dict[str, Any]:
         """Extract members from TOML into kwargs for a subclass constructor."""
+        description = data.get("description")
         return dict(
             name=name,
-            description=data.get("description"),
+            description=None if description is None else dedent(description),
             requirements=data.get("requirements", []),
             expectations=AnalysisExpectations.from_toml(data),
         )
@@ -325,7 +327,7 @@ class BaseProject(ABC):
         project_name = toml_data["project"]["name"]
         return dict(
             name=project_name,
-            description=toml_data["project"].get("description"),
+            description=dedent(toml_data["project"].get("description")),
             experiments=[
                 ExperimentClass.from_toml(f"{project_name}:{name}", data)
                 for name, data in toml_data["experiments"].items()

--- a/tests/real_projects/fawltydeps.toml
+++ b/tests/real_projects/fawltydeps.toml
@@ -1,0 +1,147 @@
+[project]
+# General information about the 3rd-party project: Its name, why we test it,
+# and where to find the relevant tarball, along with its expected checksum.
+name = "fawltydeps"
+description = "Eating our own dog food..."
+url = "https://github.com/tweag/fawltydeps/archive/refs/tags/v0.13.3.tar.gz"
+sha256 = "d4036fd3a3bd9b08526a12ae1eb0e91557c353128c60cb47184fe613c52bcbdd"
+# The SHA256 checksum above can be found by running `sha256sum` on the
+# downloaded tarball. It is used to ensure that we run tests against the
+# expected revision of the 3rd-party project.
+
+# Below are our experiments which run FawltyDeps with various options on the
+# above (unpacked) tarball. Each table represents an experiment with the
+# command-line arguments we pass to FawltyDeps (in `args`, --json is implicitly
+# added by test_real_projects), as well as our expectations for what FawltyDeps
+# should return in that scenario. These expectations are encoded as lists of
+# import/dependency names which we expect to be present in the corresponding
+# parts of the JSON: imports, declared_deps, undeclared_deps, and unused_deps.
+# All these fields are optional, and the verification will be skipped for
+# missing fields.
+
+[experiments.default]
+description = "Run FD with no options, picking up config from pyproject.toml"
+requirements = [  # Direct deps with pinned versions resolved by Poetry
+    "importlib-metadata==6.7.0 ; python_version < '3.8'",
+    "importlib-metadata==7.0.1 ; python_version >= '3.8'",
+    "isort==5.11.5 ; python_version < '3.8'",
+    "isort==5.13.2 ; python_version >= '3.8'",
+    "pip-requirements-parser==32.0.1",
+    "pydantic==2.5.3",
+    "setuptools==68.0.0 ; python_version < '3.8'",
+    "setuptools==69.0.3 ; python_version >= '3.8'",
+    "tomli==2.0.1 ; python_version < '3.11'",
+    "types-setuptools==65.7.0.4",
+    "typing-extensions==4.7.1",
+]
+args = []
+# When we run FawltyDeps with the above arguments, we expect these results:
+undeclared_deps = []
+unused_deps =  []
+
+[experiments.exclude_overlap]
+description = """
+    Try to exclude "fawltydeps", but ineffective since code=fawltydeps from
+    pyproject.toml overrides this --exclude.
+    """
+requirements = [  # Direct deps with pinned versions resolved by Poetry
+    "importlib-metadata==6.7.0 ; python_version < '3.8'",
+    "importlib-metadata==7.0.1 ; python_version >= '3.8'",
+    "isort==5.11.5 ; python_version < '3.8'",
+    "isort==5.13.2 ; python_version >= '3.8'",
+    "pip-requirements-parser==32.0.1",
+    "pydantic==2.5.3",
+    "setuptools==68.0.0 ; python_version < '3.8'",
+    "setuptools==69.0.3 ; python_version >= '3.8'",
+    "tomli==2.0.1 ; python_version < '3.11'",
+    "types-setuptools==65.7.0.4",
+    "typing-extensions==4.7.1",
+]
+args = ["--exclude=fawltydeps"]
+# When we run FawltyDeps with the above arguments, we expect these results:
+undeclared_deps = []
+unused_deps =  []
+
+[experiments.exclude_dir_overlap]
+description = """
+    Try to exclude "fawltydeps/", but ineffective since code=fawltydeps from
+    pyproject.toml still overrides this --exclude.
+    """
+requirements = [  # Direct deps with pinned versions resolved by Poetry
+    "importlib-metadata==6.7.0 ; python_version < '3.8'",
+    "importlib-metadata==7.0.1 ; python_version >= '3.8'",
+    "isort==5.11.5 ; python_version < '3.8'",
+    "isort==5.13.2 ; python_version >= '3.8'",
+    "pip-requirements-parser==32.0.1",
+    "pydantic==2.5.3",
+    "setuptools==68.0.0 ; python_version < '3.8'",
+    "setuptools==69.0.3 ; python_version >= '3.8'",
+    "tomli==2.0.1 ; python_version < '3.11'",
+    "types-setuptools==65.7.0.4",
+    "typing-extensions==4.7.1",
+]
+args = ["--exclude=fawltydeps/"]
+# When we run FawltyDeps with the above arguments, we expect these results:
+undeclared_deps = []
+unused_deps =  []
+
+[experiments.exclude_no_overlap]
+description = """
+    Exclude "fawltydeps/*" successfully, since it does not directly overlap
+    with code=fawltydeps in pyproject.toml
+    """
+requirements = [  # Direct deps with pinned versions resolved by Poetry
+    "importlib-metadata==6.7.0 ; python_version < '3.8'",
+    "importlib-metadata==7.0.1 ; python_version >= '3.8'",
+    "isort==5.11.5 ; python_version < '3.8'",
+    "isort==5.13.2 ; python_version >= '3.8'",
+    "pip-requirements-parser==32.0.1",
+    "pydantic==2.5.3",
+    "setuptools==68.0.0 ; python_version < '3.8'",
+    "setuptools==69.0.3 ; python_version >= '3.8'",
+    "tomli==2.0.1 ; python_version < '3.11'",
+    "types-setuptools==65.7.0.4",
+    "typing-extensions==4.7.1",
+]
+args = ["--exclude=fawltydeps/*"]
+# When we run FawltyDeps with the above arguments, we expect these results:
+undeclared_deps = []
+unused_deps =  [
+    "importlib_metadata",
+    "isort",
+    "pip-requirements-parser",
+    "pydantic",
+    "setuptools",
+    "tomli",
+    "types-setuptools",
+    "typing-extensions",
+]
+
+[experiments.exclude_anchored]
+description = """
+    Exclude "fawltydeps/extract_*" successfully, since it does not directly
+    overlap with code=fawltydeps in pyproject.toml. This verifies that anchored
+    patterns can be passed on the command-line.
+    """
+requirements = [  # Direct deps with pinned versions resolved by Poetry
+    "importlib-metadata==6.7.0 ; python_version < '3.8'",
+    "importlib-metadata==7.0.1 ; python_version >= '3.8'",
+    "isort==5.11.5 ; python_version < '3.8'",
+    "isort==5.13.2 ; python_version >= '3.8'",
+    "pip-requirements-parser==32.0.1",
+    "pydantic==2.5.3",
+    "setuptools==68.0.0 ; python_version < '3.8'",
+    "setuptools==69.0.3 ; python_version >= '3.8'",
+    "tomli==2.0.1 ; python_version < '3.11'",
+    "types-setuptools==65.7.0.4",
+    "typing-extensions==4.7.1",
+]
+args = ["--exclude=fawltydeps/extract_*"]
+# When we run FawltyDeps with the above arguments, we expect these results:
+undeclared_deps = []
+unused_deps =  [
+    "isort",
+    "pip-requirements-parser",
+    "setuptools",
+    "types-setuptools",
+]

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -286,17 +286,6 @@ def test_list_imports__comment_in_exclude_pattern__fails_with_exit_code_2(tmp_pa
     assert returncode == 2
 
 
-def test_list_imports__error_in_exclude_pattern__fails_with_exit_code_2(tmp_path):
-    _output, errors, returncode = run_fawltydeps_subprocess(
-        "--list-imports", "--exclude=foo/bar"
-    )
-    assert (
-        "Error while parsing exclude pattern: Anchored pattern without base_dir: 'foo/bar'"
-        in errors
-    )
-    assert returncode == 2
-
-
 def test_list_imports__from_empty_dir__logs_but_extracts_nothing(tmp_path):
     # Enable log level INFO with --verbose
     expect_logs = [

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -523,6 +523,41 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
         ],
     ),
     DirectoryTraversalVector(
+        "exclude_pattern_without_slash_at_end__matches_dir_and_file",
+        given=[
+            File("dir1/some_path"),  # some_path is not a dir
+            File("dir2/some_path/a_file"),  # some_path is a dir
+        ],
+        exclude_patterns=[ExcludePattern("some_path")],  # matches both
+        expect=[
+            ExpectedTraverseStep(".", subdirs=["dir1", "dir2"]),
+            ExpectedTraverseStep("dir1", excluded_files=["some_path"]),
+            ExpectedTraverseStep("dir2", excluded_subdirs=["some_path"]),
+        ],
+    ),
+    DirectoryTraversalVector(
+        "exclude_pattern_with_slash_at_end__overridden_by_specified_path",
+        given=[File("dir/some_path/a_file")],
+        exclude_patterns=[ExcludePattern("some_path/")],
+        add=[AddCall(path="."), AddCall(path="dir/some_path")],
+        expect=[
+            ExpectedTraverseStep(".", subdirs=["dir"]),
+            ExpectedTraverseStep("dir", subdirs=["some_path"]),
+            ExpectedTraverseStep("dir/some_path", files=["a_file"]),
+        ],
+    ),
+    DirectoryTraversalVector(
+        "exclude_pattern_without_slash_at_end__overridden_by_specified_path",
+        given=[File("dir/some_path/a_file")],
+        exclude_patterns=[ExcludePattern("some_path")],
+        add=[AddCall(path="."), AddCall(path="dir/some_path")],
+        expect=[
+            ExpectedTraverseStep(".", subdirs=["dir"]),
+            ExpectedTraverseStep("dir", subdirs=["some_path"]),
+            ExpectedTraverseStep("dir/some_path", files=["a_file"]),
+        ],
+    ),
+    DirectoryTraversalVector(
         "exclude_pattern_with_combined_slashes_and_base_dir",
         given=[
             Dir("b"),

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -66,10 +66,9 @@ class AbsoluteSymlink(BaseEntry):
     target: str
 
     def __call__(self, tmp_path: Path):
-        assert tmp_path.is_absolute()
         path = tmp_path / self.path
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.symlink_to(tmp_path / self.target)
+        path.symlink_to(tmp_path.resolve() / self.target)
 
 
 @dataclass
@@ -896,6 +895,16 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
 def test_DirectoryTraversal_w_abs_paths(vector: DirectoryTraversalVector, tmp_path):
     traversal = vector.setup(tmp_path)  # Traverse tmp_path with absolute paths
     vector.verify_traversal(traversal, tmp_path)
+
+
+@pytest.mark.parametrize(
+    "vector", [pytest.param(v, id=v.id) for v in directory_traversal_vectors]
+)
+def test_DirectoryTraversal_w_rel_paths(
+    vector: DirectoryTraversalVector, inside_tmp_path
+):
+    traversal = vector.setup(Path("."))  # Traverse relatively from inside tmp_path
+    vector.verify_traversal(traversal, Path("."))
 
 
 def test_DirectoryTraversal__raises_error__when_adding_missing_dir(tmp_path):

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -18,53 +18,33 @@ class GitignoreParserTestVector(NamedTuple):
     patterns: List[str]
     does_match: List[PathOrStr]
     doesnt_match: List[PathOrStr]
-    base_dir: str = "/some/dir"
+    base_dir: str = "."
 
 
 test_vectors = [
     GitignoreParserTestVector(
         "simple",
         ["__pycache__/", "*.py[cod]"],
-        does_match=[
-            "/some/dir/main.pyc",
-            "/some/dir/dir/main.pyc",
-            "/some/dir/__pycache__/",
-        ],
-        doesnt_match=["/some/dir/main.py"],
+        does_match=["main.pyc", "dir/main.pyc", "__pycache__/"],
+        doesnt_match=["main.py"],
     ),
     GitignoreParserTestVector(
         "incomplete_filename",
         ["o.py"],
-        does_match=[
-            "/some/dir/o.py",
-            "/some/dir/dir/o.py",
-        ],
-        doesnt_match=[
-            "/some/dir/foo.py",
-            "/some/dir/o.pyc",
-            "/some/dir/dir/foo.py",
-            "/some/dir/dir/o.pyc",
-        ],
+        does_match=["o.py", "dir/o.py"],
+        doesnt_match=["foo.py", "o.pyc", "dir/foo.py", "dir/o.pyc"],
     ),
     GitignoreParserTestVector(
         "wildcard",
         ["hello.*"],
-        does_match=[
-            "/some/dir/hello.txt",
-            "/some/dir/hello.foobar/",
-            "/some/dir/dir/hello.txt",
-            "/some/dir/hello.",
-        ],
-        doesnt_match=[
-            "/some/dir/hello",
-            "/some/dir/helloX",
-        ],
+        does_match=["hello.txt", "hello.foobar/", "dir/hello.txt", "hello."],
+        doesnt_match=["hello", "helloX"],
     ),
     GitignoreParserTestVector(
         "anchored_wildcard",
         ["/hello.*"],
-        does_match=["/some/dir/hello.txt", "/some/dir/hello.c"],
-        doesnt_match=["/some/dir/a/hello.java"],
+        does_match=["hello.txt", "hello.c"],
+        doesnt_match=["a/hello.java"],
     ),
     GitignoreParserTestVector(
         "trailing_spaces",
@@ -76,155 +56,125 @@ test_vectors = [
             "notignoredmultiplespace\\ \\ \\ ",
         ],
         does_match=[
-            "/some/dir/ignoretrailingspace",
-            "/some/dir/partiallyignoredspace ",
-            "/some/dir/partiallyignoredspace2  ",
-            "/some/dir/notignoredspace ",
-            "/some/dir/notignoredmultiplespace   ",
+            "ignoretrailingspace",
+            "partiallyignoredspace ",
+            "partiallyignoredspace2  ",
+            "notignoredspace ",
+            "notignoredmultiplespace   ",
         ],
         doesnt_match=[
-            "/some/dir/ignoretrailingspace ",
-            "/some/dir/partiallyignoredspace  ",
-            "/some/dir/partiallyignoredspace",
-            "/some/dir/partiallyignoredspace2   ",
-            "/some/dir/partiallyignoredspace2 ",
-            "/some/dir/partiallyignoredspace2",
-            "/some/dir/notignoredspace",
-            "/some/dir/notignoredmultiplespace",
+            "ignoretrailingspace ",
+            "partiallyignoredspace  ",
+            "partiallyignoredspace",
+            "partiallyignoredspace2   ",
+            "partiallyignoredspace2 ",
+            "partiallyignoredspace2",
+            "notignoredspace",
+            "notignoredmultiplespace",
         ],
     ),
     GitignoreParserTestVector(
         "comment",
         ["somematch", "#realcomment", "othermatch", "\\#imnocomment"],
-        does_match=[
-            "/some/dir/somematch",
-            "/some/dir/othermatch",
-            "/some/dir/#imnocomment",
-        ],
-        doesnt_match=["/some/dir/#realcomment"],
+        does_match=["somematch", "othermatch", "#imnocomment"],
+        doesnt_match=["#realcomment"],
     ),
     GitignoreParserTestVector(
         "ignore_directory",
         [".venv/"],
         does_match=[
-            "/some/dir/.venv/",  # a dir
-            "/some/dir/.venv/folder/",
-            "/some/dir/.venv/file.txt",
+            ".venv/",  # a dir
+            ".venv/folder/",
+            ".venv/file.txt",
         ],
         doesnt_match=[
-            "/some/dir/.venv",  # not a dir
-            "/some/dir/.venv_other_folder",
-            "/some/dir/.venv_no_folder.py",
+            ".venv",  # not a dir
+            ".venv_other_folder",
+            ".venv_no_folder.py",
         ],
     ),
     GitignoreParserTestVector(
         "ignore_directory_asterisk",
         [".venv/*"],
-        does_match=["/some/dir/.venv/folder/", "/some/dir/.venv/file.txt"],
-        doesnt_match=["/some/dir/.venv"],
+        does_match=[".venv/folder/", ".venv/file.txt"],
+        doesnt_match=[".venv"],
     ),
     GitignoreParserTestVector(
         "negation",
         ["*.ignore", "!keep.ignore"],
-        does_match=["/some/dir/trash.ignore", "/some/dir/waste.ignore"],
-        doesnt_match=["/some/dir/keep.ignore"],
+        does_match=["trash.ignore", "waste.ignore"],
+        doesnt_match=["keep.ignore"],
     ),
     GitignoreParserTestVector(
         "literal_exclamation_mark",
         ["\\!ignore_me!"],
-        does_match=["/some/dir/!ignore_me!"],
-        doesnt_match=["/some/dir/ignore_me!", "/some/dir/ignore_me"],
+        does_match=["!ignore_me!"],
+        doesnt_match=["ignore_me!", "ignore_me"],
     ),
     GitignoreParserTestVector(
         "double_asterisks",
         ["foo/**/Bar"],
-        does_match=[
-            "/some/dir/foo/hello/Bar",
-            "/some/dir/foo/world/Bar",
-            "/some/dir/foo/Bar",
-        ],
-        doesnt_match=["/some/dir/foo/BarBar"],
+        does_match=["foo/hello/Bar", "foo/world/Bar", "foo/Bar"],
+        doesnt_match=["foo/BarBar"],
     ),
     GitignoreParserTestVector(
         "double_asterisk_without_slashes_handled_like_single_asterisk",
         ["a/b**c/d"],
-        does_match=[
-            "/some/dir/a/bc/d",
-            "/some/dir/a/bXc/d",
-            "/some/dir/a/bbc/d",
-            "/some/dir/a/bcc/d",
-        ],
-        doesnt_match=[
-            "/some/dir/a/bcd",
-            "/some/dir/a/b/c/d",
-            "/some/dir/a/bb/cc/d",
-            "/some/dir/a/bb/XX/cc/d",
-        ],
+        does_match=["a/bc/d", "a/bXc/d", "a/bbc/d", "a/bcc/d"],
+        doesnt_match=["a/bcd", "a/b/c/d", "a/bb/cc/d", "a/bb/XX/cc/d"],
     ),
     GitignoreParserTestVector(
         "more_asterisks_handled_like_single_asterisk_1",
         ["***a/b"],
-        does_match=["/some/dir/XYZa/b"],
-        doesnt_match=["/some/dir/foo/a/b"],
+        does_match=["XYZa/b"],
+        doesnt_match=["foo/a/b"],
     ),
     GitignoreParserTestVector(
         "more_asterisks_handled_like_single_asterisk_2",
         ["a/b***"],
-        does_match=["/some/dir/a/bXYZ"],
-        doesnt_match=["/some/dir/a/b/foo"],
+        does_match=["a/bXYZ"],
+        doesnt_match=["a/b/foo"],
     ),
     GitignoreParserTestVector(
         "directory_only_negation",
         ["data/**", "!data/**/", "!.gitkeep", "!data/01_raw/*"],
-        does_match=["/some/dir/data/02_processed/processed_file.csv"],
+        does_match=["data/02_processed/processed_file.csv"],
         doesnt_match=[
-            "/some/dir/data/01_raw/",
-            "/some/dir/data/01_raw/.gitkeep",
-            "/some/dir/data/01_raw/raw_file.csv",
-            "/some/dir/data/02_processed/",
-            "/some/dir/data/02_processed/.gitkeep",
+            "data/01_raw/",
+            "data/01_raw/.gitkeep",
+            "data/01_raw/raw_file.csv",
+            "data/02_processed/",
+            "data/02_processed/.gitkeep",
         ],
     ),
     GitignoreParserTestVector(
         "single_asterisk",
         ["*"],
-        does_match=[
-            "/some/dir/file.txt",
-            "/some/dir/directory/",
-            "/some/dir/directory-trailing/",
-        ],
+        does_match=["file.txt", "directory/", "directory-trailing/"],
         doesnt_match=[],
     ),
     GitignoreParserTestVector(
         "supports_path_type_argument",
         ["file1", "!file2"],
-        does_match=[Path("/some/dir/file1")],
-        doesnt_match=[Path("/some/dir/file2")],
+        does_match=[Path("file1")],
+        doesnt_match=[Path("file2")],
     ),
     GitignoreParserTestVector(
         "slash_in_range_does_not_match_dirs",
         ["abc[X-Z/]def"],
-        does_match=[
-            "/some/dir/abcXdef",
-            "/some/dir/abcYdef",
-            "/some/dir/abcZdef",
-        ],
-        doesnt_match=[
-            "/some/dir/abcdef",
-            "/some/dir/abc/def",
-            "/some/dir/abcXYZdef",
-        ],
+        does_match=["abcXdef", "abcYdef", "abcZdef"],
+        doesnt_match=["abcdef", "abc/def", "abcXYZdef"],
     ),
 ]
 
 
 @pytest.mark.parametrize("vector", [pytest.param(v, id=v.id) for v in test_vectors])
-def test_gitignore_parser(vector: GitignoreParserTestVector):
+def test_gitignore_parser_w_abs_paths(vector: GitignoreParserTestVector):
     def absolutify(path: PathOrStr) -> Path:
-        """Make Unix-style absolute paths also absolute on Windows."""
-        if sys.platform.startswith("win") and str(path).startswith(("/", "\\")):
-            return Path("C:" + str(path))
-        return Path(path)
+        """Make relative paths absolute. on both POSIX and Windows."""
+        if sys.platform.startswith("win"):
+            return Path("C:/some/dir", str(path))
+        return Path("/some/dir", path)
 
     base_dir = absolutify(vector.base_dir)
     rules = list(

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -192,6 +192,25 @@ def test_gitignore_parser_w_abs_paths(vector: GitignoreParserTestVector):
         )
 
 
+@pytest.mark.parametrize("vector", [pytest.param(v, id=v.id) for v in test_vectors])
+def test_gitignore_parser_w_rel_paths(vector: GitignoreParserTestVector):
+    rules = list(
+        parse_gitignore_lines(
+            vector.patterns, Path(vector.base_dir), Path(vector.base_dir, ".gitignore")
+        )
+    )
+    # Use a trailing '/' in the test vectors to signal is_dir=True.
+    # This trailing slash is stripped by Path() in any case.
+    for path in vector.does_match:
+        assert match_rules(
+            rules, Path(path), isinstance(path, str) and path.endswith("/")
+        )
+    for path in vector.doesnt_match:
+        assert not match_rules(
+            rules, Path(path), isinstance(path, str) and path.endswith("/")
+        )
+
+
 def test_symlink_to_another_directory(tmp_path):
     project_dir = tmp_path / "project_dir"
     link = project_dir / "link"

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -84,12 +84,32 @@ test_vectors = [
         [".venv/"],
         does_match=[
             ".venv/",  # a dir
-            ".venv/folder/",
-            ".venv/file.txt",
+            "subdir/.venv/",
         ],
         doesnt_match=[
             ".venv",  # not a dir
             ".venv_other_folder",
+            ".venv_no_folder.py",
+            # The following two has been moved from does_match to doesnt_match,
+            # and reflect that gitignore_parser no longer evaluates patterns in
+            # complete isolation. Instead, it expects parent dirs to be tested/
+            # matched _before_ their children. If a parent matches (i.e. should
+            # be ignored) then we don't expect the child to be tested at all
+            # (i.e. the parent dir is never traversed). Thus, the child is NOT
+            # responsible for matching its parent dir against the pattern.
+            ".venv/folder/",  # folder/ does not match .venv/
+            ".venv/file.txt",  # file.txt does not match .venv/
+        ],
+    ),
+    GitignoreParserTestVector(
+        "ignore_directory_also_without_trailing_slash",
+        [".venv"],
+        does_match=[
+            ".venv/",  # a dir
+            ".venv",  # not a dir
+        ],
+        doesnt_match=[
+            ".venv_other_folder/",
             ".venv_no_folder.py",
         ],
     ),

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -7,7 +7,6 @@ should find/report.
 """
 import json
 import logging
-import os
 import subprocess
 import sys
 import tarfile
@@ -53,9 +52,9 @@ def verify_requirements(venv_path: Path, requirements: List[str]) -> None:
 def run_fawltydeps_json(
     *args: str, venv_dir: Optional[Path], cwd: Optional[Path] = None
 ) -> JsonData:
-    argv = [sys.executable, "-m", "fawltydeps", f"--config-file={os.devnull}", "--json"]
+    argv = [sys.executable, "-I", "-m", "fawltydeps", "--json"]
     if venv_dir is not None:
-        argv += [f"--pyenv={venv_dir}"]
+        argv += [f"--pyenv={venv_dir}", "--pyenv=."]
     proc = subprocess.run(
         argv + list(args),
         stdout=subprocess.PIPE,

--- a/tests/test_traverse_project.py
+++ b/tests/test_traverse_project.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Set, Type
 
 import pytest
 
-from fawltydeps.gitignore_parser import RuleError, RuleMissing
+from fawltydeps.gitignore_parser import RuleMissing
 from fawltydeps.settings import ParserChoice, Settings
 from fawltydeps.traverse_project import find_sources
 from fawltydeps.types import (
@@ -523,29 +523,14 @@ find_sources_vectors = [
     TraverseProjectVector(
         "empty_exclude_pattern__raises_RuleMissing",
         "empty",
-        code=set(),
-        deps=set(),
-        pyenvs=set(),
         exclude={"", "\t", "    "},
         expect_raised=RuleMissing,
     ),
     TraverseProjectVector(
         "comment_exclude_pattern__raises_RuleMissing",
         "empty",
-        code=set(),
-        deps=set(),
-        pyenvs=set(),
         exclude={"# a comment", "# another comment"},
         expect_raised=RuleMissing,
-    ),
-    TraverseProjectVector(
-        "anchored_exclude_pattern_without_basedir__raises_RuleError",
-        "empty",
-        code=set(),
-        deps=set(),
-        pyenvs=set(),
-        exclude={"foo/bar"},
-        expect_raised=RuleError,
     ),
     TraverseProjectVector(
         "disabling_default_exclude__causes_hidden_files_to_be_found",


### PR DESCRIPTION
Thanks to Maria for actually _testing_ the new `--exclude` option from a user's POV, and notifying me of various griveous issues found. Here we try to tackle the ones that were found and raise in the later stages of #388:

- Running `fawltydeps` with `--exclude` and passing relative paths instead of absolute (our test suite relies too heavily on absolute paths)
- Passing "anchored" exclude patterns to `--exclude` was initially unsupported. Fix that.
- Give the user a warning when the `--exclude` option directly overlaps with a given path (in which case the given path will always win).
- Fix issues where the precedence between `--exclude` patterns and given paths were not followed in practice.
