### PR TITLE
real_projects/python-algorithms: Pin qiskit at <1.0

### DIFF
--- a/tests/real_projects/python-algorithms.toml
+++ b/tests/real_projects/python-algorithms.toml
@@ -116,7 +116,7 @@ requirements = [
     "pandas",
     "pillow",
     "projectq",
-    "qiskit",
+    "qiskit<1",
     "requests",
     "rich",
     "scikit-fuzzy",


### PR DESCRIPTION
qiskit v1.0 starts to declare the `qiskit` import name (see issue #176 for
details about the weirdness that precedes v1.0). This changes the
behavior of our `real_projects` test of the Algortihms project.

qiskit has also dropped support for Python 3.7 (since v0.44), hence it
is easier for us to keep our tests (which need to work with Python 3.7)
running on the older version, for now.
