### PR TITLE
Dev/test environment: Support Python dependencies with pre-built binaries on Nix

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -10,6 +10,7 @@ jobs:
         python-version: ["3.11"]
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,8 @@ jobs:
   publish:
     needs: [tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v3

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,4 @@
 import hashlib
-import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -86,8 +85,6 @@ def integration_tests(session):
 def self_test(session):
     # Install all optional dependency groups for a self test
     install_groups(session, include=["nox", "test", "lint", "format", "dev"])
-    # For --pyenv, use Nox's virtualenv, or fall back to current virtualenv
-    venv_path = getattr(session.virtualenv, "location", sys.prefix)
     session.run("fawltydeps")
 
 

--- a/shell.nix
+++ b/shell.nix
@@ -24,6 +24,11 @@ pkgs.mkShell {
     python311
     python312
     poetry
+
+    # Allow installation of binary wheels by (a) providing manylinux2014
+    # support, and (b) patching binaries installed into the Poetry virtualenv.
+    autoPatchelfHook
+    pythonManylinuxPackages.manylinux2014
   ];
   shellHook = ''
     # This is needed to keep python3.7 working while in the same nix-shell
@@ -34,6 +39,8 @@ pkgs.mkShell {
 
     poetry env use "${pkgs.python311}/bin/python"
     poetry install --sync --with=dev
+    # Patch binaries in the Poetry virtualenv to link against Nix deps
+    autoPatchelf "$(poetry env info --path)"
     source "$(poetry env info --path)/bin/activate"
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,18 @@
 {
-  pkgsWith37 ? import (builtins.fetchTarball {
+  pkgsWithOldPythons ? import (builtins.fetchTarball {
     # Branch: nixos-22.11
     url = "https://github.com/NixOS/nixpkgs/archive/96e18717904dfedcd884541e5a92bf9ff632cf39.tar.gz";
     sha256 = "0zw1851mia86xqxdf8jgy1c6fm5lqw4rncv7v2lwxar3vhpn6c78";
   }) {},
-  python37_overlay ? self: super: { python37 = pkgsWith37.python37; },
+  old_pythons_overlay ? self: super: {
+    python37 = pkgsWithOldPythons.python37;
+    python38 = pkgsWithOldPythons.python38;
+  },
   pkgs ? import (builtins.fetchTarball {
     # Branch: nixos-unstable
-    url = "https://github.com/NixOS/nixpkgs/archive/1fcb41f796d091e9ebcd90d28c8fd8b5b93231be.tar.gz";
-    sha256 = "1crwvpvqrx7s4i0iygl99q7jlm07hxch4c8pzfnc98aqz6754a80";
-  }) { overlays = [ python37_overlay ]; }
+    url = "https://github.com/NixOS/nixpkgs/archive/c75037bbf9093a2acb617804ee46320d6d1fea5a.tar.gz";
+    sha256 = "1hs4rfylv0f1sbyhs1hf4f7jsq4np498fbcs5xjlmrkwhx4lpgmc";
+  }) { overlays = [ old_pythons_overlay ]; }
 }:
 pkgs.mkShell {
   name = "fawltydeps-env";


### PR DESCRIPTION
This is in preparation for adding the `ruff` linter to FawltyDeps.

Commits:
- `.github/workflows`: Add timeouts to GitHub CI actions
- `noxfile.py`: Remove unused variable
- `shell.nix`: Update to current nixos-unstable
- `shell.nix`: Add support for installing wheels with compiled binaries
- `noxfile.py`: On Nix, auto-patch binaries installed by Nox
