### PR TITLE
Make ruff much stricter

### DIFF
--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -22,10 +22,10 @@ class ArgparseUnionAction(argparse.Action):
 
     def __call__(  # type: ignore[misc, override]
         self,
-        parser: argparse.ArgumentParser,
+        _parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
         values: Sequence[Any],
-        option_string: Optional[str] = None,
+        _option_string: Optional[str] = None,
     ) -> None:
         """Compute the union of 'values' and any previously given values'."""
         items = getattr(namespace, self.dest, [])

--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -18,7 +18,7 @@ from fawltydeps.utils import version
 
 
 class ArgparseUnionAction(argparse.Action):
-    """Action for doing taking union of multiple command-line arguments for a single option"""
+    """Action to take the union of given arguments/values for one CLI option."""
 
     def __call__(  # type: ignore[misc, override]
         self,
@@ -27,6 +27,7 @@ class ArgparseUnionAction(argparse.Action):
         values: Sequence[Any],
         option_string: Optional[str] = None,
     ) -> None:
+        """Compute the union of 'values' and any previously given values'."""
         items = getattr(namespace, self.dest, [])
         setattr(namespace, self.dest, set(items) | set(values))
 
@@ -274,7 +275,7 @@ def populate_parser_configuration(parser: argparse._ActionsContainer) -> None:
 
 
 def populate_parser_other_options(parser: argparse._ActionsContainer) -> None:
-    """Add options not related to the Settings object"""
+    """Add options not related to the Settings object."""
     parser.add_argument(
         "--generate-toml-config",
         action="store_true",

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -177,9 +177,9 @@ class DirectoryTraversal(Generic[T]):
             list(parse_gitignore(file_with_exclude_patterns)) + self.exclude_rules
         )
 
-    def is_excluded(self, path: Path, is_dir: bool) -> bool:
+    def is_excluded(self, path: Path, *, is_dir: bool) -> bool:
         """Check if given path is excluded by any of our exclude rules."""
-        return match_rules(self.exclude_rules, path, is_dir)
+        return match_rules(self.exclude_rules, path, is_dir=is_dir)
 
     def traverse(self) -> Iterator[TraversalStep[T]]:
         """Perform the traversal of the added directories.
@@ -240,14 +240,14 @@ class DirectoryTraversal(Generic[T]):
                 exclude_subdirs = {
                     path
                     for path in subdir_paths
-                    if self.is_excluded(path, True)
+                    if self.is_excluded(path, is_dir=True)
                     and (DirId.from_path(path) not in remaining.values())
                 }
                 for subdir in exclude_subdirs:
                     logger.debug(f"    skip traversing excluded subdir {subdir}")
                     self.skip_dir(subdir)
                 exclude_files = {
-                    path for path in file_paths if self.is_excluded(path, False)
+                    path for path in file_paths if self.is_excluded(path, is_dir=False)
                 }
 
                 # At this yield, the caller takes over control, and may modify

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -43,7 +43,7 @@ class DirId(NamedTuple):
     @lru_cache()  # Cache stat() calls, but only with absolute paths
     def from_abs_path(cls, abs_path: Path) -> DirId:
         """Construct DirId from given absolute directory path."""
-        assert abs_path.is_absolute()  # sanity check
+        assert abs_path.is_absolute()  # noqa: S101, sanity check
         dir_stat = abs_path.stat()  # <- expensive
         return cls(dir_stat.st_dev, dir_stat.st_ino)
 
@@ -222,7 +222,7 @@ class DirectoryTraversal(Generic[T]):
                 break
             logger.debug(f"Left to traverse: {remaining}")
             base_dir = min(remaining.keys())
-            assert base_dir.is_dir()  # sanity check
+            assert base_dir.is_dir()  # noqa: S101, sanity check
             for cur, subdirs, filenames in os.walk(base_dir, followlinks=True):
                 cur_dir = Path(cur)
                 cur_id = DirId.from_path(cur_dir)

--- a/fawltydeps/dir_traversal.py
+++ b/fawltydeps/dir_traversal.py
@@ -209,8 +209,7 @@ class DirectoryTraversal(Generic[T]):
             yield each attached data item in the order they were attached.
             """
             for dir_path in reversed(list(dirs_between(parent_dir, child_dir))):
-                for data in self.attached.get(DirId.from_path(dir_path), []):
-                    yield data
+                yield from self.attached.get(DirId.from_path(dir_path), [])
 
         while True:
             remaining = {

--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -1,4 +1,4 @@
-"""Collect declared dependencies of the project"""
+"""Collect declared dependencies of the project."""
 
 import ast
 import configparser
@@ -38,7 +38,7 @@ NamedLocations = Iterator[Tuple[str, Location]]
 
 
 class DependencyParsingError(Exception):
-    """Error raised when parsing of dependency fails"""
+    """Error raised when parsing of dependency fails."""
 
     def __init__(self, node: ast.AST):
         super().__init__(node)
@@ -46,7 +46,7 @@ class DependencyParsingError(Exception):
 
 
 def parse_one_req(req_text: str, source: Location) -> DeclaredDependency:
-    """Returns the name of a dependency declared in a requirement specifier."""
+    """Return the name of a dependency declared in a requirement specifier."""
     req = Requirement.parse(req_text)
     req_name = req.unsafe_name
     return DeclaredDependency(req_name, source)
@@ -273,8 +273,7 @@ def parse_pep621_pyproject_contents(  # noqa: C901
 def parse_dynamic_pyproject_contents(
     parsed_contents: TomlData, source: Location
 ) -> Iterator[DeclaredDependency]:
-    """Extract dynamic dependencies from a pyproject.toml using the PEP 621 fields"""
-
+    """Extract dynamic dependencies from a pyproject.toml using the PEP 621 fields."""
     dynamic = parsed_contents["project"]["dynamic"]
 
     deps_files = []
@@ -364,7 +363,7 @@ def parse_pyproject_toml(path: Path) -> Iterator[DeclaredDependency]:
 
 
 class ParsingStrategy(NamedTuple):
-    """Named pairing of an applicability criterion and a dependency parser"""
+    """Named pairing of an applicability criterion and a dependency parser."""
 
     applies_to_path: Callable[[Path], bool]
     execute: Callable[[Path], Iterator[DeclaredDependency]]

--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -7,7 +7,6 @@ import re
 import sys
 import tokenize
 from dataclasses import replace
-from os import unlink
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Callable, Iterable, Iterator, NamedTuple, Optional, Tuple
@@ -169,7 +168,7 @@ def parse_setup_cfg(path: Path) -> Iterator[DeclaredDependency]:
             for dep in parse_requirements_txt(Path(temp_file.name)):
                 yield replace(dep, source=source)
         finally:
-            unlink(Path(temp_file.name))
+            Path(temp_file.name).unlink()
 
     def extract_section(section: str) -> Iterator[DeclaredDependency]:
         if section in parser:

--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -65,7 +65,7 @@ def parse_requirements_txt(path: Path) -> Iterator[DeclaredDependency]:
             yield DeclaredDependency(dep.name, source)
 
 
-def parse_setup_py(path: Path) -> Iterator[DeclaredDependency]:
+def parse_setup_py(path: Path) -> Iterator[DeclaredDependency]:  # noqa: C901
     """Extract dependencies (package names) from setup.py.
 
     This file can contain arbitrary Python code, and simply executing it has
@@ -80,7 +80,9 @@ def parse_setup_py(path: Path) -> Iterator[DeclaredDependency]:
     # resolve any variable references in the arguments to the setup() call.
     tracked_vars = VariableTracker(source)
 
-    def _extract_deps_from_setup_call(node: ast.Call) -> Iterator[DeclaredDependency]:
+    def _extract_deps_from_setup_call(  # noqa: C901
+        node: ast.Call,
+    ) -> Iterator[DeclaredDependency]:
         for keyword in node.keywords:
             try:
                 if keyword.arg == "install_requires":
@@ -203,14 +205,16 @@ def parse_poetry_pyproject_dependencies(
 
     def parse_main(contents: TomlData, src: Location) -> NamedLocations:
         return (
-            (req, src) for req in contents["dependencies"].keys() if req != "python"
+            (req, src)
+            for req in contents["dependencies"].keys()  # noqa: SIM118
+            if req != "python"
         )
 
     def parse_group(contents: TomlData, src: Location) -> NamedLocations:
         return (
             (req, src)
             for group in contents["group"].values()
-            for req in group["dependencies"].keys()
+            for req in group["dependencies"].keys()  # noqa: SIM118
             if req != "python"
         )
 
@@ -230,7 +234,7 @@ def parse_poetry_pyproject_dependencies(
     yield from parse_pyproject_elements(poetry_config, source, "Poetry", fields_parsers)
 
 
-def parse_pep621_pyproject_contents(
+def parse_pep621_pyproject_contents(  # noqa: C901
     parsed_contents: TomlData, source: Location
 ) -> Iterator[DeclaredDependency]:
     """Extract dependencies from a pyproject.toml using the PEP 621 fields."""

--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -260,9 +260,8 @@ def parse_pep621_pyproject_contents(  # noqa: C901
                 fields_parsers = []
             else:
                 fields_parsers = [("optional", parse_optional)]
-        else:
-            if "optional-dependencies" in parsed_contents["project"]["dynamic"]:
-                fields_parsers = [("main", parse_main)]
+        elif "optional-dependencies" in parsed_contents["project"]["dynamic"]:
+            fields_parsers = [("main", parse_main)]
 
     yield from parse_pyproject_elements(
         parsed_contents, source, "PEP621", fields_parsers

--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -427,6 +427,7 @@ def parse_sources(sources: Iterable[DepsSource]) -> Iterator[DeclaredDependency]
 def validate_deps_source(
     path: Path,
     parser_choice: Optional[ParserChoice] = None,
+    *,
     filter_by_parser: bool = False,
 ) -> Optional[DepsSource]:
     """Check if the given file path is a valid source for parsing declared deps.

--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -21,7 +21,7 @@ from fawltydeps.types import (
     DepsSource,
     Location,
     TomlData,
-    UnparseablePathException,
+    UnparseablePathError,
 )
 
 if sys.version_info >= (3, 11):
@@ -436,7 +436,7 @@ def validate_deps_source(
       how to parse.
     - Return None if this is a directory that must be traversed further to find
       parseable files within.
-    - Raise UnparseablePathException if the given path cannot be parsed.
+    - Raise UnparseablePathError if the given path cannot be parsed.
 
     The given 'parser_choice' and 'filter_by_parser' determine which file paths
     we consider valid sources, and how they are parsed: With parser_choice=None,
@@ -448,20 +448,20 @@ def validate_deps_source(
     if path.is_dir():
         return None
     if not path.is_file():
-        raise UnparseablePathException(
+        raise UnparseablePathError(
             ctx="Dependencies declaration path is neither dir nor file", path=path
         )
 
     if parser_choice is not None:
         # User wants a specific parser, but only if the file matches:
         if filter_by_parser and not PARSER_CHOICES[parser_choice].applies_to_path(path):
-            raise UnparseablePathException(
+            raise UnparseablePathError(
                 ctx=f"Path does not match {parser_choice} parser", path=path
             )
     else:  # no parser chosen, automatically determine parser for this path
         parser_choice = first_applicable_parser(path)
     if parser_choice is None:  # no suitable parser given
-        raise UnparseablePathException(
+        raise UnparseablePathError(
             ctx="Parsing given dependencies path isn't supported", path=path
         )
     return DepsSource(path, parser_choice)

--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -452,12 +452,12 @@ def validate_deps_source(
             ctx="Dependencies declaration path is neither dir nor file", path=path
         )
 
-    if parser_choice is not None:  # user wants a specific parser
-        if filter_by_parser:  # but only if the file matches
-            if not PARSER_CHOICES[parser_choice].applies_to_path(path):
-                raise UnparseablePathException(
-                    ctx=f"Path does not match {parser_choice} parser", path=path
-                )
+    if parser_choice is not None:
+        # User wants a specific parser, but only if the file matches:
+        if filter_by_parser and not PARSER_CHOICES[parser_choice].applies_to_path(path):
+            raise UnparseablePathException(
+                ctx=f"Path does not match {parser_choice} parser", path=path
+            )
     else:  # no parser chosen, automatically determine parser for this path
         parser_choice = first_applicable_parser(path)
     if parser_choice is None:  # no suitable parser given

--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -34,7 +34,7 @@ def make_isort_config(path: Path, src_paths: Tuple[Path, ...] = ()) -> isort.Con
     )
 
 
-ISORT_FALLBACK_CONFIG = make_isort_config(Path("."))
+ISORT_FALLBACK_CONFIG = make_isort_config(Path())
 
 
 def parse_code(
@@ -95,7 +95,7 @@ def parse_notebook_file(  # noqa: C901
     they appear in the file.
     """
     if not local_context:
-        local_context = make_isort_config(Path("."), (path.parent,))
+        local_context = make_isort_config(Path(), (path.parent,))
 
     def filter_out_magic_commands(
         lines: Iterable[str], source: Location
@@ -159,7 +159,7 @@ def parse_python_file(
     they appear in the file.
     """
     if not local_context:
-        local_context = make_isort_config(Path("."), (path.parent,))
+        local_context = make_isort_config(Path(), (path.parent,))
     with tokenize.open(path) as pyfile:
         yield from parse_code(
             pyfile.read(), source=Location(path), local_context=local_context

--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -86,7 +86,7 @@ def parse_code(
                     )
 
 
-def parse_notebook_file(
+def parse_notebook_file(  # noqa: C901
     path: Path, local_context: Optional[isort.Config] = None
 ) -> Iterator[ParsedImport]:
     """Extract import statements from an ipynb notebook.
@@ -185,7 +185,7 @@ def parse_source(
             logger.warning("Reading code from terminal input. Ctrl+D to stop.")
         return parse_code(stdin.read(), source=Location(src.path))
 
-    assert isinstance(src.path, Path)  # sanity check / silence mypy
+    assert isinstance(src.path, Path)  # noqa: S101, sanity check / silence mypy
 
     local_context = (
         None
@@ -226,7 +226,7 @@ def validate_code_source(
     """
     if path == "<stdin>":
         return CodeSource(path, base_dir)
-    assert isinstance(path, Path)  # sanity check: SpecialPath handled above
+    assert isinstance(path, Path)  # noqa: S101, sanity check: SpecialPath handled above
     if path.is_dir():
         logger.info("Finding Python files under %s", path)
         return None

--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -14,7 +14,7 @@ from fawltydeps.types import (
     Location,
     ParsedImport,
     PathOrSpecial,
-    UnparseablePathException,
+    UnparseablePathError,
 )
 from fawltydeps.utils import dirs_between
 
@@ -178,7 +178,7 @@ def parse_source(
     """
     if src.path == "<stdin>":
         if stdin is None:
-            raise UnparseablePathException(ctx="Missing <stdin> handle", path=Path("-"))
+            raise UnparseablePathError(ctx="Missing <stdin> handle", path=Path("-"))
         logger.info("Parsing Python code from standard input")
         # 'isatty' checks if the stream is interactive.
         if stdin.isatty():
@@ -222,7 +222,7 @@ def validate_code_source(
       file (or the "<stdin>" special case).
     - Return None if this is a directory that must be traversed further to find
       parseable files within.
-    - Raise UnparseablePathException if the given path cannot be parsed.
+    - Raise UnparseablePathError if the given path cannot be parsed.
     """
     if path == "<stdin>":
         return CodeSource(path, base_dir)

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -78,7 +78,7 @@ def parse_gitignore_lines(
     """
     for lineno, line in enumerate(lines, start=1):
         source = None if file_hint is None else Location(file_hint, lineno=lineno)
-        line = line.rstrip("\n")
+        line = line.rstrip("\n")  # noqa: PLW2901
         try:
             yield Rule.from_pattern(line, base_dir, source)
         except RuleMissing as exc:
@@ -114,7 +114,7 @@ class Rule(NamedTuple):
         return f"Rule({self.pattern!r}, {self.regex!r}, ...)"
 
     @classmethod
-    def from_pattern(
+    def from_pattern(  # noqa: C901
         cls,
         pattern: str,
         base_dir: Optional[Path] = None,
@@ -234,7 +234,7 @@ def fnmatch_pathname_to_regex(pattern: str, anchored: bool = False) -> CompiledR
     result = []
 
     def handle_character_set(pattern: str) -> Tuple[str, str]:
-        assert pattern.startswith("[")  # precondition
+        assert pattern.startswith("[")  # noqa: S101, sanity check precondition
         try:
             end = pattern.index("]")
         except ValueError:  # "]" not found

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -43,7 +43,7 @@ class RuleError(ValueError):
         return f"{self.msg}: {self.pattern!r}"
 
 
-class RuleMissing(RuleError):
+class RuleMissing(RuleError):  # noqa: N818
     """A blank line or comment passed to DirectoryTraversal.ignore()."""
 
 

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -58,7 +58,7 @@ def parse_gitignore(full_path: Path, base_dir: Optional[Path] = None) -> Iterato
     """
     if base_dir is None:
         base_dir = full_path.parent
-    with open(full_path) as ignore_file:
+    with Path(full_path).open() as ignore_file:
         yield from parse_gitignore_lines(ignore_file, base_dir, full_path)
 
 

--- a/fawltydeps/gitignore_parser.py
+++ b/fawltydeps/gitignore_parser.py
@@ -86,10 +86,10 @@ def parse_gitignore_lines(
             logger.debug(str(exc))
 
 
-def match_rules(rules: List[Rule], path: Path, is_dir: bool) -> bool:
+def match_rules(rules: List[Rule], path: Path, *, is_dir: bool) -> bool:
     """Match the given path against the given list of rules."""
     for rule in reversed(rules):
-        if rule.match(path, is_dir):
+        if rule.match(path, is_dir=is_dir):
             return not rule.negated
     return False
 
@@ -186,7 +186,7 @@ class Rule(NamedTuple):
 
         return cls(
             pattern=orig_pattern,
-            regex=fnmatch_pathname_to_regex(pattern, anchored),
+            regex=fnmatch_pathname_to_regex(pattern, anchored=anchored),
             negated=negated,
             dir_only=dir_only,
             anchored=anchored,
@@ -194,7 +194,7 @@ class Rule(NamedTuple):
             source=source,
         )
 
-    def match(self, path: Path, is_dir: bool) -> bool:
+    def match(self, path: Path, *, is_dir: bool) -> bool:
         """Return True iff the given path should be ignored."""
         if self.base_dir:
             try:
@@ -225,7 +225,7 @@ NONSEP = rf"[^{'|'.join(SEPS)}]"
 
 # Frustratingly, python's fnmatch doesn't provide the FNM_PATHNAME option that
 # .gitignore's behavior depends on, so convert the pattern to a regex instead.
-def fnmatch_pathname_to_regex(pattern: str, anchored: bool = False) -> CompiledRegex:
+def fnmatch_pathname_to_regex(pattern: str, *, anchored: bool = False) -> CompiledRegex:
     """Convert the given fnmatch-style pattern to the equivalent regex.
 
     Implements fnmatch style-behavior, as though with FNM_PATHNAME flagged;

--- a/fawltydeps/limited_eval.py
+++ b/fawltydeps/limited_eval.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 TrackedValue = Union[str, List[str], Dict[str, "TrackedValue"]]
 
 
-class CannotResolve(Exception):
+class CannotResolve(Exception):  # noqa: N818
     """Error raised when we fail to resolve the value of a variable."""
 
     def __init__(self, node: ast.AST, source: Location):

--- a/fawltydeps/limited_eval.py
+++ b/fawltydeps/limited_eval.py
@@ -66,10 +66,8 @@ class VariableTracker:
                         )
                 else:
                     logger.warning(f"Don't known how to parse {self._dump(node)}")
-        elif isinstance(node, ast.AnnAssign):
-            logger.warning(f"Don't known how to parse {self._dump(node)}!")
-        elif isinstance(node, ast.AugAssign):
-            logger.warning(f"Don't known how to parse {self._dump(node)}!")
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            logger.warning(f"Don't know how to parse {self._dump(node)}!")
 
     def resolve(self, node: ast.AST) -> TrackedValue:
         """Convert a literal or a variable reference to the ultimate value.
@@ -93,9 +91,12 @@ class VariableTracker:
                 for key, val in zip(node.keys, node.values)
                 if isinstance(key, ast.AST)
             }
-        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
-            if node.id in self.vars:
-                return self.vars[node.id]
+        if (
+            isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id in self.vars
+        ):
+            return self.vars[node.id]
 
         logger.warning(f"Unable to resolve {self._dump(node)}")
         raise CannotResolve(node, self.source.supply(lineno=node.lineno))

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -263,7 +263,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
                 for dep in sorted(unique_deps, key=attrgetter("source", "name")):
                     yield f"{dep.source}: {dep.name}"
             else:
-                yield from sorted(set(d.name for d in self.declared_deps))
+                yield from sorted({d.name for d in self.declared_deps})
 
         def render_undeclared() -> Iterator[str]:
             yield "\nThese imports appear to be undeclared dependencies:"

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -292,7 +292,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def success_message(check_undeclared: bool, check_unused: bool) -> Optional[str]:
-        """Returns the message to print when the analysis finds no errors."""
+        """Return the message to print when the analysis finds no errors."""
         checking = []
         if check_undeclared:
             checking.append("undeclared")
@@ -304,8 +304,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
 
 
 def assign_exit_code(analysis: Analysis) -> int:
-    """
-    Assign exit code based on the analysis results.
+    """Assign exit code based on the analysis results.
 
     Exit codes:
     0 - success, no problems found

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -135,7 +135,7 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
         """The list of declared dependencies parsed from this project."""
         return list(
             extract_declared_dependencies.parse_sources(
-                (src for src in self.sources if isinstance(src, DepsSource))
+                src for src in self.sources if isinstance(src, DepsSource)
             )
         )
 

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -185,15 +185,15 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
 
         # Compute only the properties needed to satisfy settings.actions:
         if ret.is_enabled(Action.LIST_SOURCES):
-            ret.sources  # pylint: disable=pointless-statement
+            ret.sources  # pylint: disable=pointless-statement  # noqa: B018
         if ret.is_enabled(Action.LIST_IMPORTS):
-            ret.imports  # pylint: disable=pointless-statement
+            ret.imports  # pylint: disable=pointless-statement  # noqa: B018
         if ret.is_enabled(Action.LIST_DEPS):
-            ret.declared_deps  # pylint: disable=pointless-statement
+            ret.declared_deps  # pylint: disable=pointless-statement  # noqa: B018
         if ret.is_enabled(Action.REPORT_UNDECLARED):
-            ret.undeclared_deps  # pylint: disable=pointless-statement
+            ret.undeclared_deps  # pylint: disable=pointless-statement  # noqa: B018
         if ret.is_enabled(Action.REPORT_UNUSED):
-            ret.unused_deps  # pylint: disable=pointless-statement
+            ret.unused_deps  # pylint: disable=pointless-statement  # noqa: B018
 
         return ret
 
@@ -226,7 +226,9 @@ class Analysis:  # pylint: disable=too-many-instance-attributes
         }
         json.dump(json_dict, out, indent=2, default=encoder)
 
-    def print_human_readable(self, out: TextIO, detailed: bool = True) -> None:
+    def print_human_readable(  # noqa: C901
+        self, out: TextIO, detailed: bool = True
+    ) -> None:
         """Print a human-readable rendering of this analysis to 'out'."""
 
         def render_sources() -> Iterator[str]:

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -44,7 +44,7 @@ from fawltydeps.types import (
     PyEnvSource,
     Source,
     UndeclaredDependency,
-    UnparseablePathException,
+    UnparseablePathError,
     UnresolvedDependenciesError,
     UnusedDependency,
 )
@@ -369,7 +369,7 @@ def main(
 
     try:
         analysis = Analysis.create(settings, stdin)
-    except UnparseablePathException as exc:
+    except UnparseablePathError as exc:
         return parser.error(exc.msg)  # exit code 2
     except ExcludeRuleError as exc:
         return parser.error(f"Error while parsing exclude pattern: {exc}")

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -140,7 +140,7 @@ def accumulate_mappings(
             else:  # replace existing Package instance with "augmented" version
                 prev = result[normalized_name]
                 debug_info = prev.debug_info
-                assert isinstance(debug_info, dict)
+                assert isinstance(debug_info, dict)  # noqa: S101, sanity check
                 debug_info.setdefault(debug_key, set()).update(imports)
                 result[normalized_name] = replace(
                     prev,
@@ -310,7 +310,7 @@ class LocalPackageResolver(InstalledPackageResolver):
         self.package_dirs: Set[Path] = set(src.path for src in srcs)
 
     @classmethod
-    def find_package_dirs(cls, path: Path) -> Iterator[Path]:
+    def find_package_dirs(cls, path: Path) -> Iterator[Path]:  # noqa: C901, PLR0912
         """Return the packages directories corresponding to the given path.
 
         The given 'path' is a user-provided directory path meant to point to
@@ -473,7 +473,7 @@ class TemporaryPipInstallResolver(BasePackageResolver):
         .installed_requirements() above. The caller is expected to handle any
         requirements that we failed to install.
         """
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory() as tmpdir:  # noqa: SIM117
             with cls.installed_requirements(Path(tmpdir), requirements) as venv_dir:
                 yield venv_dir
 

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -38,7 +38,7 @@ from importlib_metadata import (
 from fawltydeps.types import (
     CustomMapping,
     PyEnvSource,
-    UnparseablePathException,
+    UnparseablePathError,
     UnresolvedDependenciesError,
 )
 from fawltydeps.utils import calculated_once, site_packages
@@ -161,7 +161,7 @@ class UserDefinedMapping(BasePackageResolver):
         self.mapping_paths = mapping_paths or set()
         for path in self.mapping_paths:
             if not path.is_file():
-                raise UnparseablePathException(
+                raise UnparseablePathError(
                     ctx="Given mapping path is not a file.", path=path
                 )
         self.custom_mapping = custom_mapping
@@ -592,10 +592,10 @@ def validate_pyenv_source(path: Path) -> Optional[Set[PyEnvSource]]:
       package dirs (typically only one) found within this Python environment.
     - Return None if this is a directory that must be traversed further to find
       Python environments within.
-    - Raise UnparseablePathException if the given path is not a directory.
+    - Raise UnparseablePathError if the given path is not a directory.
     """
     if not path.is_dir():
-        raise UnparseablePathException(ctx="Not a directory!", path=path)
+        raise UnparseablePathError(ctx="Not a directory!", path=path)
     try:
         return pyenv_sources(path)
     except ValueError:

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -338,14 +338,13 @@ class LocalPackageResolver(InstalledPackageResolver):
             if found:
                 return
 
-        else:  # Assume POSIX
-            if (path / "bin/python").is_file():
-                for _site_packages in path.glob("lib/python?.*/site-packages"):
-                    if _site_packages.is_dir():
-                        yield _site_packages
-                        found = True
-                if found:
-                    return
+        elif (path / "bin/python").is_file():  # Assume POSIX
+            for _site_packages in path.glob("lib/python?.*/site-packages"):
+                if _site_packages.is_dir():
+                    yield _site_packages
+                    found = True
+            if found:
+                return
 
         # Workaround for projects using PEP582:
         if path.name == "__pypackages__":

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -191,7 +191,7 @@ class UserDefinedMapping(BasePackageResolver):
             if self.mapping_paths is not None:
                 for path in self.mapping_paths:
                     logger.debug(f"Loading user-defined mapping from {path}")
-                    with open(path, "rb") as mapping_file:
+                    with Path(path).open("rb") as mapping_file:
                         yield tomllib.load(mapping_file), str(path)
 
         return accumulate_mappings(self.__class__, _custom_mappings())

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -453,7 +453,7 @@ class TemporaryPipInstallResolver(BasePackageResolver):
                 logger.warning("Output:\n%s", proc.stdout)
             logger.info("Retrying each requirement individually...")
             for req in requirements:
-                proc = pip_install_runner(argv + [req])
+                proc = pip_install_runner([*argv, req])
                 if proc.returncode:  # pip install failed
                     logger.warning("Failed to install %s", repr(req))
                     if proc.stdout.strip():

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -307,7 +307,7 @@ class LocalPackageResolver(InstalledPackageResolver):
         provided import names.
         """
         super().__init__()
-        self.package_dirs: Set[Path] = set(src.path for src in srcs)
+        self.package_dirs: Set[Path] = {src.path for src in srcs}
 
     @classmethod
     def find_package_dirs(cls, path: Path) -> Iterator[Path]:  # noqa: C901, PLR0912

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -84,7 +84,7 @@ class Package:
         object.__setattr__(self, "package_name", self.normalize_name(self.package_name))
 
     def has_type_stubs(self) -> Set[str]:
-        """Returns a set of import names without type stubs suffix."""
+        """Return a set of import names without type stubs suffix."""
         provides_stubs_for = [
             import_name[: -len("-stubs")]
             for import_name in self.import_names
@@ -151,7 +151,7 @@ def accumulate_mappings(
 
 
 class UserDefinedMapping(BasePackageResolver):
-    """Use user-defined mapping loaded from a toml file"""
+    """Use user-defined mapping loaded from a toml file."""
 
     def __init__(
         self,
@@ -382,10 +382,10 @@ class LocalPackageResolver(InstalledPackageResolver):
 
 
 def pyenv_sources(*pyenv_paths: Path) -> Set[PyEnvSource]:
-    """Helper for converting Python environment paths into PyEnvSources.
+    """Convert Python environment paths into PyEnvSources.
 
-    Convenience when you want to construct a LocalPackageResolver from one or
-    more Python environment paths.
+    Convenience helper when you want to construct a LocalPackageResolver from
+    one or more Python environment paths.
     """
     ret: Set[PyEnvSource] = set()
     for path in pyenv_paths:
@@ -405,7 +405,8 @@ class TemporaryPipInstallResolver(BasePackageResolver):
     local environment. This is done by creating a temporary venv, and then
     `pip install`ing the packages into this venv, and then resolving the
     packages in this venv. The venv is automatically deleted before as soon as
-    the packages have been resolved."""
+    the packages have been resolved.
+    """
 
     # This is only used in tests by `test_resolver`
     cached_venv: Optional[Path] = None

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -156,9 +156,9 @@ class Settings(BaseSettings):
 
     actions: Set[Action] = {Action.REPORT_UNDECLARED, Action.REPORT_UNUSED}
     output_format: OutputFormat = OutputFormat.HUMAN_SUMMARY
-    code: Set[PathOrSpecial] = {Path(".")}
-    deps: Set[Path] = {Path(".")}
-    pyenvs: Set[Path] = {Path(".")}
+    code: Set[PathOrSpecial] = {Path()}
+    deps: Set[Path] = {Path()}
+    pyenvs: Set[Path] = {Path()}
     custom_mapping: Optional[CustomMapping] = None
     ignore_undeclared: Set[str] = set()
     ignore_unused: Set[str] = DEFAULT_IGNORE_UNUSED

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -192,7 +192,7 @@ class Settings(BaseSettings):
             cls,
             init_settings: SettingsSourceCallable,
             env_settings: SettingsSourceCallable,
-            file_secret_settings: SettingsSourceCallable,  # pylint: disable=W0613
+            file_secret_settings: SettingsSourceCallable,  # pylint: disable=W0613  # noqa: ARG003
         ) -> Tuple[SettingsSourceCallable, ...]:
             """Select and prioritize the various configuration sources."""
             # Use class vars in Settings to determine which configuration file
@@ -216,7 +216,7 @@ class Settings(BaseSettings):
         configuration file is read).
         """
         for key, value in kwargs.items():
-            assert key in cls.__class_vars__
+            assert key in cls.__class_vars__  # noqa: S101, sanity check
             setattr(cls, key, value)
         return cls
 
@@ -285,7 +285,7 @@ def print_toml_config(settings: Settings, out: TextIO = sys.stdout) -> None:
 
     dictionary_options = {"custom_mapping"}
 
-    def _option_to_toml(name, value) -> str:  # type: ignore[no-untyped-def]
+    def _option_to_toml(name, value) -> str:  # type: ignore[no-untyped-def]  # noqa: ANN001
         """Serialize options to toml configuration entries
 
         Options that are of dictionary type must be given a section entry.
@@ -301,7 +301,7 @@ def print_toml_config(settings: Settings, out: TextIO = sys.stdout) -> None:
         if value is None:
             # sanity check: None values are represented in TOML by omission,
             # hence make sure these are always commented (i.e. equal to default)
-            assert has_default_value[name]
+            assert has_default_value[name]  # noqa: S101
 
         prefix = "# " if has_default_value[name] else ""
 

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -232,7 +232,6 @@ class Settings(BaseSettings):
         ultimately - from the hardcoded defaults above) must NOT appear in
         these keyword args (cf. use of argparse.SUPPRESS above).
         """
-
         args_dict = cmdline_args.__dict__
 
         base_paths = set(getattr(cmdline_args, "basepaths", []))
@@ -286,7 +285,7 @@ def print_toml_config(settings: Settings, out: TextIO = sys.stdout) -> None:
     dictionary_options = {"custom_mapping"}
 
     def _option_to_toml(name, value) -> str:  # type: ignore[no-untyped-def]  # noqa: ANN001
-        """Serialize options to toml configuration entries
+        """Serialize options to toml configuration entries.
 
         Options that are of dictionary type must be given a section entry.
         Assumption: dictionaries options are not nested.

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -239,11 +239,7 @@ class Settings(BaseSettings):
             code_paths = args_dict.setdefault("code", base_paths)
             deps_paths = args_dict.setdefault("deps", base_paths)
             pyenv_paths = args_dict.setdefault("pyenvs", base_paths)
-            if (
-                code_paths != base_paths
-                and deps_paths != base_paths
-                and pyenv_paths != base_paths
-            ):
+            if base_paths not in (code_paths, deps_paths, pyenv_paths):
                 msg = (
                     "All four path specifications (code, deps, pyenvs, and base)"
                     f"have been used. Use at most 3. basepaths={base_paths}, "

--- a/fawltydeps/traverse_project.py
+++ b/fawltydeps/traverse_project.py
@@ -14,7 +14,7 @@ from fawltydeps.types import (
     DepsSource,
     PyEnvSource,
     Source,
-    UnparseablePathException,
+    UnparseablePathError,
 )
 
 logger = logging.getLogger(__name__)
@@ -162,7 +162,7 @@ def find_sources(  # pylint: disable=too-many-branches,too-many-statements  # no
                     validated = validate_code_source(path, base_dir)
                     assert validated is not None  # noqa: S101, sanity check
                     yield validated
-                except UnparseablePathException:  # don't abort directory walk for this
+                except UnparseablePathError:  # don't abort directory walk for this
                     pass
         if DepsSource in types:
             for path in step.files:
@@ -172,5 +172,5 @@ def find_sources(  # pylint: disable=too-many-branches,too-many-statements  # no
                     )
                     assert validated is not None  # noqa: S101, sanity check
                     yield validated
-                except UnparseablePathException:  # don't abort directory walk for this
+                except UnparseablePathError:  # don't abort directory walk for this
                     pass

--- a/fawltydeps/traverse_project.py
+++ b/fawltydeps/traverse_project.py
@@ -57,7 +57,6 @@ def find_sources(  # pylint: disable=too-many-branches,too-many-statements  # no
       symlinks-to-dirs. We should be resistant to infinite traversal loops
       caused by symlinks. (This is handled by DirectoryTraversal)
     """
-
     logger.debug("find_sources() Looking for sources under:")
     logger.debug(f"    code:         {settings.code}")
     logger.debug(f"    deps:         {settings.deps}")

--- a/fawltydeps/traverse_project.py
+++ b/fawltydeps/traverse_project.py
@@ -30,7 +30,7 @@ AttachedData = Union[
 ]
 
 
-def find_sources(  # pylint: disable=too-many-branches,too-many-statements
+def find_sources(  # pylint: disable=too-many-branches,too-many-statements  # noqa: C901, PLR0912, PLR0915
     settings: Settings,
     source_types: AbstractSet[Type[Source]] = frozenset(
         [CodeSource, DepsSource, PyEnvSource]
@@ -108,7 +108,7 @@ def find_sources(  # pylint: disable=too-many-branches,too-many-statements
             yield validated
         else:  # must traverse directory
             # sanity check: convince mypy that SpecialPath is already handled
-            assert isinstance(path_or_special, Path)
+            assert isinstance(path_or_special, Path)  # noqa: S101, sanity check
             # record also base dir for later
             traversal.add(path_or_special, (CodeSource, path_or_special))
 
@@ -141,8 +141,8 @@ def find_sources(  # pylint: disable=too-many-branches,too-many-statements
         #   - We should not be looking for any _other_ source types than those
         #     that were given in our `source_types` argument.
         types = {t[0] if isinstance(t, tuple) else t for t in step.attached}
-        assert len(types) > 0
-        assert all(t in source_types for t in types)
+        assert len(types) > 0  # noqa: S101, sanity check
+        assert all(t in source_types for t in types)  # noqa: S101, sanity check
 
         if PyEnvSource in types:
             for path in step.subdirs | step.excluded_subdirs:
@@ -156,11 +156,12 @@ def find_sources(  # pylint: disable=too-many-branches,too-many-statements
                 (t[1] for t in reversed(step.attached) if isinstance(t, tuple)),
                 None,
             )
-            assert base_dir is not None  # sanity check: No CodeSource w/o base_dir
+            # Sanity check: No CodeSource w/o base_dir
+            assert base_dir is not None  # noqa: S101
             for path in step.files:
                 try:  # catch all exceptions while traversing dirs
                     validated = validate_code_source(path, base_dir)
-                    assert validated is not None  # sanity check
+                    assert validated is not None  # noqa: S101, sanity check
                     yield validated
                 except UnparseablePathException:  # don't abort directory walk for this
                     pass
@@ -170,7 +171,7 @@ def find_sources(  # pylint: disable=too-many-branches,too-many-statements
                     validated = validate_deps_source(
                         path, settings.deps_parser_choice, filter_by_parser=True
                     )
-                    assert validated is not None  # sanity check
+                    assert validated is not None  # noqa: S101, sanity check
                     yield validated
                 except UnparseablePathException:  # don't abort directory walk for this
                     pass

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -160,12 +160,11 @@ class PyEnvSource(Source):
             ):
                 return  # also ok
         # Support vitualenvs, poetry2nix envs, system-wide installs, etc.
-        else:
-            if (
-                self.path.match("lib/python?.*/site-packages")
-                and (self.path.parent.parent.parent / "bin/python").is_file()
-            ):
-                return  # all ok
+        elif (
+            self.path.match("lib/python?.*/site-packages")
+            and (self.path.parent.parent.parent / "bin/python").is_file()
+        ):
+            return  # all ok
 
         # Also support projects using __pypackages__ from PEP582:
         if self.path.match("__pypackages__/?.*/lib"):

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -86,7 +86,7 @@ class CodeSource(Source):
     def __post_init__(self) -> None:
         super().__post_init__()
         if self.path != "<stdin>":
-            assert isinstance(self.path, Path)
+            assert isinstance(self.path, Path)  # noqa: S101, sanity check
             if not self.path.is_file():
                 raise UnparseablePathException(
                     ctx="Code path to parse is neither dir nor file",
@@ -124,7 +124,7 @@ class DepsSource(Source):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        assert self.path.is_file()  # sanity check
+        assert self.path.is_file()  # noqa: S101, sanity check
 
     def render(self, detailed: bool) -> str:
         if detailed:
@@ -148,7 +148,7 @@ class PyEnvSource(Source):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        assert self.path.is_dir()  # sanity check
+        assert self.path.is_dir()  # noqa: S101, sanity check
 
         # Support Windows projects
         if sys.platform.startswith("win"):

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -154,14 +154,18 @@ class PyEnvSource(Source):
 
         # Support Windows projects
         if sys.platform.startswith("win"):
-            if self.path.match(str(Path("Lib", "site-packages"))):
-                if (self.path.parent.parent / "Scripts" / "python.exe").is_file():
-                    return  # also ok
+            if (
+                self.path.match(str(Path("Lib", "site-packages")))
+                and (self.path.parent.parent / "Scripts" / "python.exe").is_file()
+            ):
+                return  # also ok
         # Support vitualenvs, poetry2nix envs, system-wide installs, etc.
         else:
-            if self.path.match("lib/python?.*/site-packages"):
-                if (self.path.parent.parent.parent / "bin/python").is_file():
-                    return  # all ok
+            if (
+                self.path.match("lib/python?.*/site-packages")
+                and (self.path.parent.parent.parent / "bin/python").is_file()
+            ):
+                return  # all ok
 
         # Also support projects using __pypackages__ from PEP582:
         if self.path.match("__pypackages__/?.*/lib"):

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -24,14 +24,14 @@ CustomMapping = Dict[str, List[str]]
 
 
 class UnparseablePathException(Exception):
-    """Exception type when alleged path (deps or code) can't be parsed"""
+    """Exception type when alleged path (deps or code) can't be parsed."""
 
     def __init__(self, ctx: str, path: Path):
         self.msg = f"{ctx}: {path}"
 
 
 class UnresolvedDependenciesError(Exception):
-    """Exception type when not all dependencies were are resolved"""
+    """Exception type when not all dependencies were are resolved."""
 
     def __init__(self, names: Set[str]):
         self.msg = f"Unresolved dependencies: {', '.join(sorted(names))}"
@@ -99,6 +99,7 @@ class CodeSource(Source):
                 )
 
     def render(self, detailed: bool) -> str:
+        """Return a human-readable string representation of this source."""
         if detailed and self.base_dir is not None:
             return f"{self.path} (using {self.base_dir} as base for 1st-party imports)"
         return f"{self.path}"
@@ -127,6 +128,7 @@ class DepsSource(Source):
         assert self.path.is_file()  # noqa: S101, sanity check
 
     def render(self, detailed: bool) -> str:
+        """Return a human-readable string representation of this source."""
         if detailed:
             return f"{self.path} (parsed as a {self.parser_choice} file)"
         return f"{self.path}"
@@ -168,6 +170,7 @@ class PyEnvSource(Source):
         raise ValueError(f"{self.path} is not a valid dir for Python packages!")
 
     def render(self, detailed: bool) -> str:
+        """Return a human-readable string representation of this source."""
         if detailed:
             return f"{self.path} (as a source of Python packages)"
         return f"{self.path}"
@@ -265,7 +268,7 @@ class ParsedImport:
 
 @dataclass(eq=True, frozen=True, order=True)
 class DeclaredDependency:
-    """Declared dependencies parsed from configuration-containing files"""
+    """Declared dependencies parsed from configuration-containing files."""
 
     name: str
     source: Location

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -62,7 +62,7 @@ class Source(ABC):
         object.__setattr__(self, "source_type", self.__class__)
 
     @abstractmethod
-    def render(self, detailed: bool) -> str:
+    def render(self, *, detailed: bool) -> str:
         """Return a human-readable string representation of this source."""
         raise NotImplementedError
 
@@ -98,7 +98,7 @@ class CodeSource(Source):
                     path=self.path,
                 )
 
-    def render(self, detailed: bool) -> str:
+    def render(self, *, detailed: bool) -> str:
         """Return a human-readable string representation of this source."""
         if detailed and self.base_dir is not None:
             return f"{self.path} (using {self.base_dir} as base for 1st-party imports)"
@@ -127,7 +127,7 @@ class DepsSource(Source):
         super().__post_init__()
         assert self.path.is_file()  # noqa: S101, sanity check
 
-    def render(self, detailed: bool) -> str:
+    def render(self, *, detailed: bool) -> str:
         """Return a human-readable string representation of this source."""
         if detailed:
             return f"{self.path} (parsed as a {self.parser_choice} file)"
@@ -172,7 +172,7 @@ class PyEnvSource(Source):
 
         raise ValueError(f"{self.path} is not a valid dir for Python packages!")
 
-    def render(self, detailed: bool) -> str:
+    def render(self, *, detailed: bool) -> str:
         """Return a human-readable string representation of this source."""
         if detailed:
             return f"{self.path} (as a source of Python packages)"
@@ -284,7 +284,7 @@ class UndeclaredDependency:
     name: str
     references: List[Location]
 
-    def render(self, include_references: bool) -> str:
+    def render(self, *, include_references: bool) -> str:
         """Return a human-readable string representation.
 
         Level of detail is determined by `include_references`.
@@ -301,7 +301,7 @@ class UnusedDependency:
     name: str
     references: List[Location]
 
-    def render(self, include_references: bool) -> str:
+    def render(self, *, include_references: bool) -> str:
         """Return a human-readable string representation.
 
         Level of detail is determined by `include_references`.

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -23,7 +23,7 @@ TomlData = Dict[str, Any]  # type: ignore[misc]
 CustomMapping = Dict[str, List[str]]
 
 
-class UnparseablePathException(Exception):
+class UnparseablePathError(Exception):
     """Exception type when alleged path (deps or code) can't be parsed."""
 
     def __init__(self, ctx: str, path: Path):
@@ -88,12 +88,12 @@ class CodeSource(Source):
         if self.path != "<stdin>":
             assert isinstance(self.path, Path)  # noqa: S101, sanity check
             if not self.path.is_file():
-                raise UnparseablePathException(
+                raise UnparseablePathError(
                     ctx="Code path to parse is neither dir nor file",
                     path=self.path,
                 )
             if self.path.suffix not in {".py", ".ipynb"}:
-                raise UnparseablePathException(
+                raise UnparseablePathError(
                     ctx="Supported formats are .py and .ipynb; Cannot parse code",
                     path=self.path,
                 )

--- a/fawltydeps/utils.py
+++ b/fawltydeps/utils.py
@@ -1,4 +1,4 @@
-"""Common utilities"""
+"""Common utilities."""
 
 import logging
 import sys
@@ -17,8 +17,7 @@ logger = logging.getLogger(__name__)
 
 @no_type_check
 def version() -> str:
-    """Returns the version of fawltydeps."""
-
+    """Return the version of fawltydeps."""
     # This function is extracted to allow annotation with `@no_type_check`.
     # Using `#type: ignore` on the line below leads to an
     # "unused type ignore comment" MyPy error in python's version 3.8 and
@@ -78,7 +77,9 @@ def calculated_once(method: Callable[[Instance], T]) -> Callable[[Instance], T]:
 
 def site_packages(venv_dir: Path = Path()) -> Path:
     """Return the site-packages directory of a virtual environment.
-    Works for both, Windows and POSIX."""
+
+    Works for both, Windows and POSIX.
+    """
     # Windows
     if sys.platform.startswith("win"):
         return venv_dir / "Lib" / "site-packages"

--- a/noxfile.py
+++ b/noxfile.py
@@ -79,7 +79,7 @@ def install_groups(
     if include_self:
         session.install("-e", ".")
 
-    if not session.virtualenv._reused:
+    if not session.virtualenv._reused:  # noqa: SLF001
         patch_binaries_if_needed(session, session.virtualenv.location)
 
 
@@ -137,7 +137,7 @@ def lint(session):
 
 
 @nox.session
-def format(session):
+def format(session):  # noqa: A001
     install_groups(session, include=["format"], include_self=False)
     session.run("codespell", "--enable-colors")
     session.run("isort", "fawltydeps", "tests", "--check", "--diff", "--color")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,8 +169,130 @@ extend-exclude = [
     "tests/sample_projects/legacy_encoding/big5.py",  # Fails with E902 (not UTF-8)
 ]
 
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+    # Ignore some unwanted checks:
+    "ANN10",  # Deprecated: Missing type annotation for self/cls in (class)method
+    "ANN204",  # Missing return type annotation for special method
+    "D104",  # Missing docstring in public package
+    "D105",  # Missing docstring in magic method
+    "D107",  # Missing docstring in `__init__`
+    "D203",  # one-blank-line-before-class conflicts with D211: no-blank-line-before-class
+    "D213",  # multi-line-summary-second-line conflicts with D212: multi-line-summary-first-line
+    "EM",  # Exception must not use a (f-)string literal, assign to variable first
+
+    # To be fixed soon:
+    "ARG002",  # Unused method argument: `...`
+    "C401",  # Unnecessary generator (rewrite as a `set` comprehension)
+    "D102",  # Missing docstring in public method
+    "D202",  # No blank lines allowed after function docstring
+    "D205",  # 1 blank line required between summary line and description
+    "D209",  # Multi-line docstring closing quotes should be on a separate line
+    "D212",  # Multi-line docstring summary should start at the first line
+    "D400",  # First line should end with a period
+    "D401",  # First line of docstring should be in imperative mood
+    "D415",  # First line should end with a period, question mark, or exclamation point
+    "FBT001",  # Boolean-typed positional argument in function definition
+    "FBT002",  # Boolean default positional argument in function definition"
+    "FBT003",  # Boolean positional value in function call
+    "N818",  # Exception name `...` should be named with an Error suffix
+    "PLR1714",  # Consider merging multiple comparisons. Use a `set` if the elements are hashable.
+    "PLR5501",  # Use `elif` instead of `else` then `if`, to reduce indentation
+    "PTH108",  # `os.unlink()` should be replaced by `Path.unlink()`
+    "PTH123",  # `open()` should be replaced by `Path.open()`
+    "PTH201",  # Do not pass the current directory explicitly to `Path`
+    "RUF005",  # Consider `[...]` instead of concatenation
+    "SIM102",  # Use a single `if` statement instead of nested `if` statements
+    "SIM114",  # Combine `if` branches using logical `or` operator
+    "UP028",  # Replace `yield` over `for` loop with `yield from`
+    "UP034",  # Avoid extraneous parentheses
+
+    # Probably not fixed so soon:
+    "FIX002",  # Line contains TODO, consider resolving the issue
+    "G004",  # Logging statement uses f-string
+    "PERF203",  # `try`-`except` within a loop incurs performance overhead
+    "TD",  # Ignore checks on TODO comments
+    "TRY003",  # Avoid specifying long messages outside the exception class
+    "TRY301",  # Abstract `raise` to an inner function
+    "TRY400",  # Use `logging.exception` instead of `logging.error`
+
+    # To be fixed in a larger refactoring of our type annotations
+    "FA100",  # Missing `from __future__ import annotations`, but uses `typing.*`
+    "TCH002",  # Move third-party import `...` into a type-checking block
+    "TCH003",  # Move standard library import `...` into a type-checking block
+    "UP006",  # Use `list` instead of `List` for type annotation
+    "UP007",  # Use `X | Y` for type annotations
+
+    # Ruff recommends avoiding these checks when using `ruff format`. Since
+    # `ruff format` is a drop-in replacement for `black`, we avoid the same
+    # checks here (https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    # has more details):
+    "W191",  # tab-indentation
+    "E111",  # indentation-with-invalid-multiple
+    "E114",  # indentation-with-invalid-multiple-comment
+    "E117",  # over-indented
+    "D206",  # indent-with-spaces
+    "D300",  # triple-single-quotes
+    "Q000",  # bad-quotes-inline-string
+    "Q001",  # bad-quotes-multiline-string
+    "Q002",  # bad-quotes-docstring
+    "Q003",  # avoidable-escaped-quote
+    "COM812",  # missing-trailing-comma
+    "COM819",  # prohibited-trailing-comma
+    "ISC001",  # single-line-implicit-string-concatenation
+    "ISC002",  # multi-line-implicit-string-concatenation
+    "E501",  # line-too-long
+]
+
 [tool.ruff.lint.per-file-ignores]
-"tests/sample_projects/*" = ["F401"]  # Allow unused imports in sample projects
+"noxfile.py" = [
+    "ANN",  # Missing type annotations
+    "D",  # Missing docstrings
+]
+"tests/sample_projects/*" = [
+    "F401",  # Allow unused imports in sample projects
+    "ICN001",  # `<module>` should be imported as `<mod>`
+    "INP001",  # File `...` is part of an implicit namespace package. Add an `__init__.py`.
+]
+"tests/*" = [
+    # Ignore some groups of checks in our test code
+    "ANN",  # Type annotations
+    "D10",  # Missing docstrings
+    "TCH00",  # Imports and type checking blocks
+
+    # Ignore some more specific checks in our test code
+    "C408",  # Unnecessary `dict` call (rewrite as a literal)
+    "D401",  # First line of docstring should be in imperative mood
+    "N802",  # Function name `...` should be lowercase
+    "N806",  # Variable `...` in function should be lowercase
+    "PLR0913",  # Too many arguments in function definition
+    "PT018",  # Assertion should be broken down into multiple parts
+    "S101",  # Use of `assert` detected
+    "S603",  # `subprocess` call: check for execution of untrusted input
+    "T201",  # `print` found
+
+    # To be fixed soon:
+    "A001",  # Variable `id` is shadowing a Python builtin
+    "ARG001",  # Unused function argument: `py_version`
+    "B011",  # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
+    "C405",  # Unnecessary `list` literal (rewrite as a `set` literal)
+    "D200",  # One-line docstring should fit on one line
+    "D210",  # No whitespaces allowed surrounding docstring text
+    "PLR2004",  # Magic value used in comparison, consider replacing ... with a constant variable
+    "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
+    "PT006",  # Wrong name(s) type in `@pytest.mark.parametrize`, expected `tuple`
+    "PT015",  # Assertion always fails, replace with `pytest.fail()`
+    "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
+    "RUF003",  # Comment contains ambiguous `’` (RIGHT SINGLE QUOTATION MARK). Did you mean ``` (GRAVE ACCENT)?
+    "RUF010",  # Use explicit conversion flag
+    "RUF100",  # Unused `noqa` directive (unused: `ARG001`)
+    "SIM108",  # Use ternary operator `...` instead of `if`-`else`-block
+    "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
+    "SIM910",  # Use `...get(dep)` instead of `...get(..., None)`
+    "UP021",  # `universal_newlines` is deprecated, use `text`
+    "UP022",  # Prefer `capture_output` over sending `stdout` and `stderr` to `PIPE`
+]
 
 [tool.codespell]
 skip = ".git,.mypy_cache,.nox,.vscode,__pycache__,poetry.lock"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,7 +266,6 @@ ignore = [
     "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
     "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
     "SIM108",  # Use ternary operator `...` instead of `if`-`else`-block
-    "SIM910",  # Use `...get(dep)` instead of `...get(..., None)`
 ]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,7 +265,6 @@ ignore = [
     # To be fixed soon:
     "C405",  # Unnecessary `list` literal (rewrite as a `set` literal)
     "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
-    "PT006",  # Wrong name(s) type in `@pytest.mark.parametrize`, expected `tuple`
     "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
     "RUF003",  # Comment contains ambiguous `’` (RIGHT SINGLE QUOTATION MARK). Did you mean ``` (GRAVE ACCENT)?
     "RUF010",  # Use explicit conversion flag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,6 @@ ignore = [
     "EM",  # Exception must not use a (f-)string literal, assign to variable first
 
     # To be fixed soon:
-    "C401",  # Unnecessary generator (rewrite as a `set` comprehension)
     "FBT001",  # Boolean-typed positional argument in function definition
     "FBT002",  # Boolean default positional argument in function definition"
     "FBT003",  # Boolean positional value in function call

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,6 @@ ignore = [
     "SIM102",  # Use a single `if` statement instead of nested `if` statements
     "SIM114",  # Combine `if` branches using logical `or` operator
     "UP028",  # Replace `yield` over `for` loop with `yield from`
-    "UP034",  # Avoid extraneous parentheses
 
     # Probably not fixed so soon:
     "FIX002",  # Line contains TODO, consider resolving the issue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,9 +261,6 @@ ignore = [
     "S101",  # Use of `assert` detected
     "S603",  # `subprocess` call: check for execution of untrusted input
     "T201",  # `print` found
-
-    # To be fixed soon:
-    "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
 ]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,7 +266,6 @@ ignore = [
     "C405",  # Unnecessary `list` literal (rewrite as a `set` literal)
     "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
     "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
-    "RUF003",  # Comment contains ambiguous `’` (RIGHT SINGLE QUOTATION MARK). Did you mean ``` (GRAVE ACCENT)?
     "RUF010",  # Use explicit conversion flag
     "SIM108",  # Use ternary operator `...` instead of `if`-`else`-block
     "SIM118",  # Use `key in dict` instead of `key in dict.keys()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ cache_dir = "~/.cache/pytest"
 # would lead to other rule violations. Use 100 as a maximum hard limit:
 line-length = 100
 target-version = "py37"
+extend-include = ["*.ipynb"]
 extend-exclude = [
     "tests/sample_projects/legacy_encoding/big5.py",  # Fails with E902 (not UTF-8)
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,6 @@ ignore = [
     "T201",  # `print` found
 
     # To be fixed soon:
-    "C405",  # Unnecessary `list` literal (rewrite as a `set` literal)
     "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
     "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
     "SIM108",  # Use ternary operator `...` instead of `if`-`else`-block

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,6 @@ ignore = [
     "EM",  # Exception must not use a (f-)string literal, assign to variable first
 
     # To be fixed soon:
-    "N818",  # Exception name `...` should be named with an Error suffix
     "PTH201",  # Do not pass the current directory explicitly to `Path`
 
     # Probably not fixed so soon:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,6 @@ ignore = [
     "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
     "RUF010",  # Use explicit conversion flag
     "SIM108",  # Use ternary operator `...` instead of `if`-`else`-block
-    "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
     "SIM910",  # Use `...get(dep)` instead of `...get(..., None)`
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,14 +185,6 @@ ignore = [
     # To be fixed soon:
     "ARG002",  # Unused method argument: `...`
     "C401",  # Unnecessary generator (rewrite as a `set` comprehension)
-    "D102",  # Missing docstring in public method
-    "D202",  # No blank lines allowed after function docstring
-    "D205",  # 1 blank line required between summary line and description
-    "D209",  # Multi-line docstring closing quotes should be on a separate line
-    "D212",  # Multi-line docstring summary should start at the first line
-    "D400",  # First line should end with a period
-    "D401",  # First line of docstring should be in imperative mood
-    "D415",  # First line should end with a period, question mark, or exclamation point
     "FBT001",  # Boolean-typed positional argument in function definition
     "FBT002",  # Boolean default positional argument in function definition"
     "FBT003",  # Boolean positional value in function call
@@ -277,8 +269,6 @@ ignore = [
     "ARG001",  # Unused function argument: `py_version`
     "B011",  # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
     "C405",  # Unnecessary `list` literal (rewrite as a `set` literal)
-    "D200",  # One-line docstring should fit on one line
-    "D210",  # No whitespaces allowed surrounding docstring text
     "PLR2004",  # Magic value used in comparison, consider replacing ... with a constant variable
     "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
     "PT006",  # Wrong name(s) type in `@pytest.mark.parametrize`, expected `tuple`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,9 +183,6 @@ ignore = [
     "EM",  # Exception must not use a (f-)string literal, assign to variable first
 
     # To be fixed soon:
-    "FBT001",  # Boolean-typed positional argument in function definition
-    "FBT002",  # Boolean default positional argument in function definition"
-    "FBT003",  # Boolean positional value in function call
     "N818",  # Exception name `...` should be named with an Error suffix
     "PLR1714",  # Consider merging multiple comparisons. Use a `set` if the elements are hashable.
     "PTH201",  # Do not pass the current directory explicitly to `Path`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,8 +274,6 @@ ignore = [
     "SIM108",  # Use ternary operator `...` instead of `if`-`else`-block
     "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
     "SIM910",  # Use `...get(dep)` instead of `...get(..., None)`
-    "UP021",  # `universal_newlines` is deprecated, use `text`
-    "UP022",  # Prefer `capture_output` over sending `stdout` and `stderr` to `PIPE`
 ]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,9 +182,6 @@ ignore = [
     "D213",  # multi-line-summary-second-line conflicts with D212: multi-line-summary-first-line
     "EM",  # Exception must not use a (f-)string literal, assign to variable first
 
-    # To be fixed soon:
-    "PTH201",  # Do not pass the current directory explicitly to `Path`
-
     # Probably not fixed so soon:
     "FIX002",  # Line contains TODO, consider resolving the issue
     "G004",  # Logging statement uses f-string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ ignore = [
     "FBT003",  # Boolean positional value in function call
     "N818",  # Exception name `...` should be named with an Error suffix
     "PLR1714",  # Consider merging multiple comparisons. Use a `set` if the elements are hashable.
-    "PLR5501",  # Use `elif` instead of `else` then `if`, to reduce indentation
     "PTH201",  # Do not pass the current directory explicitly to `Path`
 
     # Probably not fixed so soon:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,6 @@ ignore = [
     "EM",  # Exception must not use a (f-)string literal, assign to variable first
 
     # To be fixed soon:
-    "ARG002",  # Unused method argument: `...`
     "C401",  # Unnecessary generator (rewrite as a `set` comprehension)
     "FBT001",  # Boolean-typed positional argument in function definition
     "FBT002",  # Boolean default positional argument in function definition"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,6 @@ ignore = [
 
     # To be fixed soon:
     "N818",  # Exception name `...` should be named with an Error suffix
-    "PLR1714",  # Consider merging multiple comparisons. Use a `set` if the elements are hashable.
     "PTH201",  # Do not pass the current directory explicitly to `Path`
 
     # Probably not fixed so soon:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,7 +265,6 @@ ignore = [
     # To be fixed soon:
     "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
     "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
-    "SIM108",  # Use ternary operator `...` instead of `if`-`else`-block
 ]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,6 @@ ignore = [
     "T201",  # `print` found
 
     # To be fixed soon:
-    "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
     "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,7 +266,6 @@ ignore = [
     "C405",  # Unnecessary `list` literal (rewrite as a `set` literal)
     "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
     "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
-    "RUF010",  # Use explicit conversion flag
     "SIM108",  # Use ternary operator `...` instead of `if`-`else`-block
     "SIM910",  # Use `...get(dep)` instead of `...get(..., None)`
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,6 @@ ignore = [
     "PLR1714",  # Consider merging multiple comparisons. Use a `set` if the elements are hashable.
     "PLR5501",  # Use `elif` instead of `else` then `if`, to reduce indentation
     "PTH201",  # Do not pass the current directory explicitly to `Path`
-    "RUF005",  # Consider `[...]` instead of concatenation
 
     # Probably not fixed so soon:
     "FIX002",  # Line contains TODO, consider resolving the issue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,13 +264,11 @@ ignore = [
 
     # To be fixed soon:
     "C405",  # Unnecessary `list` literal (rewrite as a `set` literal)
-    "PLR2004",  # Magic value used in comparison, consider replacing ... with a constant variable
     "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
     "PT006",  # Wrong name(s) type in `@pytest.mark.parametrize`, expected `tuple`
     "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
     "RUF003",  # Comment contains ambiguous `’` (RIGHT SINGLE QUOTATION MARK). Did you mean ``` (GRAVE ACCENT)?
     "RUF010",  # Use explicit conversion flag
-    "RUF100",  # Unused `noqa` directive (unused: `ARG001`)
     "SIM108",  # Use ternary operator `...` instead of `if`-`else`-block
     "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
     "SIM910",  # Use `...get(dep)` instead of `...get(..., None)`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,12 +263,10 @@ ignore = [
     "T201",  # `print` found
 
     # To be fixed soon:
-    "B011",  # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
     "C405",  # Unnecessary `list` literal (rewrite as a `set` literal)
     "PLR2004",  # Magic value used in comparison, consider replacing ... with a constant variable
     "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`
     "PT006",  # Wrong name(s) type in `@pytest.mark.parametrize`, expected `tuple`
-    "PT015",  # Assertion always fails, replace with `pytest.fail()`
     "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
     "RUF003",  # Comment contains ambiguous `’` (RIGHT SINGLE QUOTATION MARK). Did you mean ``` (GRAVE ACCENT)?
     "RUF010",  # Use explicit conversion flag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,8 +189,6 @@ ignore = [
     "N818",  # Exception name `...` should be named with an Error suffix
     "PLR1714",  # Consider merging multiple comparisons. Use a `set` if the elements are hashable.
     "PLR5501",  # Use `elif` instead of `else` then `if`, to reduce indentation
-    "PTH108",  # `os.unlink()` should be replaced by `Path.unlink()`
-    "PTH123",  # `open()` should be replaced by `Path.open()`
     "PTH201",  # Do not pass the current directory explicitly to `Path`
     "RUF005",  # Consider `[...]` instead of concatenation
     "SIM102",  # Use a single `if` statement instead of nested `if` statements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,8 +191,6 @@ ignore = [
     "PLR5501",  # Use `elif` instead of `else` then `if`, to reduce indentation
     "PTH201",  # Do not pass the current directory explicitly to `Path`
     "RUF005",  # Consider `[...]` instead of concatenation
-    "SIM102",  # Use a single `if` statement instead of nested `if` statements
-    "SIM114",  # Combine `if` branches using logical `or` operator
 
     # Probably not fixed so soon:
     "FIX002",  # Line contains TODO, consider resolving the issue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,6 @@ ignore = [
     "RUF005",  # Consider `[...]` instead of concatenation
     "SIM102",  # Use a single `if` statement instead of nested `if` statements
     "SIM114",  # Combine `if` branches using logical `or` operator
-    "UP028",  # Replace `yield` over `for` loop with `yield from`
 
     # Probably not fixed so soon:
     "FIX002",  # Line contains TODO, consider resolving the issue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,6 @@ ignore = [
     "T201",  # `print` found
 
     # To be fixed soon:
-    "ARG001",  # Unused function argument: `py_version`
     "B011",  # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
     "C405",  # Unnecessary `list` literal (rewrite as a `set` literal)
     "PLR2004",  # Magic value used in comparison, consider replacing ... with a constant variable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,6 @@ ignore = [
     "T201",  # `print` found
 
     # To be fixed soon:
-    "A001",  # Variable `id` is shadowing a Python builtin
     "ARG001",  # Unused function argument: `py_version`
     "B011",  # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
     "C405",  # Unnecessary `list` literal (rewrite as a `set` literal)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def inside_tmp_path(monkeypatch, tmp_path):
 
 
 @pytest.fixture
-def local_pypi(request, monkeypatch):
+def local_pypi(request, monkeypatch):  # noqa: PT004
     cache_dir = TarballPackage.cache_dir(request.config.cache)
     TarballPackage.get_tarballs(request.config.cache)
     # set the test's env variables so that pip would install from the local repo
@@ -120,7 +120,7 @@ def isolate_default_resolver(
 
 
 @pytest.fixture
-def fake_project(write_tmp_files, fake_venv):
+def fake_project(write_tmp_files, fake_venv):  # noqa: C901
     """Create a temporary Python project with the given contents/properties.
 
     This is a generalized helper to create the directory structure and file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 """Fixtures for tests."""
-import sys
 import venv
 from pathlib import Path
 from tempfile import mkdtemp
@@ -54,10 +53,7 @@ def write_tmp_files(tmp_path: Path):
 @pytest.fixture
 def fake_venv(tmp_path):
     def create_one_fake_venv(
-        fake_packages: Dict[str, Set[str]],
-        *,
-        venv_dir: Optional[Path] = None,
-        py_version: Tuple[int, int] = sys.version_info[:2],
+        fake_packages: Dict[str, Set[str]], *, venv_dir: Optional[Path] = None
     ) -> Tuple[Path, Path]:
         if venv_dir is None:
             venv_dir = Path(mkdtemp(prefix="fake_venv.", dir=tmp_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from fawltydeps.utils import site_packages
 from .project_helpers import TarballPackage
 
 
-@pytest.fixture
+@pytest.fixture()
 def inside_tmp_path(monkeypatch, tmp_path):
     """Convenience fixture to run a test with CWD set to tmp_path.
 
@@ -25,7 +25,7 @@ def inside_tmp_path(monkeypatch, tmp_path):
     return tmp_path
 
 
-@pytest.fixture
+@pytest.fixture()
 def local_pypi(request, monkeypatch):  # noqa: PT004
     cache_dir = TarballPackage.cache_dir(request.config.cache)
     TarballPackage.get_tarballs(request.config.cache)
@@ -34,7 +34,7 @@ def local_pypi(request, monkeypatch):  # noqa: PT004
     monkeypatch.setenv("PIP_FIND_LINKS", str(cache_dir))
 
 
-@pytest.fixture
+@pytest.fixture()
 def write_tmp_files(tmp_path: Path):
     def _inner(file_contents: Dict[str, Union[str, bytes]]) -> Path:
         for filename, contents in file_contents.items():
@@ -50,7 +50,7 @@ def write_tmp_files(tmp_path: Path):
     return _inner
 
 
-@pytest.fixture
+@pytest.fixture()
 def fake_venv(tmp_path):
     def create_one_fake_venv(
         fake_packages: Dict[str, Set[str]], *, venv_dir: Optional[Path] = None
@@ -81,7 +81,7 @@ def fake_venv(tmp_path):
     return create_one_fake_venv
 
 
-@pytest.fixture
+@pytest.fixture()
 def isolate_default_resolver(
     fake_venv: Callable[[Dict[str, Set[str]]], Tuple[Path, Path]], monkeypatch
 ):
@@ -115,7 +115,7 @@ def isolate_default_resolver(
     return inner
 
 
-@pytest.fixture
+@pytest.fixture()
 def fake_project(write_tmp_files, fake_venv):  # noqa: C901
     """Create a temporary Python project with the given contents/properties.
 
@@ -248,7 +248,7 @@ def fake_project(write_tmp_files, fake_venv):  # noqa: C901
     return create_one_fake_project
 
 
-@pytest.fixture
+@pytest.fixture()
 def project_with_setup_and_requirements(fake_project):
     return fake_project(
         files_with_declared_deps={
@@ -263,7 +263,7 @@ def project_with_setup_and_requirements(fake_project):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def project_with_setup_with_cfg_pyproject_and_requirements(fake_project):
     return fake_project(
         files_with_declared_deps={
@@ -288,7 +288,7 @@ def project_with_setup_with_cfg_pyproject_and_requirements(fake_project):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def project_with_multiple_python_files(fake_project):
     return fake_project(
         declared_deps=["pandas", "click"],
@@ -301,7 +301,7 @@ def project_with_multiple_python_files(fake_project):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def setup_fawltydeps_config(write_tmp_files):
     """Write a custom tmp_path/pyproject.toml with a [tool.fawltydeps] section.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Fixtures for tests"""
+"""Fixtures for tests."""
 import sys
 import venv
 from pathlib import Path
@@ -151,7 +151,6 @@ def fake_project(write_tmp_files, fake_venv):  # noqa: C901
     Returns tmp_path, which is regarded as the root directory of the temporary
     Python project.
     """
-
     Imports = List[str]
     Deps = List[str]
     ExtraDeps = Dict[str, Deps]

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -145,7 +145,7 @@ class TarballPackage:
             logger.error(f"    Downloaded file: {tarball_path}")
             logger.error(f"    Retrieved SHA256 {sha256sum(tarball_path)}")
             logger.error(f"     Expected SHA256 {self.sha256}")
-            assert False
+            pytest.fail(f"Failed integrity check after downloading {self.url!r}!")
         cache.set(self.cache_key, str(tarball_path))
         return tarball_path
 

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -139,7 +139,7 @@ class TarballPackage:
         # Must (re)download
         tarball_path = self.tarball_path(cache)
         logger.info(f"Downloading {self.url!r} to {tarball_path}...")
-        urlretrieve(self.url, tarball_path)
+        urlretrieve(self.url, tarball_path)  # noqa: S310
         if not self.is_cached(tarball_path):
             logger.error(f"Failed integrity check after downloading {self.url!r}!")
             logger.error(f"    Downloaded file: {tarball_path}")
@@ -370,7 +370,7 @@ class BaseProject(ABC):
 
     @staticmethod
     def _init_args_from_toml(
-        toml_data: TomlData, ExperimentClass: Type[BaseExperiment]
+        toml_data: TomlData, ExperimentClass: Type[BaseExperiment]  # noqa: N803
     ) -> Dict[str, Any]:
         """Extract members from TOML into kwargs for a subclass constructor."""
         # We ultimately _trust_ the .toml files read here, so we can skip all

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,5 +1,5 @@
 """Verify behavior of the Analysis class."""
-
+# ruff: noqa: PLR2004,SLF001
 from fawltydeps.main import calculated_once
 
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -64,7 +64,7 @@ def make_json_settings_dict(**kwargs):
 
 
 @pytest.mark.parametrize(
-    "cli_options,expect_output,expect_logs",
+    ("cli_options", "expect_output", "expect_logs"),
     [
         pytest.param(
             ["--detailed", "--verbose"],
@@ -1080,7 +1080,7 @@ def test_check_json__no_pyenvs_found__falls_back_to_current_env(fake_project):
 
 
 @pytest.mark.parametrize(
-    "args,imports,dependencies,expected",
+    ("args", "imports", "dependencies", "expected"),
     [
         pytest.param(
             ["--check-unused"],
@@ -1161,7 +1161,7 @@ def test_cmdline_on_ignored_undeclared_option(
 
 
 @pytest.mark.parametrize(
-    "config,args,expect",
+    ("config", "args", "expect"),
     [
         pytest.param(
             {},

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -33,9 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 def make_json_settings_dict(**kwargs):
-    """
-    Create an expected version of Settings.dict(), with customizations.
-    """
+    """Create an expected version of Settings.dict(), with customizations."""
     settings = {
         "actions": ["check_undeclared", "check_unused"],
         "code": ["."],

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -269,7 +269,7 @@ def test_list_imports__from_missing_file__fails_with_exit_code_2(tmp_path):
     assert returncode == 2
 
 
-def test_list_imports__missing_exclude_pattern__fails_with_exit_code_2(tmp_path):
+def test_list_imports__missing_exclude_pattern__fails_with_exit_code_2():
     _output, errors, returncode = run_fawltydeps_subprocess(
         "--list-imports", "--exclude="
     )
@@ -277,7 +277,7 @@ def test_list_imports__missing_exclude_pattern__fails_with_exit_code_2(tmp_path)
     assert returncode == 2
 
 
-def test_list_imports__comment_in_exclude_pattern__fails_with_exit_code_2(tmp_path):
+def test_list_imports__comment_in_exclude_pattern__fails_with_exit_code_2():
     _output, errors, returncode = run_fawltydeps_subprocess(
         "--list-imports", "--exclude", "# comment"
     )

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -32,6 +32,14 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
+EXIT_SUCCESS = 0
+EXIT_EXCEPTION = 1
+EXIT_CLI_PARSE_ERROR = 2
+EXIT_UNDECLARED = 3
+EXIT_UNUSED = 4
+EXIT_UNRESOLVED = 5
+
+
 def make_json_settings_dict(**kwargs):
     """Create an expected version of Settings.dict(), with customizations."""
     settings = {
@@ -94,7 +102,7 @@ def test_list_imports__from_dash__prints_imports_from_stdin(
     )
     assert output.splitlines() == expect_output
     assert_unordered_equivalence(errors.splitlines(), expect_logs)
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_imports__from_py_file__prints_imports_from_file(write_tmp_files):
@@ -119,7 +127,7 @@ def test_list_imports__from_py_file__prints_imports_from_file(write_tmp_files):
         "--list-imports", "--detailed", f"--code={tmp_path / 'myfile.py'}"
     )
     assert output.splitlines() == expect
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_imports_json__from_py_file__prints_imports_from_file(write_tmp_files):
@@ -173,7 +181,7 @@ def test_list_imports_json__from_py_file__prints_imports_from_file(write_tmp_fil
         "--list-imports", "--json", f"--code={tmp_path / 'myfile.py'}"
     )
     assert json.loads(output) == expect
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_imports__from_ipynb_file__prints_imports_from_file(write_tmp_files):
@@ -188,7 +196,7 @@ def test_list_imports__from_ipynb_file__prints_imports_from_file(write_tmp_files
         "--list-imports", "--detailed", f"--code={tmp_path / 'myfile.ipynb'}"
     )
     assert output.splitlines() == expect
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_imports__from_dir__prints_imports_from_py_and_ipynb_files_only(
@@ -218,7 +226,7 @@ def test_list_imports__from_dir__prints_imports_from_py_and_ipynb_files_only(
         "--list-imports", "--detailed", f"--code={tmp_path}"
     )
     assert output.splitlines() == expect
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_imports__from_dir_with_some_excluded__prints_imports_from_unexcluded_only(
@@ -245,7 +253,7 @@ def test_list_imports__from_dir_with_some_excluded__prints_imports_from_unexclud
         "--list-imports", "--detailed", f"--code={tmp_path}", "--exclude=*.py"
     )
     assert output.splitlines() == expect
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_imports__from_unsupported_file__fails_with_exit_code_2(tmp_path):
@@ -257,7 +265,7 @@ def test_list_imports__from_unsupported_file__fails_with_exit_code_2(tmp_path):
     assert (
         f"Supported formats are .py and .ipynb; Cannot parse code: {filepath}" in errors
     )
-    assert returncode == 2
+    assert returncode == EXIT_CLI_PARSE_ERROR
 
 
 def test_list_imports__from_missing_file__fails_with_exit_code_2(tmp_path):
@@ -266,7 +274,7 @@ def test_list_imports__from_missing_file__fails_with_exit_code_2(tmp_path):
         "--list-imports", f"--code={missing_path}"
     )
     assert f"Code path to parse is neither dir nor file: {missing_path}" in errors
-    assert returncode == 2
+    assert returncode == EXIT_CLI_PARSE_ERROR
 
 
 def test_list_imports__missing_exclude_pattern__fails_with_exit_code_2():
@@ -274,7 +282,7 @@ def test_list_imports__missing_exclude_pattern__fails_with_exit_code_2():
         "--list-imports", "--exclude="
     )
     assert "Error while parsing exclude pattern: No rule found: ''" in errors
-    assert returncode == 2
+    assert returncode == EXIT_CLI_PARSE_ERROR
 
 
 def test_list_imports__comment_in_exclude_pattern__fails_with_exit_code_2():
@@ -282,7 +290,7 @@ def test_list_imports__comment_in_exclude_pattern__fails_with_exit_code_2():
         "--list-imports", "--exclude", "# comment"
     )
     assert "Error while parsing exclude pattern: No rule found: '# comment'" in errors
-    assert returncode == 2
+    assert returncode == EXIT_CLI_PARSE_ERROR
 
 
 def test_list_imports__from_empty_dir__logs_but_extracts_nothing(tmp_path):
@@ -295,7 +303,7 @@ def test_list_imports__from_empty_dir__logs_but_extracts_nothing(tmp_path):
     )
     assert output == ""
     assert_unordered_equivalence(errors.splitlines(), expect_logs)
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_imports__pick_multiple_files_dir__prints_all_imports(
@@ -308,7 +316,7 @@ def test_list_imports__pick_multiple_files_dir__prints_all_imports(
     )
     expect = ["django", "pandas", "click"]
     assert_unordered_equivalence(output.splitlines()[:-2], expect)
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_imports__pick_multiple_files_dir_and_code__prints_all_imports(
@@ -330,7 +338,7 @@ def test_list_imports__pick_multiple_files_dir_and_code__prints_all_imports(
     )
     expect = ["django", "requests", "foo", "numpy"]
     assert_unordered_equivalence(output.splitlines()[:-2], expect)
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_imports__stdin_with_legacy_encoding__prints_all_imports():
@@ -349,7 +357,7 @@ def test_list_imports__stdin_with_legacy_encoding__prints_all_imports():
     )
     expect = ["numpy"]
     assert_unordered_equivalence(output.splitlines()[:-2], expect)
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_deps_detailed__dir__prints_deps_from_requirements_txt(fake_project):
@@ -366,7 +374,7 @@ def test_list_deps_detailed__dir__prints_deps_from_requirements_txt(fake_project
         "--list-deps", "--detailed", f"--deps={tmp_path}"
     )
     assert output.splitlines() == expect
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_deps_json__dir__prints_deps_from_requirements_txt(fake_project):
@@ -406,7 +414,7 @@ def test_list_deps_json__dir__prints_deps_from_requirements_txt(fake_project):
         "--list-deps", "--json", f"--deps={tmp_path}"
     )
     assert json.loads(output) == expect
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_deps_summary__dir__prints_deps_from_requirements_txt(fake_project):
@@ -418,7 +426,7 @@ def test_list_deps_summary__dir__prints_deps_from_requirements_txt(fake_project)
     expect = ["pandas", "requests"]
     output, returncode = run_fawltydeps_function("--list-deps", f"--deps={tmp_path}")
     assert output.splitlines()[:-2] == expect
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_deps__unsupported_file__fails_with_exit_code_2(tmp_path):
@@ -428,7 +436,7 @@ def test_list_deps__unsupported_file__fails_with_exit_code_2(tmp_path):
     _output, errors, returncode = run_fawltydeps_subprocess(
         "--list-deps", f"--deps={filepath}"
     )
-    assert returncode == 2
+    assert returncode == EXIT_CLI_PARSE_ERROR
     assert f"Parsing given dependencies path isn't supported: {filepath}" in errors
 
 
@@ -438,7 +446,7 @@ def test_list_deps__missing_path__fails_with_exit_code_2(tmp_path):
     _output, errors, returncode = run_fawltydeps_subprocess(
         "--list-deps", f"--deps={missing_path}"
     )
-    assert returncode == 2
+    assert returncode == EXIT_CLI_PARSE_ERROR
     assert (
         f"Dependencies declaration path is neither dir nor file: {missing_path}"
         in errors
@@ -452,7 +460,7 @@ def test_list_deps__empty_dir__verbosely_logs_but_extracts_nothing(tmp_path):
     )
     assert output == ""
     assert errors == ""  # TODO: Should there be a INFO-level log message here?
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_deps__pick_multiple_listed_files__prints_all_dependencies(
@@ -465,14 +473,14 @@ def test_list_deps__pick_multiple_listed_files__prints_all_dependencies(
     )
     expect = ["annoy", "jieba", "click", "pandas", "tensorflow"]
     assert_unordered_equivalence(output.splitlines()[:-2], expect)
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_sources__in_empty_project__lists_nothing(tmp_path):
     output, returncode = run_fawltydeps_function("--list-sources", f"{tmp_path}")
     expect = []
     assert_unordered_equivalence(output.splitlines()[:-2], expect)
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_sources__in_varied_project__lists_all_files(fake_project):
@@ -508,7 +516,7 @@ def test_list_sources__in_varied_project__lists_all_files(fake_project):
         ]
     ]
     assert_unordered_equivalence(output.splitlines()[:-2], expect)
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_sources_detailed__in_varied_project__lists_all_files(fake_project):
@@ -562,7 +570,7 @@ def test_list_sources_detailed__in_varied_project__lists_all_files(fake_project)
         *expect_pyenv_lines,
     ]
     assert output.splitlines() == expect
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_sources_detailed__from_both_python_file_and_stdin(fake_project):
@@ -583,7 +591,7 @@ def test_list_sources_detailed__from_both_python_file_and_stdin(fake_project):
         ],
     ]
     assert output.splitlines() in expect
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_list_sources__with_exclude_from(fake_project):
@@ -637,7 +645,7 @@ class ProjectTestVector:
 
     expect_output: List[str] = field(default_factory=list)
     expect_logs: List[str] = field(default_factory=list)
-    expect_returncode: int = 0
+    expect_returncode: int = EXIT_SUCCESS
 
 
 full_success_message = (
@@ -662,7 +670,7 @@ project_tests_samples = [
             "- 'requests' imported at:",
             f"    {Path('{path}', 'code.py')}:1",
         ],
-        expect_returncode=3,
+        expect_returncode=EXIT_UNDECLARED,
     ),
     ProjectTestVector(
         id="simple_project_with_extra_deps__reports_unused",
@@ -674,7 +682,7 @@ project_tests_samples = [
             "- 'pandas' declared in:",
             f"    {Path('{path}', 'requirements.txt')}",
         ],
-        expect_returncode=4,
+        expect_returncode=EXIT_UNUSED,
     ),
     ProjectTestVector(
         id="simple_project_with_extra_deps__reports_unused_and_undeclared",
@@ -690,7 +698,7 @@ project_tests_samples = [
             "- 'pandas' declared in:",
             f"    {Path('{path}', 'requirements.txt')}",
         ],
-        expect_returncode=3,  # undeclared is more important than unused
+        expect_returncode=EXIT_UNDECLARED,  # undeclared is more important than unused
     ),
     ProjectTestVector(
         id="simple_project__summary_report_with_verbose_logging",
@@ -713,7 +721,7 @@ project_tests_samples = [
             "INFO:fawltydeps.packages:'pandas' was not resolved."
             " Assuming it can be imported as 'pandas'.",
         ],
-        expect_returncode=3,  # undeclared is more important than unused
+        expect_returncode=EXIT_UNDECLARED,  # undeclared is more important than unused
     ),
     ProjectTestVector(
         id="simple_project__summary_report_with_quiet_logging",
@@ -729,7 +737,7 @@ project_tests_samples = [
             "- 'pandas' declared in:",
             f"    {Path('{path}', 'requirements.txt')}",
         ],
-        expect_returncode=3,  # undeclared is more important than unused
+        expect_returncode=EXIT_UNDECLARED,  # undeclared is more important than unused
     ),
 ]
 
@@ -831,7 +839,7 @@ def test_check_json__simple_project__can_report_both_undeclared_and_unused(
         f"--pyenv={tmp_path}",
     )
     assert json.loads(output) == expect
-    assert returncode == 3  # --json does not affect exit code
+    assert returncode == EXIT_UNDECLARED  # --json does not affect exit code
 
 
 def test_check_undeclared__simple_project__reports_only_undeclared(fake_project):
@@ -853,7 +861,7 @@ def test_check_undeclared__simple_project__reports_only_undeclared(fake_project)
         f"{tmp_path}",
     )
     assert output.splitlines() == expect
-    assert returncode == 3
+    assert returncode == EXIT_UNDECLARED
 
 
 def test_check_unused__simple_project__reports_only_unused(fake_project):
@@ -875,7 +883,7 @@ def test_check_unused__simple_project__reports_only_unused(fake_project):
         f"{tmp_path}",
     )
     assert output.splitlines() == expect
-    assert returncode == 4
+    assert returncode == EXIT_UNUSED
 
 
 def test__no_action__defaults_to_check_action(fake_project):
@@ -897,7 +905,7 @@ def test__no_action__defaults_to_check_action(fake_project):
         f"--code={tmp_path}", "--detailed", f"--deps={tmp_path}"
     )
     assert output.splitlines() == expect
-    assert returncode == 3
+    assert returncode == EXIT_UNDECLARED
 
 
 def test__no_options__defaults_to_check_action_in_current_dir(fake_project):
@@ -919,7 +927,7 @@ def test__no_options__defaults_to_check_action_in_current_dir(fake_project):
     output, errors, returncode = run_fawltydeps_subprocess("--detailed", cwd=tmp_path)
     assert output.splitlines() == expect
     assert_unordered_equivalence(errors.splitlines(), expect_logs)
-    assert returncode == 3
+    assert returncode == EXIT_UNDECLARED
 
 
 def test_check__summary__writes_only_names_of_unused_and_undeclared(fake_project):
@@ -939,7 +947,7 @@ def test_check__summary__writes_only_names_of_unused_and_undeclared(fake_project
     ]
     output, returncode = run_fawltydeps_function("--check", basepath=tmp_path)
     assert output.splitlines() == expect
-    assert returncode == 3
+    assert returncode == EXIT_UNDECLARED
 
 
 def test_check_detailed__simple_project_in_fake_venv__resolves_imports_vs_deps(
@@ -962,7 +970,7 @@ def test_check_detailed__simple_project_in_fake_venv__resolves_imports_vs_deps(
     assert output.splitlines() == [
         Analysis.success_message(check_undeclared=True, check_unused=True),
     ]
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_check_detailed__simple_project_w_2_fake_venv__resolves_imports_vs_deps(
@@ -983,7 +991,7 @@ def test_check_detailed__simple_project_w_2_fake_venv__resolves_imports_vs_deps(
     assert output.splitlines() == [
         Analysis.success_message(check_undeclared=True, check_unused=True),
     ]
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 def test_check_json__no_pyenvs_found__falls_back_to_current_env(fake_project):
@@ -1068,7 +1076,7 @@ def test_check_json__no_pyenvs_found__falls_back_to_current_env(fake_project):
     }
     output, returncode = run_fawltydeps_function("--check", "--json", f"{tmp_path}")
     assert json.loads(output) == expect
-    assert returncode == 0  # --json does not affect exit code
+    assert returncode == EXIT_SUCCESS  # --json does not affect exit code
 
 
 @pytest.mark.parametrize(
@@ -1149,7 +1157,7 @@ def test_cmdline_on_ignored_undeclared_option(
     )
     output, returncode = run_fawltydeps_function(*args, basepath=tmp_path)
     assert output.splitlines() == expected
-    assert returncode == 0
+    assert returncode == EXIT_SUCCESS
 
 
 @pytest.mark.parametrize(
@@ -1360,7 +1368,7 @@ def test_cmdline_args_in_combination_with_config_file(
     )
     assert output.splitlines() == expect
     assert errors == ""
-    assert returncode in {0, 3, 4}
+    assert returncode in {EXIT_SUCCESS, EXIT_UNDECLARED, EXIT_UNUSED}
 
 
 def test_deps_across_groups_appear_just_once_in_list_deps_detailed(tmp_path):

--- a/tests/test_cmdline_options.py
+++ b/tests/test_cmdline_options.py
@@ -96,7 +96,7 @@ def code_option_strategy(paths: List[str]):
         st.sampled_from(paths),
         min_size=0,
         max_size=MAX_NUMBER_OF_CODE_ARGS,
-    ).map(lambda xs: ["--code"] + xs if xs else [])
+    ).map(lambda xs: ["--code", *xs] if xs else [])
 
 
 def deps_option_strategy(paths: List[str]):
@@ -106,15 +106,15 @@ def deps_option_strategy(paths: List[str]):
         st.sampled_from(paths),
         min_size=0,
         max_size=MAX_NUMBER_OF_DEPS_ARGS,
-    ).map(lambda xs: ["--deps"] + xs if xs else [])
+    ).map(lambda xs: ["--deps", *xs] if xs else [])
 
 
 ignored_strategy = st.lists(safe_string, min_size=0, max_size=MAX_IGNORE_ARGS)
 ignored_undeclared_strategy = ignored_strategy.map(
-    lambda xs: ["--ignore-undeclared"] + xs if xs else []
+    lambda xs: ["--ignore-undeclared", *xs] if xs else []
 )
 ignored_unused_strategy = ignored_strategy.map(
-    lambda xs: ["--ignore-unused"] + xs if xs else []
+    lambda xs: ["--ignore-unused", *xs] if xs else []
 )
 
 deps_parser_choice_strategy = st.one_of(st.sampled_from(deps_parser_choice), st.none())

--- a/tests/test_cmdline_options.py
+++ b/tests/test_cmdline_options.py
@@ -1,5 +1,4 @@
-"""
-Parametrized property-based tests for command line interface.
+"""Parametrized property-based tests for command line interface.
 
 Contains a strategy, for generating a CLI commands with
 combination of parameters in a randomized order (apart from positional args).
@@ -187,10 +186,7 @@ def cli_arguments_combinations(draw):
     max_examples=100,
 )
 def test_options_interactions__correct_options__does_not_abort(cli_arguments):
-    """Check if a combination of valid options
-
-    makes a valid run of fawltydeps CLI tool.
-    """
+    """Check if a combination of valid options makes a valid run of fawltydeps CLI tool."""
     project_dir, drawn_args, to_stdin = cli_arguments
     basepath = (
         [] if {"--code", "--deps"}.issubset(set(drawn_args)) else [str(project_dir)]

--- a/tests/test_cmdline_options.py
+++ b/tests/test_cmdline_options.py
@@ -193,7 +193,7 @@ def test_options_interactions__correct_options__does_not_abort(cli_arguments):
     )
     args = basepath + drawn_args
 
-    with open(os.devnull, "w") as f_out:
+    with Path(os.devnull).open("w") as f_out:
         exit_code = main(cmdline_args=args, stdin=io.StringIO(to_stdin), stdout=f_out)
 
     assert exit_code in {0, 3, 4}

--- a/tests/test_deps_parser_determination.py
+++ b/tests/test_deps_parser_determination.py
@@ -20,7 +20,7 @@ from .utils import assert_unordered_equivalence, collect_dep_names
 
 
 @pytest.mark.parametrize(
-    ["path", "expect_choice"],
+    ("path", "expect_choice"),
     [
         pytest.param(Path(path), expect_choice, id=path)
         for path, expect_choice in [
@@ -70,7 +70,7 @@ PARSER_CHOICE_FILE_NAME_MISMATCH_GRID = {
 
 
 @pytest.mark.parametrize(
-    ["parser_choice", "deps_file_name", "has_log"],
+    ("parser_choice", "deps_file_name", "has_log"),
     [
         pytest.param(pc, fn, has_log, id=f"{pc}__{fn}__{has_log}")
         for pc, fn, has_log in [
@@ -99,7 +99,7 @@ def test_explicit_parse_strategy__mismatch_yields_appropriate_logging(
 
 
 @pytest.mark.parametrize(
-    ["deps_file_name", "exp_deps"],
+    ("deps_file_name", "exp_deps"),
     [
         pytest.param(fn, deps, id=fn)
         for fn, deps in [
@@ -127,7 +127,7 @@ def test_filepath_inference(
 
 
 @pytest.mark.parametrize(
-    ["parser_choice", "exp_deps"],
+    ("parser_choice", "exp_deps"),
     [
         pytest.param(choice, exp, id=f"{choice.name}")
         for choice, exp in [
@@ -155,7 +155,7 @@ def test_extract_from_directory_applies_manual_parser_choice_iff_choice_applies(
 
 
 @pytest.mark.parametrize(
-    ["parser_choice", "fn1", "fn2", "exp_deps"],
+    ("parser_choice", "fn1", "fn2", "exp_deps"),
     [
         pytest.param(choice, fn1, fn2, exp, id=f"{choice.name}__{fn1}__{fn2}")
         for choice, fn1, fn2, exp in [

--- a/tests/test_deps_parser_determination.py
+++ b/tests/test_deps_parser_determination.py
@@ -1,4 +1,4 @@
-""" Test the determination of strategy to parse dependency declarations. """
+"""Test the determination of strategy to parse dependency declarations."""
 
 import logging
 import shutil

--- a/tests/test_deps_parser_determination.py
+++ b/tests/test_deps_parser_determination.py
@@ -113,7 +113,7 @@ def test_explicit_parse_strategy__mismatch_yields_appropriate_logging(
 # pylint: disable=unused-argument
 def test_filepath_inference(
     tmp_path,
-    project_with_setup_with_cfg_pyproject_and_requirements,
+    project_with_setup_with_cfg_pyproject_and_requirements,  # noqa: ARG001
     deps_file_name,
     exp_deps,
 ):
@@ -144,7 +144,7 @@ def test_filepath_inference(
 # pylint: disable=unused-argument
 def test_extract_from_directory_applies_manual_parser_choice_iff_choice_applies(
     tmp_path,
-    project_with_setup_with_cfg_pyproject_and_requirements,
+    project_with_setup_with_cfg_pyproject_and_requirements,  # noqa: ARG001
     parser_choice,
     exp_deps,
 ):
@@ -186,7 +186,7 @@ def test_extract_from_directory_applies_manual_parser_choice_iff_choice_applies(
 def test_extract_from_file_applies_manual_choice_even_if_mismatched(
     caplog,
     tmp_path,
-    project_with_setup_with_cfg_pyproject_and_requirements,
+    project_with_setup_with_cfg_pyproject_and_requirements,  # noqa: ARG001
     parser_choice,
     fn1,
     fn2,

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -131,7 +131,7 @@ class DirectoryTraversalVector:
     expect_alternatives: Optional[List[List[ExpectedTraverseStep]]] = None
     skip_me: Optional[str] = None
 
-    def setup(self, setup_dir: Path) -> DirectoryTraversal:
+    def setup(self, setup_dir: Path) -> DirectoryTraversal:  # noqa: C901
         """Perform the setup of a DirectoryTraversal object.
 
         Set up the file structure in self.given under the given 'setup_dir', and
@@ -158,12 +158,12 @@ class DirectoryTraversalVector:
             base_dir = None if ipat.base_dir is None else setup_dir / ipat.base_dir
             try:
                 traversal.exclude(ipat.pattern, base_dir=base_dir)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 exceptions_from_exclude.append(e)
         for exclude_file in self.exclude_from:
             try:
                 traversal.exclude_from(setup_dir / exclude_file)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 exceptions_from_exclude.append(e)
         if not self.exclude_exceptions:  # no exceptions are expected
             for exc in exceptions_from_exclude:
@@ -1039,7 +1039,7 @@ def test_DirectoryTraversal_w_abs_paths(vector: DirectoryTraversalVector, tmp_pa
     "vector", [pytest.param(v, id=v.id) for v in directory_traversal_vectors]
 )
 def test_DirectoryTraversal_w_rel_paths(
-    vector: DirectoryTraversalVector, inside_tmp_path
+    vector: DirectoryTraversalVector, inside_tmp_path  # noqa: ARG001
 ):
     traversal = vector.setup(Path("."))  # Traverse relatively from inside tmp_path
     vector.verify_traversal(traversal, Path("."))

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -448,7 +448,7 @@ directory_traversal_vectors: List[DirectoryTraversalVector] = [
     # An optional prefix "!" which negates the pattern; any matching file
     # excluded by a previous pattern will become included again. It is not
     # possible to re-include a file if a parent directory of that file is
-    # excluded. Git doesn’t list excluded directories for performance reasons,
+    # excluded. Git doesn't list excluded directories for performance reasons,
     # so any patterns on contained files have no effect, no matter where they
     # are defined. Put a backslash ("\") in front of the first "!" for patterns
     # that begin with a literal "!", for example, "\!important!.txt".

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -1041,8 +1041,8 @@ def test_DirectoryTraversal_w_abs_paths(vector: DirectoryTraversalVector, tmp_pa
 def test_DirectoryTraversal_w_rel_paths(
     vector: DirectoryTraversalVector, inside_tmp_path  # noqa: ARG001
 ):
-    traversal = vector.setup(Path("."))  # Traverse relatively from inside tmp_path
-    vector.verify_traversal(traversal, Path("."))
+    traversal = vector.setup(Path())  # Traverse relatively from inside tmp_path
+    vector.verify_traversal(traversal, Path())
 
 
 def test_DirectoryTraversal__raises_error__when_adding_missing_dir(tmp_path):

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -188,7 +188,7 @@ class DirectoryTraversalVector:
                 else:  # this alternative passed
                     break  # abort loop and skip below else clause
             else:  # we exhausted all alternatives
-                assert False, f"None of the alternatives matched {actual}"
+                pytest.fail(f"None of the alternatives matched {actual}")
 
 
 def on_windows(msg: str) -> Optional[str]:

--- a/tests/test_extract_declared_dependencies_errors.py
+++ b/tests/test_extract_declared_dependencies_errors.py
@@ -1,4 +1,4 @@
-"""Test unhappy path, where parsing of dependencies fails"""
+"""Test unhappy path, where parsing of dependencies fails."""
 
 import logging
 

--- a/tests/test_extract_declared_dependencies_errors.py
+++ b/tests/test_extract_declared_dependencies_errors.py
@@ -28,7 +28,7 @@ def test_parse_setup_cfg__malformed__logs_error(write_tmp_files, caplog):
 
 
 @pytest.mark.parametrize(
-    "code,expect,fail_arg",
+    ("code", "expect", "fail_arg"),
     [
         pytest.param(
             """\

--- a/tests/test_extract_declared_dependencies_pyproject_toml.py
+++ b/tests/test_extract_declared_dependencies_pyproject_toml.py
@@ -1,4 +1,4 @@
-"""Test extracting dependencies from pyproject.toml"""
+"""Test extracting dependencies from pyproject.toml."""
 import logging
 from dataclasses import dataclass, field
 from typing import List

--- a/tests/test_extract_declared_dependencies_pyproject_toml.py
+++ b/tests/test_extract_declared_dependencies_pyproject_toml.py
@@ -10,7 +10,7 @@ from fawltydeps.types import DeclaredDependency, Location
 
 
 @pytest.mark.parametrize(
-    "pyproject_toml,expected_deps",
+    ("pyproject_toml", "expected_deps"),
     [
         pytest.param(
             """\
@@ -280,7 +280,7 @@ def test_parse_pyproject_content__malformatted_poetry_dependencies__yields_no_de
 
 
 @pytest.mark.parametrize(
-    "pyproject_toml,expected,expected_logs",
+    ("pyproject_toml", "expected", "expected_logs"),
     [
         pytest.param(
             """\

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -23,7 +23,7 @@ from .utils import (
 
 
 @pytest.mark.parametrize(
-    "file_content,expect_deps",
+    ("file_content", "expect_deps"),
     [
         pytest.param(
             """\
@@ -93,7 +93,7 @@ def test_parse_requirements_txt(write_tmp_files, file_content, expect_deps):
 
 
 @pytest.mark.parametrize(
-    "file_content,expect_deps",
+    ("file_content", "expect_deps"),
     [
         pytest.param(
             """\
@@ -313,7 +313,7 @@ def test_parse_setup_py(write_tmp_files, file_content, expect_deps):
 
 
 @pytest.mark.parametrize(
-    "file_content,expect_deps",
+    ("file_content", "expect_deps"),
     [
         pytest.param(
             """\
@@ -744,7 +744,7 @@ def test_find_and_parse_sources__project_with_setup_cfg_pyproject_requirements__
 
 
 @pytest.mark.parametrize(
-    ["deps_file_content", "exp_deps"],
+    ("deps_file_content", "exp_deps"),
     [
         pytest.param(dedent(lines), exp, id=id_)
         for lines, exp, id_ in [

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -546,7 +546,6 @@ def test_find_and_parse_sources__project_with_pyproject__returns_list(fake_proje
 
 
 def test_find_and_parse_dynamic_sources__project_with_pyproject__returns_list(
-    write_tmp_files,
     fake_project,
 ):
     # Write requirements files into a place where files should be initially ignored
@@ -577,7 +576,6 @@ def test_find_and_parse_dynamic_sources__project_with_pyproject__returns_list(
 
 
 def test_find_and_parse_static_and_dynamic_sources__project_with_pyproject__returns_list(
-    write_tmp_files,
     fake_project,
 ):
     # Write requirements files into a place where files should be initially ignored
@@ -615,7 +613,6 @@ def test_find_and_parse_static_and_dynamic_sources__project_with_pyproject__retu
 
 
 def test_find_and_parse_static_and_dynamic_dependencies__project_with_pyproject__returns_list(
-    write_tmp_files,
     fake_project,
 ):
     # Write requirements files into a place where files should be initially ignored
@@ -654,7 +651,6 @@ def test_find_and_parse_static_and_dynamic_dependencies__project_with_pyproject_
 
 
 def test_find_and_parse_static_and_dynamic_opt_dependencies__project_with_pyproject__returns_list(
-    write_tmp_files,
     fake_project,
 ):
     # Write requirements files into a place where files should be initially ignored

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -750,8 +750,8 @@ def test_find_and_parse_sources__project_with_setup_cfg_pyproject_requirements__
 @pytest.mark.parametrize(
     ["deps_file_content", "exp_deps"],
     [
-        pytest.param(dedent(lines), exp, id=id)
-        for lines, exp, id in [
+        pytest.param(dedent(lines), exp, id=id_)
+        for lines, exp, id_ in [
             (
                 """
                 FooProject >= 1.2 --global-option="--no-user-cfg" \\

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -92,7 +92,7 @@ def write_code_sources(write_tmp_files):
 
 
 @pytest.mark.parametrize(
-    "code,expected_import_line_pairs",
+    ("code", "expected_import_line_pairs"),
     [
         pytest.param("", [], id="no_code__has_no_imports"),
         pytest.param(
@@ -493,7 +493,7 @@ def test_parse_sources__imports__are_extracted_in_order_of_encounter(
 
 
 @pytest.mark.parametrize(
-    "code,expect_data",
+    ("code", "expect_data"),
     [
         pytest.param(
             {

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -55,10 +55,9 @@ def generate_notebook(
             "source": source,
         }
 
-    if isinstance(cell_types, str):
-        types = [cell_types] * len(cells_source)
-    else:
-        types = cell_types
+    types = (
+        [cell_types] * len(cells_source) if isinstance(cell_types, str) else cell_types
+    )
 
     notebook = {
         "nbformat": 4,

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -75,7 +75,7 @@ def generate_notebook(
     return json.dumps(notebook, indent=2)
 
 
-@pytest.fixture
+@pytest.fixture()
 def write_code_sources(write_tmp_files):
     """A wrapper around write_tmp_files() that return CodeSource objects."""
 

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -83,7 +83,7 @@ def write_code_sources(write_tmp_files):
     def _inner(file_contents: Dict[str, str]) -> Tuple[Path, List[CodeSource]]:
         tmp_path = write_tmp_files(file_contents)
         sources = []
-        for filepath in file_contents.keys():
+        for filepath in file_contents:
             assert filepath.endswith((".py", ".ipynb"))
             sources.append(CodeSource(tmp_path / filepath, tmp_path))
         return tmp_path, sources

--- a/tests/test_gitignore_parser.py
+++ b/tests/test_gitignore_parser.py
@@ -204,11 +204,11 @@ def test_gitignore_parser_w_abs_paths(vector: GitignoreParserTestVector):
     # This trailing slash is stripped by Path() in any case.
     for path in vector.does_match:
         assert match_rules(
-            rules, absolutify(path), isinstance(path, str) and path.endswith("/")
+            rules, absolutify(path), is_dir=isinstance(path, str) and path.endswith("/")
         )
     for path in vector.doesnt_match:
         assert not match_rules(
-            rules, absolutify(path), isinstance(path, str) and path.endswith("/")
+            rules, absolutify(path), is_dir=isinstance(path, str) and path.endswith("/")
         )
 
 
@@ -223,11 +223,11 @@ def test_gitignore_parser_w_rel_paths(vector: GitignoreParserTestVector):
     # This trailing slash is stripped by Path() in any case.
     for path in vector.does_match:
         assert match_rules(
-            rules, Path(path), isinstance(path, str) and path.endswith("/")
+            rules, Path(path), is_dir=isinstance(path, str) and path.endswith("/")
         )
     for path in vector.doesnt_match:
         assert not match_rules(
-            rules, Path(path), isinstance(path, str) and path.endswith("/")
+            rules, Path(path), is_dir=isinstance(path, str) and path.endswith("/")
         )
 
 
@@ -248,4 +248,4 @@ def test_symlink_to_another_directory(tmp_path):
     )
     # Verify behavior according to https://git-scm.com/docs/gitignore#_notes:
     # Symlinks are not followed and are matched as if they were regular files.
-    assert match_rules(rules, link, False)
+    assert match_rules(rules, link, is_dir=False)

--- a/tests/test_install_deps.py
+++ b/tests/test_install_deps.py
@@ -12,7 +12,7 @@ from fawltydeps.packages import (
 from fawltydeps.types import UnresolvedDependenciesError
 
 
-def test_resolve_dependencies_install_deps__via_local_cache(local_pypi):
+def test_resolve_dependencies_install_deps__via_local_cache(local_pypi):  # noqa: ARG001
     debug_info = "Provided by temporary `pip install`"
     actual = resolve_dependencies(
         ["leftpadx", "click"], setup_resolvers(install_deps=True)
@@ -26,7 +26,7 @@ def test_resolve_dependencies_install_deps__via_local_cache(local_pypi):
 
 
 def test_resolve_dependencies_install_deps__raises_unresolved_error_on_pip_install_failure(
-    caplog, local_pypi
+    caplog, local_pypi  # noqa: ARG001
 ):
     # This tests the case where TemporaryPipInstallResolver encounters the
     # inevitable pip install error and returns to resolve_dependencies()
@@ -42,7 +42,7 @@ def test_resolve_dependencies_install_deps__raises_unresolved_error_on_pip_insta
 
 
 def test_resolve_dependencies_install_deps__unresolved_error_only_warns_failing_packages(
-    caplog, local_pypi
+    caplog, local_pypi  # noqa: ARG001
 ):
     # When we fail to install _some_ - but not all - packages, the error message
     # should only mention the packages that we failed to install.
@@ -58,7 +58,7 @@ def test_resolve_dependencies_install_deps__unresolved_error_only_warns_failing_
 
 
 def test_resolve_dependencies_install_deps_on_mixed_packages__raises_unresolved_error(
-    caplog, local_pypi
+    caplog, local_pypi  # noqa: ARG001
 ):
     caplog.set_level(logging.DEBUG)
     deps = {"click", "does_not_exist", "leftpadx"}

--- a/tests/test_invocation.py
+++ b/tests/test_invocation.py
@@ -16,9 +16,8 @@ pytestmark = pytest.mark.integration
 def run_package_main(*args: str) -> Tuple[str, int]:
     proc = subprocess.run(
         [sys.executable, "-m", "fawltydeps", *args],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True,
+        capture_output=True,
+        text=True,
         check=False,
     )
     return proc.stdout.strip(), proc.returncode

--- a/tests/test_invocation.py
+++ b/tests/test_invocation.py
@@ -60,5 +60,5 @@ def test_invocation_with_help(run_fawltydeps):
 @pytest.mark.parametrize("run_fawltydeps", invocation_methods)
 def test_invocation_in_empty_dir(run_fawltydeps, tmp_path):
     output, *_, exit_code = run_fawltydeps(str(tmp_path))
-    assert output == Analysis.success_message(True, True)
+    assert output == Analysis.success_message(check_undeclared=True, check_unused=True)
     assert exit_code == 0

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -35,7 +35,7 @@ def test_package__empty_package__matches_nothing():
 
 
 @pytest.mark.parametrize(
-    "package_name,matching_imports,non_matching_imports",
+    ("package_name", "matching_imports", "non_matching_imports"),
     [
         pytest.param(
             "foobar",
@@ -74,7 +74,7 @@ def test_package__identity_mapping(
 
 
 @pytest.mark.parametrize(
-    "package_name,import_names,matching_imports,non_matching_imports",
+    ("package_name", "import_names", "matching_imports", "non_matching_imports"),
     [
         pytest.param(
             "foobar",
@@ -148,7 +148,7 @@ def test_package__local_env_mapping(
 
 
 @pytest.mark.parametrize(
-    "mapping_files_content,custom_mapping,expect",
+    ("mapping_files_content", "custom_mapping", "expect"),
     [
         pytest.param(
             [
@@ -240,7 +240,7 @@ def test_user_defined_mapping__no_input__returns_empty_mapping():
 
 
 @pytest.mark.parametrize(
-    "dep_name,expect_import_names",
+    ("dep_name", "expect_import_names"),
     [
         pytest.param(
             "NOT_A_PACKAGE",

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -16,7 +16,7 @@ from fawltydeps.packages import (
 )
 from fawltydeps.types import (
     PyEnvSource,
-    UnparseablePathException,
+    UnparseablePathError,
     UnresolvedDependenciesError,
 )
 
@@ -230,7 +230,7 @@ def test_user_defined_mapping__well_formated_input_file__parses_correctly(
 
 
 def test_user_defined_mapping__input_is_no_file__raises_unparsable_path_exeption():
-    with pytest.raises(UnparseablePathException):
+    with pytest.raises(UnparseablePathError):
         UserDefinedMapping({SAMPLE_PROJECTS_DIR})
 
 

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -126,7 +126,7 @@ class ThirdPartyProject(BaseProject):
         unpack_dir = self.unpacked_project_dir(cache)
         logger.info(f"Unpacking {tarball_path} to {unpack_dir}...")
         with tarfile.open(tarball_path) as f:
-            f.extractall(unpack_dir)
+            f.extractall(unpack_dir)  # noqa: S202
         assert unpack_dir.is_dir()
         cache.set(self.unpacked_project_key, str(unpack_dir))
         return unpack_dir

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -152,10 +152,7 @@ class ThirdPartyProject(BaseProject):
 
         # Most tarballs contains a single leading directory; descend into it.
         entries = list(unpack_dir.iterdir())
-        if len(entries) == 1:
-            project_dir = entries[0]
-        else:
-            project_dir = unpack_dir
+        project_dir = entries[0] if len(entries) == 1 else unpack_dir
 
         logger.info(f"Unpacked project is at {project_dir}")
         return project_dir

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -169,7 +169,7 @@ class ThirdPartyProject(BaseProject):
 
 
 @pytest.mark.parametrize(
-    "project, experiment",
+    ("project", "experiment"),
     [
         pytest.param(project, experiment, id=experiment.name)
         for project in ThirdPartyProject.collect()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,4 +1,4 @@
-"""Verify behavior of packages resolver"""
+"""Verify behavior of packages resolver."""
 
 import sys
 import time
@@ -77,8 +77,7 @@ def generate_expected_resolved_deps(
     user_mapping_file: Optional[Path] = None,
     install_deps: bool = False,
 ) -> Dict[str, Package]:
-    """
-    Returns a dict of resolved packages.
+    """Returns a dict of resolved packages.
 
     This function does not actually resolve its input dependencies.
     It just constructs a valid dict of resolved dependencies that respects

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -70,6 +70,7 @@ def user_mapping_to_file_content(user_mapping: Dict[str, List[str]]) -> str:
 
 
 def generate_expected_resolved_deps(
+    *,
     locally_installed_deps: Dict[str, Set[str]],
     other_deps: Dict[str, Set[str]],
     user_defined_deps: List[str],

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -92,7 +92,7 @@ def generate_expected_resolved_deps(
     )
     if user_defined_deps:
         user_mapping = UserDefinedMapping(
-            set([user_mapping_file]) if user_mapping_file else None,
+            {user_mapping_file} if user_mapping_file else None,
             user_mapping_from_config,
         )
         resolved_packages = user_mapping.lookup_packages(set(user_defined_deps))
@@ -190,7 +190,7 @@ def test_resolve_dependencies__generates_expected_mappings(
         actual = resolve_dependencies(
             dep_names,
             setup_resolvers(
-                custom_mapping_files=set([custom_mapping_file])
+                custom_mapping_files={custom_mapping_file}
                 if custom_mapping_file
                 else None,
                 custom_mapping=user_config_mapping,

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -117,7 +117,7 @@ class SampleProject(BaseProject):
 
 
 @pytest.mark.parametrize(
-    "project, experiment",
+    ("project", "experiment"),
     [
         pytest.param(project, experiment, id=experiment.name)
         for project in SampleProject.collect()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -132,7 +132,7 @@ def subsets(
 
 @given(basepaths=nonempty_string_set, fillers=nonempty_string_set)
 @pytest.mark.parametrize(
-    ["filled", "unfilled"],
+    ("filled", "unfilled"),
     [
         pytest.param(opts, path_options.keys() - opts, id="Passing " + ", ".join(opts))
         for opts in subsets(set(path_options.keys()), 1, len(path_options) - 1)
@@ -159,7 +159,7 @@ def test_base_path_fills_path_options_when_other_path_settings_are_absent(basepa
 
 
 @pytest.mark.parametrize(
-    ["config_settings", "basepaths"],
+    ("config_settings", "basepaths"),
     [
         pytest.param(conf_sett, base, id=test_name)
         for conf_sett, base, test_name in [

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -75,7 +75,7 @@ def make_settings_dict(**kwargs):
     return ret
 
 
-@pytest.fixture
+@pytest.fixture()
 def setup_env(monkeypatch):
     """Allow setup of fawltydeps_* env vars in a test case."""
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -462,10 +462,9 @@ def test_settings(
     setup_fawltydeps_config,
     setup_env,
 ):  # pylint: disable=too-many-arguments
-    if vector.config is None:
-        config_file = None
-    else:
-        config_file = setup_fawltydeps_config(vector.config)
+    config_file = (
+        None if vector.config is None else setup_fawltydeps_config(vector.config)
+    )
     setup_env(**vector.env)
     cmdline_args = argparse.Namespace(**vector.cmdline)
     if isinstance(vector.expect, dict):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -42,9 +42,9 @@ except ModuleNotFoundError:
 
 EXPECT_DEFAULTS = dict(
     actions={Action.REPORT_UNDECLARED, Action.REPORT_UNUSED},
-    code={Path(".")},
-    deps={Path(".")},
-    pyenvs={Path(".")},
+    code={Path()},
+    deps={Path()},
+    pyenvs={Path()},
     custom_mapping=None,
     output_format=OutputFormat.HUMAN_SUMMARY,
     ignore_undeclared=set(),

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -241,10 +241,10 @@ def test_multivalued_options_are_aggregated_correctly(optargs):
 
 @pytest.mark.parametrize(
     "optname",
-    set(
+    {
         act.dest
         for act in build_parser()._actions  # pylint: disable=protected-access  # noqa: SLF001
-    )
+    }
     & set(Settings.__fields__.keys()),
 )
 def test_settings_members_are_absent_from_namespace_if_not_provided_at_cli(optname):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -77,7 +77,7 @@ def make_settings_dict(**kwargs):
 
 @pytest.fixture
 def setup_env(monkeypatch):
-    """Allow setup of fawltydeps_* env vars in a test case"""
+    """Allow setup of fawltydeps_* env vars in a test case."""
 
     def _inner(**kwargs: str):
         for k, v in kwargs.items():
@@ -203,9 +203,11 @@ OPTION_VALUES = {
 
 
 def multivalued_optargs_grid() -> Iterable[List[str]]:
-    """Create command-line option/argument combinations which
-    mix order and number of multivalued parameters."""
+    """Create shuffled argument list from OPTION_VALUES.
 
+    Generate command-line option/argument combinations which mix order and
+    number of multivalued parameters.
+    """
     T = TypeVar("T")
 
     def subsequence_pairs(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -142,7 +142,7 @@ def test_path_option_overrides_base_path(basepaths, filled, unfilled, fillers):
     assert filled and unfilled and (unfilled | filled) == path_options.keys()
     args = list(basepaths)
     for option in filled:
-        args += [option] + list(fillers)
+        args += [option, *list(fillers)]
     settings = run_build_settings(args)
     for option in filled:
         assert getattr(settings, path_options[option]) == to_path_set(fillers)
@@ -227,7 +227,7 @@ def multivalued_optargs_grid() -> Iterable[List[str]]:
     for param_grid in set(product(*option_partitions)):
         xss = list(chain(*param_grid))
         random.shuffle(xss)
-        yield list(chain(*[[f"--{opt_by_arg[xs[0]]}"] + list(xs) for xs in xss]))
+        yield list(chain(*[[f"--{opt_by_arg[xs[0]]}", *list(xs)] for xs in xss]))
 
 
 @pytest.mark.parametrize("optargs", multivalued_optargs_grid())

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -211,7 +211,7 @@ def multivalued_optargs_grid() -> Iterable[List[str]]:
     def subsequence_pairs(
         xs: Tuple[T, ...]
     ) -> Iterable[Tuple[Tuple[T, ...], Tuple[T, ...]]]:
-        assert len(xs) >= 2
+        assert len(xs) >= 2  # noqa: PLR2004
         for i in range(1, len(xs)):
             yield xs[:i], xs[i:]
 
@@ -239,7 +239,10 @@ def test_multivalued_options_are_aggregated_correctly(optargs):
 
 @pytest.mark.parametrize(
     "optname",
-    set(act.dest for act in build_parser()._actions)  # pylint: disable=protected-access
+    set(
+        act.dest
+        for act in build_parser()._actions  # pylint: disable=protected-access  # noqa: SLF001
+    )
     & set(Settings.__fields__.keys()),
 )
 def test_settings_members_are_absent_from_namespace_if_not_provided_at_cli(optname):

--- a/tests/test_traverse_project.py
+++ b/tests/test_traverse_project.py
@@ -16,7 +16,7 @@ from fawltydeps.types import (
     DepsSource,
     PathOrSpecial,
     PyEnvSource,
-    UnparseablePathException,
+    UnparseablePathError,
 )
 
 from .test_sample_projects import SAMPLE_PROJECTS_DIR
@@ -75,7 +75,7 @@ find_sources_vectors = [
         code={"missing.py"},
         deps=set(),
         pyenvs=set(),
-        expect_raised=UnparseablePathException,
+        expect_raised=UnparseablePathError,
     ),
     TraverseProjectVector(
         "given_code_as_non_py_file__raises_exception",
@@ -83,7 +83,7 @@ find_sources_vectors = [
         code={"README.md"},
         deps=set(),
         pyenvs=set(),
-        expect_raised=UnparseablePathException,
+        expect_raised=UnparseablePathError,
     ),
     TraverseProjectVector(
         "given_code_as_specialpath_stdin__yields_preserved_specialpath_stdin",
@@ -191,7 +191,7 @@ find_sources_vectors = [
         code=set(),
         deps={"missing_requirements.txt"},
         pyenvs=set(),
-        expect_raised=UnparseablePathException,
+        expect_raised=UnparseablePathError,
     ),
     TraverseProjectVector(
         "given_deps_as_non_deps_file__raises_exception",
@@ -199,7 +199,7 @@ find_sources_vectors = [
         code=set(),
         deps={"README.md"},
         pyenvs=set(),
-        expect_raised=UnparseablePathException,
+        expect_raised=UnparseablePathError,
     ),
     TraverseProjectVector(
         "given_deps_as_requirements_txt__yields_file",
@@ -394,7 +394,7 @@ find_sources_vectors = [
         code=set(),
         deps=set(),
         pyenvs={".does_not_exist"},
-        expect_raised=UnparseablePathException,
+        expect_raised=UnparseablePathError,
     ),
     TraverseProjectVector(
         "given_pyenv_as_non_env_dir__yields_nothing",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -43,20 +43,21 @@ testdata = {  # Test ID -> (Location args, expected string representation, sort 
 
 
 @pytest.mark.parametrize(
-    ("args", "string", "_"),
+    ("args", "string"),
     [
         pytest.param(
-            *data,
+            args,
+            string,
             id=key,
             marks=pytest.mark.skipif(
                 key == "abs_path_drive_prefix" and not sys.platform.startswith("win"),
                 reason="Drive prefix is used in Windows systems only.",
             ),
         )
-        for key, data in testdata.items()
+        for key, (args, string, _) in testdata.items()
     ],
 )
-def test_location__str(args, string, _):
+def test_location__str(args, string):
     assert str(Location(*args)) == string.replace("/", os.sep)
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -43,7 +43,7 @@ testdata = {  # Test ID -> (Location args, expected string representation, sort 
 
 
 @pytest.mark.parametrize(
-    "args,string,_",
+    ("args", "string", "_"),
     [
         pytest.param(
             *data,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -145,7 +145,7 @@ def run_fawltydeps_function(
     output = io.StringIO()
     exit_code = main(
         cmdline_args=([str(basepath)] if basepath else [])
-        + [f"--config-file={str(config_file)}"]
+        + [f"--config-file={config_file}"]
         + list(args),
         stdin=io.BytesIO(to_stdin or b""),
         stdout=output,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-""" Utilities to share among test modules """
+"""Utilities to share among test modules."""
 
 import io
 import logging
@@ -62,7 +62,7 @@ def imports_factory(*imports: str) -> List[ParsedImport]:
 
 
 def deps_factory(*deps: str, path: str = "foo") -> List[DeclaredDependency]:
-    "Dependency generator with a common path for all dependencies"
+    """Dependency generator with a common path for all dependencies."""
     return [DeclaredDependency(name=dep, source=Location(Path(path))) for dep in deps]
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -113,8 +113,7 @@ def run_fawltydeps_subprocess(
 ) -> Tuple[str, str, int]:
     """Run FawltyDeps as a subprocess. Designed for integration tests."""
     proc = subprocess.run(
-        [sys.executable, "-m", "fawltydeps", f"--config-file={config_file}"]
-        + list(args),
+        [sys.executable, "-m", "fawltydeps", f"--config-file={config_file}", *args],
         input=to_stdin,
         capture_output=True,
         text=True,
@@ -204,8 +203,10 @@ test_vectors = [
     ),
     FDTestVector(
         "mixed_imports_from_diff_files_with_unused_and_undeclared_deps",
-        imports=imports_factory("pandas")
-        + [ParsedImport("numpy", Location(Path("my_file.py"), lineno=3))],
+        imports=[
+            *imports_factory("pandas"),
+            ParsedImport("numpy", Location(Path("my_file.py"), lineno=3)),
+        ],
         declared_deps=deps_factory("pandas", "scipy"),
         expect_resolved_deps=resolved_factory("pandas", "scipy"),
         expect_undeclared_deps=[

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -81,7 +81,7 @@ default_sys_path_env_for_tests = {
 
 def resolved_factory(*deps: str) -> Dict[str, Package]:
     def make_package(dep: str) -> Package:
-        imports = default_sys_path_env_for_tests.get(dep, None)
+        imports = default_sys_path_env_for_tests.get(dep)
         if imports is not None:  # exists in local env
             return Package(dep, imports, SysPathPackageResolver)
         # fall back to identity mapping

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -116,9 +116,8 @@ def run_fawltydeps_subprocess(
         [sys.executable, "-m", "fawltydeps", f"--config-file={config_file}"]
         + list(args),
         input=to_stdin,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True,
+        capture_output=True,
+        text=True,
         check=False,
         cwd=cwd,
     )


### PR DESCRIPTION
Re-configure `ruff` to enable as many checks as feasible, and fix various issues throughout our codebase. The second PR in a series of 3.

Commits:
- Re-configure `ruff` to be much stricter
- Fix docstring issues
- Fix unused method arguments
- Fix `set(<generator>)` -> `{<set comprehension>}`
- Fix variable shadowing Python builtin
- Fix unused function arguments
- Fix `assert False` -> `pytest.fail(...)`
- Fix subprocess problems
- Fix magic values used in comparisons
- Fix use of non-tuples in `@pytest.mark.parametrize`
- Fix ambiguous character in comment
- Fix unnecessary use of `.keys()`
- Fix unnecessary use of `str()`
- Fix `set([...])` -> `{...}`
- Fix unnecessary None argument to `.get()`
- Use ternary operator instead of `if-else` block
- Use `@pytest.fixture()` over `@pytest.fixture`
- Fix unecessary use of `_` in parametrized args
- Use `Path.*` methods where available
- Avoid extraneous parentheses
- Use `yield from` instead of `for`-loop with `yield` inside
- Consolidate `if`-conditions
- Use `[foo, *bars]` instead of `[foo] + bars`
- Use `elif` instead of `else` + `if` where possible
- Ensure `bool` flag arguments to functions are always named
- Merge multiple comparisons
- Rename `UnparseablePathException` -> `UnparseablePathError`
- Ignore remaining/intentional violations of N818
- Fix PTH201: Do not pass the current directory explicitly to `Path()`
