### PR TITLE
Use `ruff format` instead of `black`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,9 @@ nox -R            # Run all available sessions, while reusing virtualenvs (i.e. 
 nox -s tests      # Run unit tests on supported Python versions (that are available)
 nox -s tests-3.7  # Run unit tests on Python v3.7 (assuming it is available locally)
 nox -s integration_tests-3.11  # Run integration tests on Python 3.11
-nox -s lint       # Run linters (mypy + ruff) on all supported Python versions
-nox -s format     # Check formatting (isort + black)
-nox -s reformat   # Fix formatting (isort + black)
+nox -s lint       # Run linters (mypy + ruff check) on all supported Python versions
+nox -s format     # Check formatting (ruff format)
+nox -s reformat   # Fix formatting (ruff format)
 ```
 
 If you want to run a command individually, the corresponding session is defined inside
@@ -90,9 +90,8 @@ commands will work:
 pytest                   # Run unit tests
 pytest -m integration    # Run integration tests
 mypy                     # Run static type checking
-ruff check .             # Run ruff
-isort fawltydeps tests   # Fix sorting of import statements
-black .                  # Fix code formatting
+ruff check .             # Run ruff linter
+ruff format .            # Run ruff formatter
 ```
 
 #### Shortcut: Nix

--- a/docs/CodeDesign.md
+++ b/docs/CodeDesign.md
@@ -20,8 +20,8 @@ We value composability and functional style.
 
 We want the code to be readable, testable and maintainable. That is why we use:
 
-- code formatter `black` to unify the code style,
-- `ruff` and `isort` for linting
+- code formatter `ruff format` to unify the code style,
+- `ruff check` for linting
 - `mypy` for typecheck
 - `pytest` for testing
   to ensure this quality.

--- a/fawltydeps/settings.py
+++ b/fawltydeps/settings.py
@@ -1,4 +1,5 @@
 """FawltyDeps configuration and command-line options."""
+
 from __future__ import annotations
 
 import argparse

--- a/fawltydeps/traverse_project.py
+++ b/fawltydeps/traverse_project.py
@@ -1,4 +1,5 @@
 """Traverse a project to identify appropriate inputs to FawltyDeps."""
+
 import logging
 from pathlib import Path
 from typing import AbstractSet, Iterator, Optional, Set, Tuple, Type, Union

--- a/noxfile.py
+++ b/noxfile.py
@@ -121,7 +121,7 @@ def format(session):  # noqa: A001
     install_groups(session, include=["format"], include_self=False)
     session.run("codespell", "--enable-colors")
     session.run("isort", "fawltydeps", "tests", "--check", "--diff", "--color")
-    session.run("black", ".", "--check", "--diff", "--color")
+    session.run("ruff", "format", "--diff", ".")
 
 
 @nox.session
@@ -129,4 +129,4 @@ def reformat(session):
     install_groups(session, include=["format"], include_self=False)
     session.run("codespell", "--write-changes")
     session.run("isort", "fawltydeps", "tests")
-    session.run("black", ".")
+    session.run("ruff", "format", ".")

--- a/noxfile.py
+++ b/noxfile.py
@@ -120,7 +120,6 @@ def lint(session):
 def format(session):  # noqa: A001
     install_groups(session, include=["format"], include_self=False)
     session.run("codespell", "--enable-colors")
-    session.run("isort", "fawltydeps", "tests", "--check", "--diff", "--color")
     session.run("ruff", "format", "--diff", ".")
 
 
@@ -128,5 +127,4 @@ def format(session):  # noqa: A001
 def reformat(session):
     install_groups(session, include=["format"], include_self=False)
     session.run("codespell", "--write-changes")
-    session.run("isort", "fawltydeps", "tests")
     session.run("ruff", "format", ".")

--- a/poetry.lock
+++ b/poetry.lock
@@ -51,58 +51,6 @@ tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
 tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
 
 [[package]]
-name = "black"
-version = "22.12.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
-    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
-    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
-    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
-    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
-    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
-    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
-    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
-    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
-    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
-    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
-    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-colorama = {version = ">=0.4.3", optional = true, markers = "extra == \"colorama\""}
-mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
-typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-
-[[package]]
 name = "codespell"
 version = "2.2.5"
 description = "Codespell"
@@ -389,17 +337,6 @@ python-versions = ">=3.7"
 files = [
     {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
     {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
-]
-
-[[package]]
-name = "pathspec"
-version = "0.11.2"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
-    {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
 ]
 
 [[package]]
@@ -851,4 +788,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2"
-content-hash = "ea68dd724439bda614a8becbe341c45269af4f96cd387953d17a3b922a19d6de"
+content-hash = "46271a0ae55a7a3e38caf7d986b6d2dc7132f9546e35adf480a337fdcfcded98"

--- a/poetry.lock
+++ b/poetry.lock
@@ -788,4 +788,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2"
-content-hash = "46271a0ae55a7a3e38caf7d986b6d2dc7132f9546e35adf480a337fdcfcded98"
+content-hash = "398c15b845f1da197ed4b41f9b13e83caaf7a69356a8c8f01c50d60f6558a5cf"

--- a/poetry.lock
+++ b/poetry.lock
@@ -851,4 +851,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2"
-content-hash = "a7eca5f3a2ec318d15dbfc42b62da93d00a9012d493e1d06335fd25884454b32"
+content-hash = "ea68dd724439bda614a8becbe341c45269af4f96cd387953d17a3b922a19d6de"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ types-setuptools = "^65.6.0.2"
 optional = true
 
 [tool.poetry.group.format.dependencies]
-black = {version = "^22", extras = ["colorama"]}
 isort = [
     # isort 5.12.0 drops support for Python v3.7:
     {version = "^5.10", extras = ["colors"], python = ">=3.8"},
@@ -100,7 +99,6 @@ optional = true
 # something to the above groups (i.e. something that targets a specific purpose
 # (e.g. a CI action), consider whether it's also useful to have this available
 # in a developers environment
-black = {version = "^22", extras = ["colorama"]}
 codespell = "^2.2.4"
 hypothesis = "^6.68.2"
 mypy = "^1.0.1"
@@ -108,9 +106,6 @@ nox = "^2022.11.21"
 pytest = "^7.1.0"
 ruff = ">=0.3"
 types-setuptools = "^65.6.0.2"
-
-[tool.black]
-target-version = ["py37"]
 
 [tool.isort]
 profile = "black"
@@ -243,7 +238,6 @@ build-backend = "poetry.core.masonry.api"
 code = ["fawltydeps"]
 deps = ["pyproject.toml"]
 ignore_unused = [
-    "black",
     "codespell",
     "hypothesis",
     "mypy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ isort = [
     {version = ">=5.10,<5.12.0", extras = ["colors"], python = "<3.8"},
 ]
 codespell = "^2.2.4"
+ruff = ">=0.3"
 
 [tool.poetry.group.dev]
 optional = true
@@ -180,10 +181,8 @@ ignore = [
     "UP006",  # Use `list` instead of `List` for type annotation
     "UP007",  # Use `X | Y` for type annotations
 
-    # Ruff recommends avoiding these checks when using `ruff format`. Since
-    # `ruff format` is a drop-in replacement for `black`, we avoid the same
-    # checks here (https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
-    # has more details):
+    # Ruff recommends avoiding these checks when using `ruff format`.
+    # Details: https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "W191",  # tab-indentation
     "E111",  # indentation-with-invalid-multiple
     "E114",  # indentation-with-invalid-multiple-comment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,6 @@ types-setuptools = "^65.6.0.2"
 optional = true
 
 [tool.poetry.group.format.dependencies]
-isort = [
-    # isort 5.12.0 drops support for Python v3.7:
-    {version = "^5.10", extras = ["colors"], python = ">=3.8"},
-    {version = ">=5.10,<5.12.0", extras = ["colors"], python = "<3.8"},
-]
 codespell = "^2.2.4"
 ruff = ">=0.3"
 
@@ -106,9 +101,6 @@ nox = "^2022.11.21"
 pytest = "^7.1.0"
 ruff = ">=0.3"
 types-setuptools = "^65.6.0.2"
-
-[tool.isort]
-profile = "black"
 
 [tool.mypy]
 files = ['*.py', 'fawltydeps/*.py', 'tests/*.py']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,9 +145,6 @@ addopts = "-m 'not integration'"
 cache_dir = "~/.cache/pytest"
 
 [tool.ruff]
-# Black uses line-length = 88, but allows exceptions when breaking the line
-# would lead to other rule violations. Use 100 as a maximum hard limit:
-line-length = 100
 target-version = "py37"
 extend-include = ["*.ipynb"]
 extend-exclude = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for tests."""
+
 import venv
 from pathlib import Path
 from tempfile import mkdtemp
@@ -171,23 +172,19 @@ def fake_project(write_tmp_files, fake_venv):  # noqa: C901
 
     def format_setup_cfg(deps: Deps, no_extras: ExtraDeps) -> str:
         assert not no_extras  # not supported
-        return (
-            dedent(
-                """\
+        return dedent(
+            """\
                 [metadata]
                 name = "MyLib"
 
                 [options]
                 install_requires =
                 """
-            )
-            + "\n".join(f"    {d}" for d in deps)
-        )
+        ) + "\n".join(f"    {d}" for d in deps)
 
     def format_pyproject_toml(deps: Deps, extras: ExtraDeps) -> str:
-        return (
-            dedent(
-                f"""\
+        return dedent(
+            f"""\
                 [project]
                 name = "MyLib"
 
@@ -195,9 +192,7 @@ def fake_project(write_tmp_files, fake_venv):  # noqa: C901
 
                 [project.optional-dependencies]
                 """
-            )
-            + "\n".join(f"{k} = {v!r}" for k, v in extras.items())
-        )
+        ) + "\n".join(f"{k} = {v!r}" for k, v in extras.items())
 
     def format_deps(
         filename: str, all_deps: Union[Deps, Tuple[Deps, ExtraDeps]]

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -1,4 +1,5 @@
 """Common helpers shared between test_real_project and test_sample_projects."""
+
 from __future__ import annotations
 
 import hashlib
@@ -370,7 +371,8 @@ class BaseProject(ABC):
 
     @staticmethod
     def _init_args_from_toml(
-        toml_data: TomlData, ExperimentClass: Type[BaseExperiment]  # noqa: N803
+        toml_data: TomlData,
+        ExperimentClass: Type[BaseExperiment],  # noqa: N803
     ) -> Dict[str, Any]:
         """Extract members from TOML into kwargs for a subclass constructor."""
         # We ultimately _trust_ the .toml files read here, so we can skip all

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,4 +1,5 @@
 """Verify behavior of the Analysis class."""
+
 # ruff: noqa: PLR2004,SLF001
 from fawltydeps.main import calculated_once
 

--- a/tests/test_cmdline_options.py
+++ b/tests/test_cmdline_options.py
@@ -14,6 +14,7 @@ Strategy setup consists of three phases:
 The strategy construction can be viewed as a reference
 to how the CLI options are expected to be used.
 """
+
 import io
 import os
 import string

--- a/tests/test_compare_imports_to_dependencies.py
+++ b/tests/test_compare_imports_to_dependencies.py
@@ -1,4 +1,5 @@
 """Test the imports to dependencies comparison function."""
+
 import logging
 
 import pytest

--- a/tests/test_dir_traversal.py
+++ b/tests/test_dir_traversal.py
@@ -1,4 +1,5 @@
 """Test core functionality of DirectoryTraversal class."""
+
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -1039,7 +1040,8 @@ def test_DirectoryTraversal_w_abs_paths(vector: DirectoryTraversalVector, tmp_pa
     "vector", [pytest.param(v, id=v.id) for v in directory_traversal_vectors]
 )
 def test_DirectoryTraversal_w_rel_paths(
-    vector: DirectoryTraversalVector, inside_tmp_path  # noqa: ARG001
+    vector: DirectoryTraversalVector,
+    inside_tmp_path,  # noqa: ARG001
 ):
     traversal = vector.setup(Path())  # Traverse relatively from inside tmp_path
     vector.verify_traversal(traversal, Path())

--- a/tests/test_extract_declared_dependencies_pyproject_toml.py
+++ b/tests/test_extract_declared_dependencies_pyproject_toml.py
@@ -1,4 +1,5 @@
 """Test extracting dependencies from pyproject.toml."""
+
 import logging
 from dataclasses import dataclass, field
 from typing import List

--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -1,4 +1,5 @@
 """Test that dependencies are parsed from requirements files."""
+
 from textwrap import dedent
 
 import pytest

--- a/tests/test_extract_imports_simple.py
+++ b/tests/test_extract_imports_simple.py
@@ -1,4 +1,5 @@
 """Test that we can extract simple imports from Python code."""
+
 import json
 import logging
 from io import BytesIO

--- a/tests/test_install_deps.py
+++ b/tests/test_install_deps.py
@@ -1,4 +1,5 @@
 """Verify behavior of TemporaryPipInstallResolver."""
+
 import logging
 
 import pytest
@@ -26,7 +27,8 @@ def test_resolve_dependencies_install_deps__via_local_cache(local_pypi):  # noqa
 
 
 def test_resolve_dependencies_install_deps__raises_unresolved_error_on_pip_install_failure(
-    caplog, local_pypi  # noqa: ARG001
+    caplog,
+    local_pypi,  # noqa: ARG001
 ):
     # This tests the case where TemporaryPipInstallResolver encounters the
     # inevitable pip install error and returns to resolve_dependencies()
@@ -42,7 +44,8 @@ def test_resolve_dependencies_install_deps__raises_unresolved_error_on_pip_insta
 
 
 def test_resolve_dependencies_install_deps__unresolved_error_only_warns_failing_packages(
-    caplog, local_pypi  # noqa: ARG001
+    caplog,
+    local_pypi,  # noqa: ARG001
 ):
     # When we fail to install _some_ - but not all - packages, the error message
     # should only mention the packages that we failed to install.
@@ -58,7 +61,8 @@ def test_resolve_dependencies_install_deps__unresolved_error_only_warns_failing_
 
 
 def test_resolve_dependencies_install_deps_on_mixed_packages__raises_unresolved_error(
-    caplog, local_pypi  # noqa: ARG001
+    caplog,
+    local_pypi,  # noqa: ARG001
 ):
     caplog.set_level(logging.DEBUG)
     deps = {"click", "does_not_exist", "leftpadx"}

--- a/tests/test_local_env.py
+++ b/tests/test_local_env.py
@@ -1,4 +1,5 @@
 """Verify behavior of package module looking at a given Python environment."""
+
 import sys
 import venv
 from pathlib import Path

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -5,6 +5,7 @@ We download/extract pinned releases several 3rd-party Python projects, and run
 FawltyDeps on them, with hardcoded expectations per project on what FawltyDeps
 should find/report.
 """
+
 from __future__ import annotations
 
 import json

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -19,6 +19,7 @@ tests/sample_projects
     ├── expected.toml (mandatory)
     └── ... (regular Python project)
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,5 @@
 """Test how settings cascade/combine across command-line, config file, etc."""
+
 import argparse
 import logging
 import random
@@ -211,7 +212,7 @@ def multivalued_optargs_grid() -> Iterable[List[str]]:
     T = TypeVar("T")
 
     def subsequence_pairs(
-        xs: Tuple[T, ...]
+        xs: Tuple[T, ...],
     ) -> Iterable[Tuple[Tuple[T, ...], Tuple[T, ...]]]:
         assert len(xs) >= 2  # noqa: PLR2004
         for i in range(1, len(xs)):

--- a/tests/test_traverse_project.py
+++ b/tests/test_traverse_project.py
@@ -1,4 +1,5 @@
 """Test that we can traverse a project to find our inputs."""
+
 import dataclasses
 import logging
 import os


### PR DESCRIPTION
Ruff comes with a built-in formatter (`ruff format`) which serves as a drop-in replacement for `black`. The difference in the formatting are minuscule, and can be seen in the second commit in this PR.

Also remove `isort` as a formatting dependency, since `ruff check` already performs the same checks.

Commits:
- Use ruff's default `line-length`
- Formatting changes introduced by `ruff format .`
- `noxfile.py`: Run `ruff format` instead of `black`
- Remove `black` as a dependency
- Remove `isort` as a formatting dependency
- Update docs to mention `ruff` instead of `black` + `isort`
