### PR TITLE
Use uv instead of pip to manage virtualenvs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,6 +31,7 @@ jobs:
           path: |
             ~/.cache/pypoetry/virtualenvs
             ~/.cache/pytest
+            ~/.cache/uv
           key: ${{ runner.os }}-poetry-tests-${{ hashFiles('poetry.lock') }}
       - name: Install project
         run: poetry install --no-interaction --sync --with=nox,test

--- a/README.md
+++ b/README.md
@@ -232,14 +232,13 @@ fallback strategy.
 
 #### Mapping by temporarily installing packages
 
-Your local Python environements might not always have all your project's
+Your local Python environments might not always have all your project's
 dependencies installed. Assuming that you don’t want to go through the
 bother of installing packages manually, and you also don't want to rely on
 the inaccurate identity mapping as your fallback strategy, you can use the
-`--install-deps` option. This will `pip install`
-missing dependencies (from [PyPI](https://pypi.org/), by default) into a
-_temporary virtualenv_, and allow FawltyDeps to use this to come up with the
-correct mapping.
+`--install-deps` option. This will automatically install missing dependencies
+(from [PyPI](https://pypi.org/), by default) into a _temporary virtualenv_,
+and allow FawltyDeps to use this to come up with the correct mapping.
 
 Since this is a potentially expensive strategy (e.g. downloading packages from
 PyPI), we have chosen to hide it behind the `--install-deps` command-line
@@ -247,8 +246,14 @@ option. If you want to always enable this option, you can set the corresponding
 `install_deps` configuration variable to `true` in the `[tool.fawltydeps]`
 section of your `pyproject.toml`.
 
-To customize how this auto-installation happens (e.g. use a different package index),
-you can use [pip’s environment variables](https://pip.pypa.io/en/stable/topics/configuration/).
+FawltyDeps will use [`uv`](https://github.com/astral-sh/uv) by default to
+temporarily install missing dependencies. If `uv` not available, `pip` will be
+used instead.
+
+To further customize how this automatic installation is done (e.g. if you need
+to use a different package index), you can use environment variables to alter
+[`uv`'s](https://github.com/astral-sh/uv?tab=readme-ov-file#environment-variables)
+or [`pip`’s ](https://pip.pypa.io/en/stable/topics/configuration/) behavior.
 
 Note that we’re never guaranteed to be able to resolve _all_ dependencies with
 this method: For example, there could be a typo in your `requirements.txt` that

--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ section of your `pyproject.toml`.
 
 FawltyDeps will use [`uv`](https://github.com/astral-sh/uv) by default to
 temporarily install missing dependencies. If `uv` not available, `pip` will be
-used instead.
+used instead. If you want to ensure that the faster `uv` is available, you can
+install `fawltydeps` with the `uv` extra (e.g. `pip install fawltydeps[uv]`).
 
 To further customize how this automatic installation is done (e.g. if you need
 to use a different package index), you can use environment variables to alter

--- a/README.md
+++ b/README.md
@@ -439,8 +439,8 @@ Here is a complete list of configuration directives we support:
   `"setup.cfg"`, `"pyproject.toml"`, or leave it unset (i.e. the default) for
   auto-detection (based on filename).
 - `install-deps`: Automatically install Python dependencies gathered with
-  FawltyDeps into a temporary virtual environment. This will use `pip install`,
-  which downloads packages from PyPI by default.
+  FawltyDeps into a temporary virtual environment. This will use `uv` or `pip`
+  to download and install packages from PyPI by default.
 - `exclude`: File/directory patterns to exclude/ignore when looking for code
   (imports), dependency declarations and/or Python environments. Defaults to
   `exclude = [".*"]`, meaning that hidden/dot paths are excluded from traversal.

--- a/docs/DesignDoc.md
+++ b/docs/DesignDoc.md
@@ -187,11 +187,11 @@ Requirements files may have non-standard names so to extract dependencies Fawlty
 
 Some Python packages require other packages to be installed first (like `numpy` for `pandas`). We call them transitive dependencies. When a transitive dependency `A` is imported explicitly in the code, it becomes a direct dependency. Even though the code would work without explicitly declaring `A`, it is a better practice to do so.
 
-To determine the list of transitive dependencies of a library `myLibrary`, the pip command:
+To determine the list of transitive dependencies of a library `myLibrary`, one of these commands may be used:
 
     pip show myLibrary
-
-may be used or the `poetry show` command.
+    uv pip show myLibrary
+    poetry show
 
 Since a transitive dependency does not need to be explicitly declared, declaring transitive dependencies that are not also direct dependencies in requirements is not a common practice. Checking for these dependencies is therefore not supported by FawltyDeps.
 

--- a/fawltydeps/cli_parser.py
+++ b/fawltydeps/cli_parser.py
@@ -208,7 +208,7 @@ def populate_parser_paths_options(parser: argparse._ActionsContainer) -> None:
         dest="install_deps",
         action="store_true",
         help=(
-            "Allow FawltyDeps to `pip install` declared dependencies into a"
+            "Allow FawltyDeps to auto-install declared dependencies into a"
             " separate temporary virtualenv to discover the imports they expose."
         ),
     )

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -397,14 +397,14 @@ def pyenv_sources(*pyenv_paths: Path) -> Set[PyEnvSource]:
     return ret
 
 
-class TemporaryPipInstallResolver(BasePackageResolver):
+class TemporaryAutoInstallResolver(BasePackageResolver):
     """Resolve packages by installing them in to a temporary venv.
 
     This provides a resolver for packages that are not installed in an existing
-    local environment. This is done by creating a temporary venv, and then
-    `pip install`ing the packages into this venv, and then resolving the
-    packages in this venv. The venv is automatically deleted before as soon as
-    the packages have been resolved.
+    local environment. This is done by creating a temporary venv, installing
+    the packages into this venv, and then resolving the packages in this venv.
+    The venv is automatically deleted before as soon as the packages have been
+    resolved.
     """
 
     # This is only used in tests by `test_resolver`
@@ -466,8 +466,8 @@ class TemporaryPipInstallResolver(BasePackageResolver):
         """Create a temporary venv and install the given requirements into it.
 
         Provide a path to the temporary venv into the caller's context in which
-        the given requirements have been `pip install`ed. Automatically remove
-        the venv at the end of the context.
+        the given requirements have been installed. Automatically remove the
+        venv at the end of the context.
 
         Installation is done on a "best effort" basis as documented by
         .installed_requirements() above. The caller is expected to handle any
@@ -478,12 +478,11 @@ class TemporaryPipInstallResolver(BasePackageResolver):
                 yield venv_dir
 
     def lookup_packages(self, package_names: Set[str]) -> Dict[str, Package]:
-        """Convert package names into Package objects via temporary pip install.
+        """Convert package names into Package objects via temporary auto-install.
 
-        Use the temp_installed_requirements() above to `pip install` the given
-        package names into a temporary venv, and then use LocalPackageResolver
-        on this venv to provide the Package objects that correspond to the
-        package names.
+        Use the temp_installed_requirements() above to install the given package
+        names into a temporary venv, then use LocalPackageResolver on this venv
+        to provide the Package objects that correspond to the package names.
         """
         if self.cached_venv is None:
             installed = self.temp_installed_requirements
@@ -499,7 +498,7 @@ class TemporaryPipInstallResolver(BasePackageResolver):
                 name: replace(
                     package,
                     resolved_with=self.__class__,
-                    debug_info="Provided by temporary `pip install`",
+                    debug_info="Provided by temporary auto-install",
                 )
                 for name, package in resolver.lookup_packages(package_names).items()
             }
@@ -550,7 +549,7 @@ def setup_resolvers(
         yield SysPathPackageResolver()
 
     if install_deps:
-        yield TemporaryPipInstallResolver()
+        yield TemporaryAutoInstallResolver()
     else:
         yield IdentityMapping()
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,11 +1,16 @@
 import hashlib
 import os
+import shutil
 from pathlib import Path
 from typing import Iterable
 
 import nox
 
 python_versions = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+
+# Use 'uv' to manager Nox' virtualenvs, if available
+if shutil.which("uv"):
+    nox.options.default_venv_backend = "uv"
 
 
 def patch_binaries_if_needed(session: nox.Session, venv_dir: str) -> None:
@@ -76,11 +81,12 @@ def install_groups(
         hashfile.write_text(digest)
 
     session.install("-r", str(requirements_txt))
-    if include_self:
-        session.install("-e", ".")
 
     if not session.virtualenv._reused:  # noqa: SLF001
         patch_binaries_if_needed(session, session.virtualenv.location)
+
+    if include_self:
+        session.install("-e", ".")
 
 
 @nox.session(python=python_versions)

--- a/poetry.lock
+++ b/poetry.lock
@@ -308,25 +308,26 @@ files = [
 
 [[package]]
 name = "nox"
-version = "2022.11.21"
+version = "2024.4.15"
 description = "Flexible test automation."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "nox-2022.11.21-py3-none-any.whl", hash = "sha256:0e41a990e290e274cb205a976c4c97ee3c5234441a8132c8c3fd9ea3c22149eb"},
-    {file = "nox-2022.11.21.tar.gz", hash = "sha256:e21c31de0711d1274ca585a2c5fde36b1aa962005ba8e9322bf5eeed16dcd684"},
+    {file = "nox-2024.4.15-py3-none-any.whl", hash = "sha256:6492236efa15a460ecb98e7b67562a28b70da006ab0be164e8821177577c0565"},
+    {file = "nox-2024.4.15.tar.gz", hash = "sha256:ecf6700199cdfa9e5ea0a41ff5e6ef4641d09508eda6edb89d9987864115817f"},
 ]
 
 [package.dependencies]
-argcomplete = ">=1.9.4,<3.0"
+argcomplete = ">=1.9.4,<4.0"
 colorlog = ">=2.6.1,<7.0.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 packaging = ">=20.9"
-typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
-virtualenv = ">=14"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+uv = {version = ">=0.1.6", optional = true, markers = "extra == \"uv\""}
+virtualenv = ">=20.14.1"
 
 [package.extras]
 tox-to-nox = ["jinja2", "tox"]
+uv = ["uv (>=0.1.6)"]
 
 [[package]]
 name = "packaging"
@@ -368,9 +369,6 @@ files = [
     {file = "platformdirs-4.0.0-py3-none-any.whl", hash = "sha256:118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b"},
     {file = "platformdirs-4.0.0.tar.gz", hash = "sha256:cb633b2bcf10c51af60beb0ab06d2f1d69064b43abf4c185ca6b28865f3f9731"},
 ]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.7.1", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
@@ -735,6 +733,32 @@ files = [
 ]
 
 [[package]]
+name = "uv"
+version = "0.1.32"
+description = "An extremely fast Python package installer and resolver, written in Rust."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "uv-0.1.32-py3-none-linux_armv6l.whl", hash = "sha256:ac453ebbc52da083501a56e0378a71be637920c4cbf60b6dca64292464a00c23"},
+    {file = "uv-0.1.32-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f61de511a3296aa9519ac9cc1d30987aea00a94cd964c8227088a14f0b3f3ab3"},
+    {file = "uv-0.1.32-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:11f1df69d5adad54871e12ed7d7c9250deda9da4800b3dadfa84a65625e945f5"},
+    {file = "uv-0.1.32-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ca49cc73bf61eaf88d005bc16193a2f211a736f26c7612fa158a9a44c4efc"},
+    {file = "uv-0.1.32-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:907ff64b74da60e2280b4536f7ae64539219254286c81b857f709ab2e91487ff"},
+    {file = "uv-0.1.32-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:faf8bba1feb328b93376c2ff26a436a4a41ac45e12c3e46a850edb289e7653fd"},
+    {file = "uv-0.1.32-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed6a41164aac4538a5bbb850ab52a6c2a679e9aa642f32f001799fd5a3ccf00c"},
+    {file = "uv-0.1.32-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dac71a5abac7c45914acbdc5760be1c7c14c8ce4da7447dfa4f661a57d3d0afe"},
+    {file = "uv-0.1.32-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7547b19596bec70a041d4c74af1cdd5c3f426c9dd0edb5b6c98a159cc65f43f"},
+    {file = "uv-0.1.32-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2d1c85698040efe36b2ddf8b9072c8f01c14a9fa164b5d0a2e6b0dbb11443439"},
+    {file = "uv-0.1.32-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0db70283655a2bee8129562b0d0c33979a9ea0586572402a226ffae370e24d20"},
+    {file = "uv-0.1.32-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:47ff7ab9cdadf01033663b74d65a57648f41b81d07f047370b7eefff934680ec"},
+    {file = "uv-0.1.32-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5af112155bbd9b0abe7748d6b31186c3c0c8cf7931dc99762cc45ad9f44732f7"},
+    {file = "uv-0.1.32-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c3b9bb6194e3e2ea41174fc49d66d09eeb5566a5b3c6a6476f30ea2342e547f5"},
+    {file = "uv-0.1.32-py3-none-win32.whl", hash = "sha256:e10e3a44c73934a78eaac199952585aed1f8b0c742b8b034570b3816cb9071af"},
+    {file = "uv-0.1.32-py3-none-win_amd64.whl", hash = "sha256:9365a51e1dd711b8cab661a481b1222dba721497b8a7604bb1fe8e63db900476"},
+    {file = "uv-0.1.32.tar.gz", hash = "sha256:339a275711f2c1faab155f47c2e06e272292401ab054ede37d92ef7ebbffad9b"},
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.25.0"
 description = "Virtual Python Environment builder"
@@ -748,7 +772,6 @@ files = [
 [package.dependencies]
 distlib = ">=0.3.7,<1"
 filelock = ">=3.12.2,<4"
-importlib-metadata = {version = ">=6.6", markers = "python_version < \"3.8\""}
 platformdirs = ">=3.9.1,<5"
 
 [package.extras]
@@ -788,4 +811,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2"
-content-hash = "398c15b845f1da197ed4b41f9b13e83caaf7a69356a8c8f01c50d60f6558a5cf"
+content-hash = "c4a21bc30b8cc6eff9fc63c61ecbee3c21e2407bee0a5df439c63edc546c8b85"

--- a/poetry.lock
+++ b/poetry.lock
@@ -734,28 +734,29 @@ files = [
 
 [[package]]
 name = "uv"
-version = "0.1.32"
+version = "0.2.11"
 description = "An extremely fast Python package installer and resolver, written in Rust."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "uv-0.1.32-py3-none-linux_armv6l.whl", hash = "sha256:ac453ebbc52da083501a56e0378a71be637920c4cbf60b6dca64292464a00c23"},
-    {file = "uv-0.1.32-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f61de511a3296aa9519ac9cc1d30987aea00a94cd964c8227088a14f0b3f3ab3"},
-    {file = "uv-0.1.32-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:11f1df69d5adad54871e12ed7d7c9250deda9da4800b3dadfa84a65625e945f5"},
-    {file = "uv-0.1.32-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ca49cc73bf61eaf88d005bc16193a2f211a736f26c7612fa158a9a44c4efc"},
-    {file = "uv-0.1.32-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:907ff64b74da60e2280b4536f7ae64539219254286c81b857f709ab2e91487ff"},
-    {file = "uv-0.1.32-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:faf8bba1feb328b93376c2ff26a436a4a41ac45e12c3e46a850edb289e7653fd"},
-    {file = "uv-0.1.32-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed6a41164aac4538a5bbb850ab52a6c2a679e9aa642f32f001799fd5a3ccf00c"},
-    {file = "uv-0.1.32-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dac71a5abac7c45914acbdc5760be1c7c14c8ce4da7447dfa4f661a57d3d0afe"},
-    {file = "uv-0.1.32-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7547b19596bec70a041d4c74af1cdd5c3f426c9dd0edb5b6c98a159cc65f43f"},
-    {file = "uv-0.1.32-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2d1c85698040efe36b2ddf8b9072c8f01c14a9fa164b5d0a2e6b0dbb11443439"},
-    {file = "uv-0.1.32-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0db70283655a2bee8129562b0d0c33979a9ea0586572402a226ffae370e24d20"},
-    {file = "uv-0.1.32-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:47ff7ab9cdadf01033663b74d65a57648f41b81d07f047370b7eefff934680ec"},
-    {file = "uv-0.1.32-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5af112155bbd9b0abe7748d6b31186c3c0c8cf7931dc99762cc45ad9f44732f7"},
-    {file = "uv-0.1.32-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c3b9bb6194e3e2ea41174fc49d66d09eeb5566a5b3c6a6476f30ea2342e547f5"},
-    {file = "uv-0.1.32-py3-none-win32.whl", hash = "sha256:e10e3a44c73934a78eaac199952585aed1f8b0c742b8b034570b3816cb9071af"},
-    {file = "uv-0.1.32-py3-none-win_amd64.whl", hash = "sha256:9365a51e1dd711b8cab661a481b1222dba721497b8a7604bb1fe8e63db900476"},
-    {file = "uv-0.1.32.tar.gz", hash = "sha256:339a275711f2c1faab155f47c2e06e272292401ab054ede37d92ef7ebbffad9b"},
+    {file = "uv-0.2.11-py3-none-linux_armv6l.whl", hash = "sha256:7a4e8beb576a9d4245d763f2ae2eca709cf0c1a2a706c583c28f467cc99ec7d2"},
+    {file = "uv-0.2.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6e3ff93020c28c4d518c1c77bfe0bb46de5949adff389df27ec117eaa4c9b279"},
+    {file = "uv-0.2.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:96d3e2dd7f8a1774a0c0070732cb7d670b23043d4860de4658ff7f597ede93f0"},
+    {file = "uv-0.2.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:33e1129b673054d17d014535bf868bb22051e9437963200a3eea7ddf8aaac6e0"},
+    {file = "uv-0.2.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81687b0272f472dcd84de16da25cea21e8b697fed8603ecb62c8cdac0a842d15"},
+    {file = "uv-0.2.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:17f429eaf2141d18be22b1dc751d95326b76aebf4b51b589ed4d2fd589792098"},
+    {file = "uv-0.2.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:a2708392c38eee38f2e69384d1f37db0451d89db78d5d98ed89b00e5653a4812"},
+    {file = "uv-0.2.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bae25daae60f3d59dd82197b8d87cb081bde985c91d5ba2b3bbdecd3ba9b557"},
+    {file = "uv-0.2.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3c3dfee56d0ca79e65dfb33522509d987bffa267fe31b7a48874652ff979c1fa"},
+    {file = "uv-0.2.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20061c5795811eba07a1470f04dcc543255196c7e872e91ffc4b638dacd8cd0e"},
+    {file = "uv-0.2.11-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:f66c5b627348f04bd9773c66dc54a007d42df115a07ccb84678bdb4e3b85836d"},
+    {file = "uv-0.2.11-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:e7f24e40e24ddb66cf2b8bc4dd0a36ee7f727bf63b8c8f26fc5038cf931f98a2"},
+    {file = "uv-0.2.11-py3-none-musllinux_1_1_i686.whl", hash = "sha256:8c3b267f2db93170c537efe9521820fef1c542ecf890c863f01ccbbf2ccef22e"},
+    {file = "uv-0.2.11-py3-none-musllinux_1_1_ppc64le.whl", hash = "sha256:9da79f8eaebf56d71ad56887510a1a6875d67ec209e1ccceeb9732b8b27e0f5d"},
+    {file = "uv-0.2.11-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:8545cd5c3fd27fcb3bed1df4bae95ea33fe07460700091070973b3f1225fd8e7"},
+    {file = "uv-0.2.11-py3-none-win32.whl", hash = "sha256:8f00713a3ef6ce46687521ab512bf78b391cf7247ac8500f217a6168cbb9c099"},
+    {file = "uv-0.2.11-py3-none-win_amd64.whl", hash = "sha256:edeb6314c9e4061917918016fc84b0cabdcc24a1b4e7d04032dbfb86d41f834e"},
+    {file = "uv-0.2.11.tar.gz", hash = "sha256:1ff5742a8daf427bcca99089287871c1b90e8087d8e66182f409a8a39df6eb2d"},
 ]
 
 [[package]]
@@ -808,7 +809,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[extras]
+uv = ["uv"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2"
-content-hash = "c4a21bc30b8cc6eff9fc63c61ecbee3c21e2407bee0a5df439c63edc546c8b85"
+content-hash = "d39104ec7106d12f51f69b015c10af7fab4fb558c1836a8a672f8661f0329cc2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,10 @@ setuptools = [
 optional = true
 
 [tool.poetry.group.nox.dependencies]
-nox = "^2022.11.21"
+nox = [
+    {version="^2024.03.02", python = "<3.8"},
+    {version="^2024.03.02", extras=["uv"], python = ">=3.8"},
+]
 
 [tool.poetry.group.test]
 optional = true
@@ -74,7 +77,7 @@ optional = true
 [tool.poetry.group.lint.dependencies]
 hypothesis = "^6.68.2"
 mypy = "^1.0.1"
-nox = "^2022.11.21"
+nox = "^2024.03.02"
 pytest = "^7.1.0"
 ruff = ">=0.3"
 types-setuptools = "^65.6.0.2"
@@ -97,7 +100,10 @@ optional = true
 codespell = "^2.2.4"
 hypothesis = "^6.68.2"
 mypy = "^1.0.1"
-nox = "^2022.11.21"
+nox = [
+    {version="^2024.03.02", python = "<3.8"},
+    {version="^2024.03.02", extras=["uv"], python = ">=3.8"},
+]
 pytest = "^7.1.0"
 ruff = ">=0.3"
 types-setuptools = "^65.6.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,12 @@ setuptools = [
     {version = ">=68.0.0,<68.1.0", python = "<3.8"},
 ]
 
+# Optional dependencies, covered by .extras below:
+uv = {version = ">=0.1.6", python = ">=3.8", optional = true}
+
+[tool.poetry.extras]
+uv = ["uv"]
+
 [tool.poetry.group.nox]
 optional = true
 
@@ -242,4 +248,5 @@ ignore_unused = [
     "nox",
     "pytest",
     "ruff",
+    "uv",
 ]

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -175,7 +175,7 @@ class CachedExperimentVenv:
     ~/.cache/pytest/d/...
     """
 
-    requirements: List[str]  # PEP 508 requirements, passed to 'pip install'
+    requirements: List[str]  # PEP 508 requirements, passed to (uv) pip install
 
     @staticmethod
     def _venv_python(venv_path: Path) -> Path:

--- a/tests/real_projects/python-algorithms.toml
+++ b/tests/real_projects/python-algorithms.toml
@@ -106,65 +106,13 @@ unused_deps = [
     "yulewalker",
 ]
 
-[experiments.all_reqs_installed]
-description = """
-    Running FD on the TheAlgorithms/Python project, with all requirements
-    installed. This improves the situation somewhat, compared to the above, but
-    there are still several problems: qiskit and tensorflow (only on Windows and
-    ARM-based MacOS in some versions) are "placeholder packages" that rely on
-    transitive dependencies to provide their expected import names.
-    Additionally, there appears to be several true undeclared unused deps.
-"""
-compatibility = "LINUX"
-args = []
-requirements = [
-    "beautifulsoup4",
-    "fake_useragent",
-    "keras",
-    "lxml",
-    "matplotlib",
-    "numpy",
-    "opencv-python",
-    "pandas",
-    "pillow",
-    "projectq",
-    "qiskit<1",
-    "requests",
-    "rich",
-    "scikit-fuzzy",
-    "scikit-learn",
-    "statsmodels",
-    "sympy",
-    "tensorflow; python_version < '3.11'",
-    "texttable",
-    "tweepy",
-    "xgboost",
-    "yulewalker",
-]
-# When we run FawltyDeps with the above arguments, we expect these results:
-undeclared_deps = [
-    "django",
-    "mpmath",
-    "pytest",
-    "qiskit",
-    "scipy",
-    "seaborn",
-]
-
-unused_deps = [
-    "keras",
-    "projectq",
-    "qiskit",
-    "texttable",
-    "yulewalker",
-]
-
 [experiments.some_reqs_customized]
 description = """
     Running FD on the TheAlgorithms/Python project, with some requirements
     resolved via custom_mapping, and all other requirements installed.
     This solved the "placeholder package" problem for qiskit and tensorflow
-    by side-stepping it with a custom_mapping.
+    and the failing `uv pip install` for projectq, by side-stepping it with a
+    custom_mapping.
 """
 # TheAlgorithms/Python depends on a couple of "placeholder" packages:
 # - The qiskit package does not provide the "qiskit" import name, but depends
@@ -194,7 +142,6 @@ requirements = [
     "opencv-python",
     "pandas",
     "pillow",
-    "projectq",
     "requests",
     "rich",
     "scikit-fuzzy",
@@ -225,3 +172,4 @@ unused_deps = [
 [tool.fawltydeps.custom_mapping]
 qiskit = ["qiskit"]
 tensorflow = ["tensorflow"]
+projectq = ["projectq"]

--- a/tests/test_install_deps.py
+++ b/tests/test_install_deps.py
@@ -26,12 +26,12 @@ def test_resolve_dependencies_install_deps__via_local_cache(local_pypi):  # noqa
     }
 
 
-def test_resolve_dependencies_install_deps__raises_unresolved_error_on_pip_install_failure(
+def test_resolve_dependencies_install_deps__raises_unresolved_error_on_install_failure(
     caplog,
     local_pypi,  # noqa: ARG001
 ):
     # This tests the case where TemporaryAutoInstallResolver encounters the
-    # inevitable pip install error and returns to resolve_dependencies()
+    # inevitable (uv) pip install error and returns to resolve_dependencies()
     # with the missing package unresolved.
     # Since either install_deps or IdentityMapping are the final resolvers,
     # this should raise an `UnresolvedDependenciesError`.
@@ -66,7 +66,7 @@ def test_resolve_dependencies_install_deps_on_mixed_packages__raises_unresolved_
 ):
     caplog.set_level(logging.DEBUG)
     deps = {"click", "does_not_exist", "leftpadx"}
-    # Attempting to pip install "does_not_exist"
+    # Attempting to (uv) pip install "does_not_exist"
     # will result in an `UnresolvedDependenciesError`.
     with pytest.raises(UnresolvedDependenciesError):
         resolve_dependencies(deps, setup_resolvers(install_deps=True))

--- a/tests/test_install_deps.py
+++ b/tests/test_install_deps.py
@@ -1,4 +1,4 @@
-"""Verify behavior of TemporaryPipInstallResolver."""
+"""Verify behavior of TemporaryAutoInstallResolver."""
 
 import logging
 
@@ -6,7 +6,7 @@ import pytest
 
 from fawltydeps.packages import (
     Package,
-    TemporaryPipInstallResolver,
+    TemporaryAutoInstallResolver,
     resolve_dependencies,
     setup_resolvers,
 )
@@ -14,15 +14,15 @@ from fawltydeps.types import UnresolvedDependenciesError
 
 
 def test_resolve_dependencies_install_deps__via_local_cache(local_pypi):  # noqa: ARG001
-    debug_info = "Provided by temporary `pip install`"
+    debug_info = "Provided by temporary auto-install"
     actual = resolve_dependencies(
         ["leftpadx", "click"], setup_resolvers(install_deps=True)
     )
     assert actual == {
         "leftpadx": Package(
-            "leftpadx", {"leftpad"}, TemporaryPipInstallResolver, debug_info
+            "leftpadx", {"leftpad"}, TemporaryAutoInstallResolver, debug_info
         ),
-        "click": Package("click", {"click"}, TemporaryPipInstallResolver, debug_info),
+        "click": Package("click", {"click"}, TemporaryAutoInstallResolver, debug_info),
     }
 
 
@@ -30,7 +30,7 @@ def test_resolve_dependencies_install_deps__raises_unresolved_error_on_pip_insta
     caplog,
     local_pypi,  # noqa: ARG001
 ):
-    # This tests the case where TemporaryPipInstallResolver encounters the
+    # This tests the case where TemporaryAutoInstallResolver encounters the
     # inevitable pip install error and returns to resolve_dependencies()
     # with the missing package unresolved.
     # Since either install_deps or IdentityMapping are the final resolvers,
@@ -70,8 +70,8 @@ def test_resolve_dependencies_install_deps_on_mixed_packages__raises_unresolved_
     # will result in an `UnresolvedDependenciesError`.
     with pytest.raises(UnresolvedDependenciesError):
         resolve_dependencies(deps, setup_resolvers(install_deps=True))
-    # Attempted to install deps with TemporaryPipInstall
+    # Attempted to install deps with TemporaryAutoInstallResolver
     assert (
-        f"Trying to resolve {deps!r} with <fawltydeps.packages.TemporaryPipInstallResolver"
+        f"Trying to resolve {deps!r} with <fawltydeps.packages.TemporaryAutoInstallResolver"
         in caplog.text
     )

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -13,7 +13,7 @@ from fawltydeps.packages import (
     IdentityMapping,
     Package,
     SysPathPackageResolver,
-    TemporaryPipInstallResolver,
+    TemporaryAutoInstallResolver,
     UserDefinedMapping,
     resolve_dependencies,
     setup_resolvers,
@@ -101,7 +101,7 @@ def generate_expected_resolved_deps(
     if install_deps:
         ret.update(
             {
-                dep: Package(dep, imports, TemporaryPipInstallResolver)
+                dep: Package(dep, imports, TemporaryAutoInstallResolver)
                 for dep, imports in other_deps.items()
             }
         )
@@ -179,7 +179,7 @@ def test_resolve_dependencies__generates_expected_mappings(
 
     isolate_default_resolver(installed_deps)
 
-    # Tell TemporaryPipInstallResolver to reuse our cached venv, instead of
+    # Tell TemporaryAutoInstallResolver to reuse our cached venv, instead of
     # potentially creating a new venv for every test case.
     cached_venv = Path(
         request.config.cache.mkdir(
@@ -187,7 +187,7 @@ def test_resolve_dependencies__generates_expected_mappings(
         )
     )
     try:
-        TemporaryPipInstallResolver.cached_venv = cached_venv
+        TemporaryAutoInstallResolver.cached_venv = cached_venv
         actual = resolve_dependencies(
             dep_names,
             setup_resolvers(
@@ -200,7 +200,7 @@ def test_resolve_dependencies__generates_expected_mappings(
             ),
         )
     finally:
-        TemporaryPipInstallResolver.cached_venv = None
+        TemporaryAutoInstallResolver.cached_venv = None
 
     end_time = time.time()
     elapsed_time = end_time - start_time

--- a/tests/test_sample_projects.py
+++ b/tests/test_sample_projects.py
@@ -49,7 +49,7 @@ class Experiment(BaseExperiment):
     - pyenvs: Settings.pyenvs paths relative to the sample project root.
               If not given (or None), a cached venv with the requirements from
               BaseExperiment.requirements installed will be used instead.
-    - install_deps: Whether or not to include the TemporaryPipInstall resolver
+    - install_deps: Whether or not to include the TemporaryAutoInstall resolver
                     when resolving dependencies (default: False)
     - exclude: Settings.exclude strings with gitignore patterns. If not given
                (or None), the default [".*"] pattern is used.


### PR DESCRIPTION
`uv` is much faster than `pip` for installing package (it is also faster then `python -m venv` for creating virtualenvs). This PR switches from `venv`/`pip` to `uv` in three separate parts of our project:

1. Instruct Nox to use `uv` instead of `pip` to manage the virtualenv associated with each Nox session (first commit).
2. Use `uv` instead of `venv`/`pip` (when available) to manage virtualenvs for our `sample_project` and `real_projects` tests (next three commits).
3. Use `uv` instead of `venv`/`pip` (when available) to create and populate the temporary virtualenv managed by the `--install-deps` option (next two commits).

The first two points above only concern our tests and has no effect on the FawltyDeps program itself. The last one changes the behavior of the `--install-deps` option to use `uv` when available (otherwise fall back to `venv`/`pip`).

The last commit in this PR adds a small convenience for our users: If they want to ensure that `uv` is available for FawltyDeps to use, they can now install `fawltydeps[uv]`. This `uv` extra will bring in `uv` as a dependency in much the same way that we currently depend on `nox[uv]` in our own developement environment.

Commits:
- Use `uv` instead of `pip` to manage nox virtualenvs
- `tests/project_helpers`: Use `uv` (if available) to prepare virtualenvs
- `.github/workflows/tests.yaml`: Preserve `uv` cache across test runs
- Sidestep issues installing `projectq` with 'uv pip install'
- Prepare to decouple `--install-deps` from `pip`
- `TemporaryAutoInstallResolver`: Use `uv` if available
- `pyproject.toml`: Add `uv` as an "extra" dependency for FawltyDeps
