### PR TITLE
Work around issue in Pydantic v1.10.16

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,11 @@ def install_groups(
     requirements_txt = Path(session.cache_dir, session.name, "reqs_from_poetry.txt")
     hashfile = requirements_txt.with_suffix(".hash")
 
-    if not hashfile.is_file() or hashfile.read_text() != digest:
+    if (
+        not requirements_txt.is_file()
+        or not hashfile.is_file()
+        or hashfile.read_text() != digest
+    ):
         requirements_txt.parent.mkdir(parents=True, exist_ok=True)
         argv = [
             "poetry",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -34,12 +34,14 @@ if sys.version_info >= (3, 11):
 else:
     from tomli import TOMLDecodeError
 
-try:  # import from Pydantic V2
-    from pydantic.v1 import ValidationError
+import pydantic
+
+if pydantic.__version__.startswith("1."):
+    from pydantic import ValidationError
+    from pydantic.env_settings import SettingsError
+else:  # import from Pydantic v2
+    from pydantic.v1 import ValidationError  # type: ignore[assignment]
     from pydantic.v1.env_settings import SettingsError
-except ModuleNotFoundError:
-    from pydantic import ValidationError  # type: ignore[assignment]
-    from pydantic.env_settings import SettingsError  # type: ignore[no-redef]
 
 EXPECT_DEFAULTS = dict(
     actions={Action.REPORT_UNDECLARED, Action.REPORT_UNUSED},


### PR DESCRIPTION
Minor workaround to fix issue #438.

Upstream Pydantic issue: https://github.com/pydantic/pydantic/issues/9656

Commits:
- `test_settings`: Workaround issue in Pydantic v1.10.16
- `noxfile.py`: Rerun `poetry export` if `reqs_from_poetry.txt` is missing
