### PR TITLE
parse_setup_py: Handle string dependency when we expect list of strings

### DIFF
--- a/tests/test_extract_declared_dependencies_success.py
+++ b/tests/test_extract_declared_dependencies_success.py
@@ -302,6 +302,21 @@ def test_parse_requirements_txt(write_tmp_files, file_content, expect_deps):
             ["pandas", "click"],
             id="legacy_encoding__succeeds",
         ),
+        pytest.param(
+            """\
+            from setuptools import setup
+
+            setup(
+                extras_require={
+                    'crt1': 'botocore1>=1.33.2,<2.0a.0',
+                    'crt2': 'botocore2[crt]',
+                    'crt3': ['botocore3'],
+                },
+            )
+            """,
+            ["botocore1", "botocore2", "botocore3"],
+            id="extras_with_varying_types",
+        ),
     ],
 )
 def test_parse_setup_py(write_tmp_files, file_content, expect_deps):


### PR DESCRIPTION
As described in issue #429, the s3transfer package comes with setup.py
where the `extras_require` dictionary does not map to a list of strings
(extra requirements), but instead map to a string directly.

When s3transfer is installed with this extra (e.g. `pip install
s3transfer[crt]`), the setuptools machinery handles this variation
gracefully, i.e. it interprets the string as if it was a single-element
list containing the same string.

An experiment reveals that the same interpretation occurs if a string is
passed directly in the `install_requires` argument.

This commit teaches FawltyDeps to do the same.

Also, if parse_one_req() fails to parse a requirement string, catch that
exception (likely an `InvalidRequirement` or some other subclass of
ValueError), and convert it into a DependencyParsingError, which is
handled more gracefully (i.e. print a warning message and continue).
