### PR TITLE
Replace pkg_resources dependency with packaging.requirement

### DIFF
--- a/fawltydeps/extract_declared_dependencies.py
+++ b/fawltydeps/extract_declared_dependencies.py
@@ -11,8 +11,8 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Callable, Iterable, Iterator, NamedTuple, Optional, Tuple, Union
 
+from packaging.requirements import Requirement
 from pip_requirements_parser import RequirementsFile  # type: ignore[import]
-from pkg_resources import Requirement
 
 from fawltydeps.limited_eval import CannotResolve, VariableTracker
 from fawltydeps.settings import ParserChoice
@@ -46,9 +46,7 @@ class DependencyParsingError(Exception):
 
 def parse_one_req(req_text: str, source: Location) -> DeclaredDependency:
     """Return the name of a dependency declared in a requirement specifier."""
-    req = Requirement.parse(req_text)
-    req_name = req.unsafe_name
-    return DeclaredDependency(req_name, source)
+    return DeclaredDependency(Requirement(req_text).name, source)
 
 
 def parse_requirements_txt(path: Path) -> Iterator[DeclaredDependency]:

--- a/poetry.lock
+++ b/poetry.lock
@@ -593,38 +593,6 @@ files = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "68.0.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
-    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
-name = "setuptools"
-version = "69.0.3"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "setuptools-69.0.3-py3-none-any.whl", hash = "sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05"},
-    {file = "setuptools-69.0.3.tar.gz", hash = "sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -695,31 +663,6 @@ files = [
     {file = "typed_ast-1.5.5-cp39-cp39-win_amd64.whl", hash = "sha256:335f22ccb244da2b5c296e6f96b06ee9bed46526db0de38d2f0e5a6597b81155"},
     {file = "typed_ast-1.5.5.tar.gz", hash = "sha256:94282f7a354f36ef5dbce0ef3467ebf6a258e370ab33d5b40c249fa996e590dd"},
 ]
-
-[[package]]
-name = "types-docutils"
-version = "0.20.0.3"
-description = "Typing stubs for docutils"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-docutils-0.20.0.3.tar.gz", hash = "sha256:4928e790f42b99d5833990f99c8dd9fa9f16825f6ed30380ca981846d36870cd"},
-    {file = "types_docutils-0.20.0.3-py3-none-any.whl", hash = "sha256:a930150d8e01a9170f9bca489f46808ddebccdd8bc1e47c07968a77e49fb9321"},
-]
-
-[[package]]
-name = "types-setuptools"
-version = "65.7.0.4"
-description = "Typing stubs for setuptools"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-setuptools-65.7.0.4.tar.gz", hash = "sha256:147809433301fe7e0f4ef5c0782f9a0453788960575e1efb6da5fe8cb2493c9f"},
-    {file = "types_setuptools-65.7.0.4-py3-none-any.whl", hash = "sha256:522067dfd8e1771f8d7e047e451de2740dc4e0c9f48a22302a6cc96e6c964a13"},
-]
-
-[package.dependencies]
-types-docutils = "*"
 
 [[package]]
 name = "typing-extensions"
@@ -815,4 +758,4 @@ uv = ["uv"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2"
-content-hash = "7c22201236af760664bd507030c3661eca8c0f2c67d2df1f2640db0af8057c0a"
+content-hash = "e5b7bd68f127f8f2cd9ec1cbd5619b98615ef59bfcf938d3a3915f08da5debd2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -331,13 +331,13 @@ uv = ["uv (>=0.1.6)"]
 
 [[package]]
 name = "packaging"
-version = "23.2"
+version = "24.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
-    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
+    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
 ]
 
 [[package]]
@@ -815,4 +815,4 @@ uv = ["uv"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2"
-content-hash = "d39104ec7106d12f51f69b015c10af7fab4fb558c1836a8a672f8661f0329cc2"
+content-hash = "7c22201236af760664bd507030c3661eca8c0f2c67d2df1f2640db0af8057c0a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ isort = [
     {version = "^5.10", python = ">=3.8"},
     {version = ">=5.10,<5.12.0", python = "<3.8"},
 ]
+packaging = ">=24.0"
 pip-requirements-parser = ">=32.0.1"
 pydantic = ">=1.10.4,<3.0.0"
 tomli = {version = "^2.0.1", python = "<3.11"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,6 @@ pip-requirements-parser = ">=32.0.1"
 pydantic = ">=1.10.4,<3.0.0"
 tomli = {version = "^2.0.1", python = "<3.11"}
 typing-extensions = {version = ">=4.4.0", python = "<3.8"}
-setuptools = [
-    # v68.1.0 drops support for Python v3.7:
-    {version = ">=68.0.0", python = ">=3.8"},
-    {version = ">=68.0.0,<68.1.0", python = "<3.8"},
-]
 
 # Optional dependencies, covered by .extras below:
 uv = {version = ">=0.1.6", python = ">=3.8", optional = true}
@@ -87,7 +82,6 @@ mypy = "^1.0.1"
 nox = "^2024.03.02"
 pytest = "^7.1.0"
 ruff = ">=0.3"
-types-setuptools = "^65.6.0.2"
 
 [tool.poetry.group.format]
 optional = true
@@ -113,7 +107,6 @@ nox = [
 ]
 pytest = "^7.1.0"
 ruff = ">=0.3"
-types-setuptools = "^65.6.0.2"
 
 [tool.mypy]
 files = ['*.py', 'fawltydeps/*.py', 'tests/*.py']

--- a/tests/test_real_projects.py
+++ b/tests/test_real_projects.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Iterator, List, Optional
 
 import pytest
-from pkg_resources import Requirement
+from packaging.requirements import Requirement
 
 from fawltydeps.packages import LocalPackageResolver, pyenv_sources
 from fawltydeps.types import TomlData
@@ -44,7 +44,7 @@ REAL_PROJECTS_DIR = Path(__file__).with_name("real_projects")
 
 def verify_requirements(venv_path: Path, requirements: List[str]) -> None:
     deps = {
-        Requirement.parse(req).unsafe_name
+        Requirement(req).name
         for req in requirements
         if "python_version" not in req  # we don't know how to parse these (yet)
     }


### PR DESCRIPTION
Fixes issue #443.

Getting away from our use of `pkg_resources` turns out to be relatively easy:
The `packaging` package from the [Python Packaging Authority](https://github.com/pypa) is probably as close as we can get to an official and authoritative upstream for this kind of logic, and the `packaging.requirements.Requirement` class seems to encapsulate the equivalent logic the `pkg_resources.Requirement` class that we have used for this purpose until now.

At least, our test suite seems to pass with no further adjustments after this change. :-)

Note that this only concerns the parsing of _single_ requirement strings as they occur in `setup.py` and `pyproject.toml` files.
For parsing full `requirements.txt` files we still rely on [pip-requirements-parser](https://github.com/nexB/pip-requirements-parser/tree/main).
The reason for this is two-fold:
- `packaging.requirements` does not include functionality to parse complete files (and we don't want to have to deal with fiddly details like line continuations in `requirements.txt` files ourselves)
- `pip_requirements_parser` does not include a good API for parsing requirements strings that are _not_ part of a full `requirements.txt` file (requires writing a temp file as seen here: https://github.com/nexB/pip-requirements-parser/pull/19/files)

Commits:
- Add `packaging` as a core dependency
- Replace `pkg_resources.Requirement` with `packaging.requirements.Requirement`
- Remove `setuptools` (and `types-setuptools`) as a FawltyDeps dependency
