### PR TITLE
Fixes to CI and isort dependency

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: "1.8.5"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-poetry-format-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "1.8.5"
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pypoetry/virtualenvs

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: "1.8.5"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-poetry-lint-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "1.8.5"
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pypoetry/virtualenvs

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/setup-python@v4
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "1.8.5"
       - name: Configure access
         run: |
           poetry config repositories.testpypi https://test.pypi.org/legacy/

--- a/.github/workflows/self_test.yaml
+++ b/.github/workflows/self_test.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/self_test.yaml
+++ b/.github/workflows/self_test.yaml
@@ -19,6 +19,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "1.8.5"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/self_test.yaml
+++ b/.github/workflows/self_test.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: "1.8.5"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pypoetry/virtualenvs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: "1.8.5"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pypoetry/virtualenvs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "1.8.5"
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
Quick PR of somewhat urgent fixes related to our CI setup, Python v3.8 support, or both:
- Fix GH Actions failing due to Poetry v2 dropping support for Python v3.8
- Upgrade GH Actions action/cache helper to a supported version
- Fix omission of Python 3.12 and 3.13 for the `self_test` check in CI
- Fix #472 by stating that isort must be <v6 when we're on Python 3.8
