### PR TITLE
CI: call actionlint to check workflow files

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -15,5 +15,7 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         shell: bash
       - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        run: |
+          ${{ steps.get_actionlint.outputs.executable }} -color \
+            -ignore '"actions/setup-python@v4" action is too old'
         shell: bash

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,19 @@
+name: Actionlint
+
+on: [workflow_call]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Taken from https://github.com/rhysd/actionlint/blob/v1.7.7/docs/usage.md#use-actionlint-on-github-actions
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,5 +9,7 @@ jobs:
     uses: ./.github/workflows/self_test.yaml
   lint:
     uses: ./.github/workflows/lint.yaml
+  actionlint:
+    uses: ./.github/workflows/actionlint.yaml
   format:
     uses: ./.github/workflows/format.yaml

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v4

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8

--- a/.github/workflows/self_test.yaml
+++ b/.github/workflows/self_test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Context

As part of me learning [CodeQL](https://codeql.github.com/), I'm looking at how to run CodeQL Python security rules on FawltyDeps, in its CI. When doing so, I noticed that FawltyDeps' CI had no quality checks, so I'm proposing to add one.

## How to trust this PR

* [actionlint](https://github.com/rhysd/actionlint) is a well-established checker
* There was only one bash error found by actionlint, which I fixed in commit `CI: fix shell warning found by actionlint`, well done team :clap: 
* There was a warning about the `checkout` action version being too old. I fixed it, I think it's not controversial
* There is a warning about the `setup-python` version being too old. I didn't fix it, as I think the changelog should be inspected to understand what updating means and this seemed outside the scope of this PR. So this check is ignored with actionlint's `-ignore` flag.

Finally, you can look at a run of the augmented CI on this branch (where I had added a rule to have it trigger): https://github.com/smelc/FawltyDeps/commits/smelc/ci-add-actionlint/ and https://github.com/smelc/FawltyDeps/actions/runs/14703920052/job/41259362025

