### PR TITLE
CI: run CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,9 @@ name: "CodeQL Analysis"
 
 on:
   workflow_call:
+  push:
+    branches: ["smelc/run-code-ql-security-rules"]
+  pull_request:
 
 jobs:
   codeql:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: "CodeQL Analysis"
+
+on:
+  workflow_call:
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: "python"
+        source-root: "fawltydeps"
+        queries: security-and-quality
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:python"


### PR DESCRIPTION
> [!WARNING]
>
> The second commit needs to be dropped before merging

## Context

[CodeQL](https://codeql.github.com/) is a static analyzer provided by GitHub. Depending on the queries it is called with, it can act both as a code smell detector, as well as a checker for security vulnerabilities via dataflow analyses and taint tracking.

This PR adds CodeQL checks to this repository, to increase our users' confidence that FawltyDeps is secure. I have configured it to run Python's _quality_ rules (good practices) as well as the _security-extended_ (all security rules).

## How to trust this PR

Look at the security warnings found on my fork (where this pipeline has been merged into `main`): https://github.com/smelc/FawltyDeps/security/code-scanning

![image](https://github.com/user-attachments/assets/a73b8d90-1bd1-4a18-81f2-3b88626f0da0)

* Observe the findings make sense
* Observe that FawltyDeps is indeed secure, comparing it with a more PoC concept like https://github.com/smelc/nix-security-tracker/security/code-scanning

## Next steps if this PR is merged

### Require CodeQL checks to be provided by every PR (doesn't block PRs)(optional)

This is in branch protection:

![image](https://github.com/user-attachments/assets/31d43391-f3f7-42f7-b0e8-e579331e32b9)

## Make CodeQL block PRs on alerts (optional)

This is not per branch, but repo-wise. This is to block PRs that create new alerts (existing alerts are not considered). Given that this codebase is very secure right now, and by design FawltyDeps doesn't read user inputs interactively (no `input`, no URLs provided by the user), I advice to set this quite high.

To see an example of a PR that cannot be merged because of a new vulnerability, see https://github.com/smelc/nix-security-tracker/pull/3

![image](https://github.com/user-attachments/assets/462a2fc3-1be2-4d29-af2a-c44acb078291)

## How vulnerabilities look

Vulnerabilities can be found both on https://github.com/smelc/FawltyDeps/security/code-scanning (see that you can filter by PR) and they appear on a PR's _Files_ tab, like this (from [this PR](https://github.com/smelc/nix-security-tracker/pull/3/files)):

![image](https://github.com/user-attachments/assets/197876cc-9e1f-414a-b2a2-19effe9b4c43)