### PR TITLE
Fix infinite recursion when `--base-dir` is not a parent of a source file

### DIFF
--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -190,10 +190,7 @@ def parse_source(
 
     local_context = None
     if src.base_dir is not None:
-        try:
-            src_paths = tuple(dirs_between(src.base_dir, src.path.parent))
-        except ValueError:  # src_base_dir is not a parent of src.path
-            src_paths = ()
+        src_paths = tuple(dirs_between(src.base_dir, src.path.parent))
         local_context = make_isort_config(path=src.base_dir, src_paths=src_paths)
 
     if src.path.suffix == ".py":

--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -188,14 +188,13 @@ def parse_source(
 
     assert isinstance(src.path, Path)  # noqa: S101, sanity check / silence mypy
 
-    local_context = (
-        None
-        if src.base_dir is None
-        else make_isort_config(
-            path=src.base_dir,
-            src_paths=tuple(dirs_between(src.base_dir, src.path.parent)),
-        )
-    )
+    local_context = None
+    if src.base_dir is not None:
+        try:
+            src_paths = tuple(dirs_between(src.base_dir, src.path.parent))
+        except ValueError:  # src_base_dir is not a parent of src.path
+            src_paths = ()
+        local_context = make_isort_config(path=src.base_dir, src_paths=src_paths)
 
     if src.path.suffix == ".py":
         logger.info("Parsing Python file %s", src.path)

--- a/fawltydeps/utils.py
+++ b/fawltydeps/utils.py
@@ -4,6 +4,7 @@ import logging
 import sys
 from collections.abc import Iterator
 from dataclasses import is_dataclass
+from itertools import takewhile
 from pathlib import Path
 from typing import TypeVar
 
@@ -21,13 +22,11 @@ def version() -> str:
 
 
 def dirs_between(parent: Path, child: Path) -> Iterator[Path]:
-    """Yield directories between 'parent' and 'child', inclusive."""
-    if not child.is_relative_to(parent):
-        raise ValueError(f"{child} is not a child of {parent}")
-    for path in [child, *child.parents]:
-        yield path
-        if path == parent:
-            return
+    """Return directories between 'parent' and 'child', inclusive.
+
+    Return nothing if 'parent' is not a parent of `child'.
+    """
+    return takewhile(lambda p: p.is_relative_to(parent), [child, *child.parents])
 
 
 def hide_dataclass_fields(instance: object, *field_names: str) -> None:

--- a/fawltydeps/utils.py
+++ b/fawltydeps/utils.py
@@ -22,9 +22,12 @@ def version() -> str:
 
 def dirs_between(parent: Path, child: Path) -> Iterator[Path]:
     """Yield directories between 'parent' and 'child', inclusive."""
-    yield child
-    if child != parent:
-        yield from dirs_between(parent, child.parent)
+    if not child.is_relative_to(parent):
+        raise ValueError(f"{child} is not a child of {parent}")
+    for path in [child, *child.parents]:
+        yield path
+        if path == parent:
+            return
 
 
 def hide_dataclass_fields(instance: object, *field_names: str) -> None:


### PR DESCRIPTION
In #490 @layus demonstrated a bug introduced in PR #489: When `--base-dir` is used to point to a directory that is not a parent of the source file we're currently parsing, the `dirs_between()` helper enters an infinite recursion while attempting to trace out the intermediate directories between the source file and the base directory. Several things are wrong here, and all are fixed in this PR:

- `dirs_between()` does not have to be a recursive function, an iteration over `Path.parents` suffices.
- `dirs_between()` should detect when the given `parent` is NOT a parent dir of `child`, and raise a `ValueError` instead.
- When `parse_source()` calls `dirs_between()` to setup the `isort.Config` object for correctly determining 1st- vs 3rd-party imports, it must handle this case (by catching the `ValueError` raised by `dirs_between()`, and instead pass only the given base dir as the appropriate location for 1st-party imports.

This PR adds a test case demonstatino issue #490, and addresses all points above, AFAICS.

Fixes #490.

Commits:
- `test_extract_imports_simple`: Reformat test vectors with `dataclass`
- `test_extract_imports_simple`: Add failing test case for issue #490
- `extract_imports.parse_source()`: Fix case when `base_dir` is not a parent
