### PR TITLE
Match imports against dependencies by full import path

### DIFF
--- a/fawltydeps/check.py
+++ b/fawltydeps/check.py
@@ -2,13 +2,19 @@
 
 import logging
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from itertools import groupby
 
-from fawltydeps.packages import BasePackageResolver, Package, suggest_packages
+from fawltydeps.packages import (
+    BasePackageResolver,
+    Package,
+    module_matches,
+    suggest_packages,
+)
 from fawltydeps.settings import Settings
 from fawltydeps.types import (
     DeclaredDependency,
+    Location,
     ParsedImport,
     UndeclaredDependency,
     UnusedDependency,
@@ -29,6 +35,28 @@ def is_ignored(name: str, ignore_set: set[str]) -> bool:
     return any(re.fullmatch(pattern, name) for pattern in patterns)
 
 
+def _prefixes(import_name: str) -> Iterator[str]:
+    """Yield 'import_name' and each of its dotted prefixes, shortest first."""
+    parts = import_name.split(".")
+    for i in range(1, len(parts) + 1):
+        yield ".".join(parts[:i])
+
+
+def _report_name(import_name: str, declared_modules: set[str]) -> str:
+    """Return the dotted prefix of 'import_name' to report as undeclared.
+
+    We report the shortest prefix that is not a parent namespace shared with any
+    declared module. For an import like "pandas.DataFrame" with nothing declared
+    under "pandas", this is simply "pandas". For "google.cloud.bigquery" when
+    only "google.cloud.storage" is declared, "google" and "google.cloud" are
+    shared namespaces, so we report the distinguishing "google.cloud.bigquery".
+    """
+    for prefix in _prefixes(import_name):
+        if not any(module_matches(declared, prefix) for declared in declared_modules):
+            return prefix
+    return import_name  # pragma: no cover
+
+
 def calculate_undeclared(
     imports: list[ParsedImport],
     resolved_deps: dict[str, Package],
@@ -40,22 +68,40 @@ def calculate_undeclared(
     Return a list of UndeclaredDependency objects that represent the import
     names in 'imports' that are not found in any of the packages in
     'resolved_deps' (representing declared dependencies).
+
+    Imports are matched against declared dependencies using their full dotted
+    import path: an import is covered iff some declared package provides that
+    module or one of its parents. This distinguishes packages that share an
+    import prefix (e.g. the "google" namespace).
     """
-    declared_names = {name for p in resolved_deps.values() for name in p.import_names}
-    undeclared = [
-        i
-        for i in imports
-        if not is_ignored(i.name, settings.ignore_undeclared)
-        and i.name not in declared_names
-    ]
-    undeclared.sort(key=lambda i: i.name)  # groupby requires pre-sorting
+    declared_modules = {
+        module for p in resolved_deps.values() for module in p.import_names
+    }
+
+    def is_covered(key: str) -> bool:
+        return any(prefix in declared_modules for prefix in _prefixes(key))
+
+    # Map each undeclared import (by its reported name) to the source locations
+    # where it is imported, preserving import-encounter order.
+    undeclared: dict[str, list[Location]] = {}
+    for i in imports:
+        for key in i.match_keys:
+            if is_covered(key):
+                continue
+            name = _report_name(key, declared_modules)
+            if is_ignored(name, settings.ignore_undeclared):
+                continue
+            sources = undeclared.setdefault(name, [])
+            if i.source not in sources:  # avoid dupes from multi-name imports
+                sources.append(i.source)
+
     return [
         UndeclaredDependency(
             name,
-            [i.source for i in imports],
+            sources,
             {p.package_name for p in suggest_packages(name, resolvers)},
         )
-        for name, imports in groupby(undeclared, key=lambda i: i.name)
+        for name, sources in sorted(undeclared.items())
     ]
 
 
@@ -71,7 +117,7 @@ def calculate_unused(
     'declared_deps' for which none of the provided import names (found via
     'resolved_deps') are present in the list of actual 'imports'.
     """
-    imported_names = {i.name for i in imports}
+    imported_names = {key for i in imports for key in i.match_keys}
     unused = [
         dep
         for dep in declared_deps

--- a/fawltydeps/extract_imports.py
+++ b/fawltydeps/extract_imports.py
@@ -69,10 +69,16 @@ def parse_code(
         if isinstance(node, ast.Import):
             logger.debug(ast.dump(node))
             for alias in node.names:
+                # `name` is the top-level component (e.g. "foo" for "foo.bar.baz")
+                # presented to the user, while `qualified` keeps the full dotted
+                # path so that packages sharing a top-level prefix can be told
+                # apart when matching against declared dependencies.
                 name = alias.name.split(".", 1)[0]
                 if is_external_import(name):
                     yield ParsedImport(
-                        name=name, source=source.supply(lineno=node.lineno)
+                        name=name,
+                        source=source.supply(lineno=node.lineno),
+                        qualified=(alias.name,),
                     )
         elif isinstance(node, ast.ImportFrom):
             logger.debug(ast.dump(node))
@@ -81,10 +87,25 @@ def parse_code(
             # They are therefore uninteresting to us.
             if node.level == 0 and node.module is not None:
                 name = node.module.split(".", 1)[0]
-                if is_external_import(name):
-                    yield ParsedImport(
-                        name=name, source=source.supply(lineno=node.lineno)
-                    )
+                if not is_external_import(name):
+                    continue
+                # `from foo.bar import baz` reads the module `foo.bar`, but the
+                # name `baz` may itself be a submodule `foo.bar.baz`. We record
+                # the fully-qualified candidates so that namespace packages (e.g.
+                # `from google.cloud import storage`) can be told apart. When the
+                # imported name turns out to be an attribute rather than a
+                # submodule, prefix-matching against the parent package keeps this
+                # correct (see packages.module_matches).
+                qualified = tuple(
+                    f"{node.module}.{alias.name}"
+                    for alias in node.names
+                    if alias.name != "*"  # `import *`: nothing to qualify
+                ) or (node.module,)
+                yield ParsedImport(
+                    name=name,
+                    source=source.supply(lineno=node.lineno),
+                    qualified=qualified,
+                )
 
 
 def parse_notebook_file(  # noqa: C901

--- a/fawltydeps/main.py
+++ b/fawltydeps/main.py
@@ -218,6 +218,12 @@ class Analysis:
                 "version",
             ]
         }
+        # ParsedImport.qualified is an internal matching detail (see types.py);
+        # serialize only the user-facing 'name' and 'source' for each import.
+        if json_dict["imports"] is not None:
+            json_dict["imports"] = [
+                {"name": imp.name, "source": imp.source} for imp in json_dict["imports"]
+            ]
         json.dump(json_dict, out, indent=2, default=encoder)
 
     def print_human_readable(  # noqa: C901

--- a/fawltydeps/packages.py
+++ b/fawltydeps/packages.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 import shutil
 import subprocess
@@ -47,6 +48,92 @@ PackageDebugInfo = Union[None, str, dict[str, set[str]]]
 logger = logging.getLogger(__name__)
 
 
+def module_matches(imported: str, provided: str) -> bool:
+    """Return True iff the 'imported' name is covered by the 'provided' module.
+
+    Both arguments are (possibly dotted) import paths. An import is covered by a
+    provided module when it _is_ that module, or a submodule thereof. For
+    example, the provided module "google.cloud.storage" covers the imports
+    "google.cloud.storage" and "google.cloud.storage.blob", but neither
+    "google.cloud.bigquery" nor the bare namespace "google.cloud".
+    """
+    return imported == provided or imported.startswith(provided + ".")
+
+
+def _module_basename(filename: str) -> Optional[str]:
+    """Return the importable module name for a file, or None if not a module."""
+    if filename.endswith(".pyi"):  # type stubs are not known to importlib
+        return filename[: -len(".pyi")]
+    return inspect.getmodulename(filename)
+
+
+def _iter_module_files(dist: object) -> Iterator[tuple[tuple[str, ...], str]]:
+    """Yield (parent_dir_parts, module_name) for each importable file in dist."""
+    for file in getattr(dist, "files", None) or []:
+        parts = tuple(file.parts)
+        if not parts or ".." in parts:
+            continue  # e.g. scripts/data installed outside site-packages
+        if any(p.endswith((".dist-info", ".egg-info")) for p in parts):
+            continue
+        modname = _module_basename(parts[-1])
+        if modname is not None:  # an importable module file
+            yield parts[:-1], modname
+
+
+def _modules_from_files(dist: object) -> set[str]:
+    """Infer the full dotted module paths provided by an installed dist.
+
+    Unlike importlib_metadata's _top_level_* helpers (which only report the
+    top-level component, e.g. "google"), this walks the distribution's file list
+    and descends through PEP 420 namespace packages (directories without an
+    __init__) so that distributions sharing a namespace are distinguished by
+    their full import path, e.g. "google.cloud.storage" vs "google.cloud.bigquery".
+
+    A regular package (a directory with an __init__) owns its entire subtree, so
+    only the top-most such package is reported (e.g. "numpy", not "numpy.linalg").
+    """
+    init_dirs: set[tuple[str, ...]] = set()  # dirs containing an __init__ module
+    loose_modules: list[tuple[str, ...]] = []  # parts of standalone module files
+    for dir_parts, modname in _iter_module_files(dist):
+        if modname == "__init__":
+            init_dirs.add(dir_parts)
+        else:
+            loose_modules.append((*dir_parts, modname))
+
+    def within_regular_package(dir_parts: tuple[str, ...]) -> bool:
+        """Return True iff dir_parts (or an ancestor) is a regular package."""
+        return any(dir_parts[:i] in init_dirs for i in range(1, len(dir_parts) + 1))
+
+    modules: set[str] = set()
+    for dir_parts in init_dirs:  # keep only the top-most regular package
+        if not within_regular_package(dir_parts[:-1]):
+            modules.add(".".join(dir_parts))
+    for parts in loose_modules:  # standalone modules not owned by a package
+        if not within_regular_package(parts[:-1]):
+            modules.add(".".join(parts))
+    return modules
+
+
+def _provided_imports(dist: object) -> list[str]:
+    """Return the import names (full dotted module paths) provided by a dist.
+
+    We trust the package's declared top-level names (top_level.txt) about _which_
+    top-level names are exposed, but use the distribution's file listing to refine
+    each into its full dotted path(s). This keeps the precise sub-module
+    information needed to tell namespace-sharing packages apart, while not
+    inventing top-level names that the package did not declare.
+    """
+    declared = set(_top_level_declared(dist))  # type: ignore[no-untyped-call]
+    modules = _modules_from_files(dist)
+    if declared:
+        refined = {m for m in modules if m.split(".", 1)[0] in declared}
+        # Preserve declared top-levels that we could not refine from files.
+        refined_tops = {m.split(".", 1)[0] for m in refined}
+        refined.update(name for name in declared if name not in refined_tops)
+        return sorted(refined)
+    return sorted(modules) or list(_top_level_inferred(dist))  # type: ignore[no-untyped-call]
+
+
 @dataclass(frozen=True)
 class Package:
     """Encapsulate an installable Python package.
@@ -86,11 +173,13 @@ class Package:
         return self.normalize_name(self.package_name)
 
     def stubbed_imports(self) -> set[str]:
-        """Return a set of import names without the type stubs suffix.
+        """Return the provided modules with the type stubs suffix stripped.
 
         For example, a package that has .import_names == {"foo", "bar-stubs"},
         will return {"bar"} from this method, indicating that it provides type
-        stubs for the "bar" import.
+        stubs for the "bar" import. The "-stubs" suffix is stripped from the
+        first (top-level) component only, so e.g. "google-stubs.cloud.storage"
+        yields "google.cloud.storage".
 
         This allows stub-only packages to be matched against the import names
         for which they provide type stubs. Stub-only packages are described in
@@ -99,17 +188,36 @@ class Package:
         to assume that "FOO-stubs" is indeed directly associated with the "FOO"
         module.
         """
-        return {
-            import_name[: -len("-stubs")]
-            for import_name in self.import_names
-            if import_name.endswith("-stubs")
-        }
+        result = set()
+        for import_name in self.import_names:
+            top, sep, rest = import_name.partition(".")
+            if top.endswith("-stubs"):
+                result.add(top[: -len("-stubs")] + sep + rest)
+        return result
+
+    def provided_imports(self) -> set[str]:
+        """Return all import paths provided by this package.
+
+        This includes the package's declared import names plus the stub-stripped
+        variants (see .stubbed_imports()).
+        """
+        return self.import_names | self.stubbed_imports()
+
+    def provides(self, imported_name: str, *, include_stubs: bool = True) -> bool:
+        """Return True iff this package provides the given (dotted) import name.
+
+        When 'include_stubs' is True, type-stub (-stubs) associations are also
+        considered (so e.g. a types-requests dependency is deemed to provide the
+        'requests' import). Set it to False when suggesting packages for an
+        undeclared import, where a stubs-only package would be a misleading
+        suggestion.
+        """
+        candidates = self.provided_imports() if include_stubs else self.import_names
+        return any(module_matches(imported_name, provided) for provided in candidates)
 
     def is_used(self, imported_names: Iterable[str]) -> bool:
-        """Return True iff this package is among the given import names."""
-        return bool(self.import_names.intersection(imported_names)) or bool(
-            self.stubbed_imports().intersection(imported_names)
-        )
+        """Return True iff any of the given imports is provided by this package."""
+        return any(self.provides(name) for name in imported_names)
 
 
 class BasePackageResolver(ABC):
@@ -232,7 +340,11 @@ class UserDefinedMapping(BasePackageResolver):
 
     def lookup_import(self, import_name: str) -> Iterable[Package]:
         """Return all Package objects that provide the given import name."""
-        return (p for p in self.packages.values() if import_name in p.import_names)
+        return (
+            p
+            for p in self.packages.values()
+            if p.provides(import_name, include_stubs=False)
+        )
 
 
 class InstalledPackageResolver(BasePackageResolver):
@@ -275,10 +387,7 @@ class InstalledPackageResolver(BasePackageResolver):
 
             logger.debug(f"Found {dist.name} {dist.version} under {parent_dir}")
             seen.add(normalized_name)
-            imports = list(
-                _top_level_declared(dist)  # type: ignore[no-untyped-call]
-                or _top_level_inferred(dist)  # type: ignore[no-untyped-call]
-            )
+            imports = _provided_imports(dist)
             if not imports:
                 # We have found an installed package that provides zero import
                 # names. This might be a legitimate tool/application that is
@@ -319,7 +428,11 @@ class InstalledPackageResolver(BasePackageResolver):
 
     def lookup_import(self, import_name: str) -> Iterable[Package]:
         """Return all Package objects that provide the given import name."""
-        return (p for p in self.packages.values() if import_name in p.import_names)
+        return (
+            p
+            for p in self.packages.values()
+            if p.provides(import_name, include_stubs=False)
+        )
 
 
 class SysPathPackageResolver(InstalledPackageResolver):

--- a/fawltydeps/types.py
+++ b/fawltydeps/types.py
@@ -268,10 +268,29 @@ class Location:
 
 @dataclass(eq=True, frozen=True, order=True)
 class ParsedImport:
-    """Import parsed from the source code."""
+    """Import parsed from the source code.
+
+    'name' is the module that is imported, as it should be presented to the user
+    (e.g. via --list-imports): the dotted module path for `import a.b.c`, or the
+    module imported _from_ for `from a.b import c` (i.e. "a.b").
+
+    'qualified' carries the fully-qualified import path(s) used when matching this
+    import against the modules provided by declared dependencies. For
+    `from a.b import c, d` this is ("a.b.c", "a.b.d"), which tells apart
+    packages that share an import prefix (e.g. the "google" namespace). It is
+    excluded from equality/ordering (and from the serialized output) so that it
+    is a pure implementation detail: two imports with the same 'name' and
+    'source' remain equal regardless of their 'qualified' paths.
+    """
 
     name: str
     source: Location
+    qualified: tuple[str, ...] = field(default=(), compare=False)
+
+    @property
+    def match_keys(self) -> tuple[str, ...]:
+        """Return the fully-qualified import paths to match against packages."""
+        return self.qualified or (self.name,)
 
 
 @dataclass(eq=True, frozen=True, order=True)

--- a/tests/test_full_import_path.py
+++ b/tests/test_full_import_path.py
@@ -1,0 +1,297 @@
+"""Verify that the full (dotted) import path is used to detect bad deps.
+
+FawltyDeps historically tracked imports and dependencies by their top-level
+component only (e.g. "google"). That is insufficient when several distributions
+share an import prefix, as is the case for PEP 420 namespace packages such as
+`google-cloud-storage` (providing `google.cloud.storage`) and
+`google-cloud-bigquery` (providing `google.cloud.bigquery`). These tests pin down
+the behavior that distinguishes such packages by their full import path.
+"""
+
+from pathlib import Path, PurePosixPath
+from textwrap import dedent
+
+import pytest
+
+from fawltydeps.check import calculate_undeclared, calculate_unused
+from fawltydeps.extract_imports import parse_code
+from fawltydeps.packages import (
+    IdentityMapping,
+    LocalPackageResolver,
+    Package,
+    _modules_from_files,
+    _provided_imports,
+    module_matches,
+)
+from fawltydeps.settings import Settings
+from fawltydeps.types import (
+    DeclaredDependency,
+    Location,
+    ParsedImport,
+    PyEnvSource,
+    UndeclaredDependency,
+    UnusedDependency,
+)
+
+# --- module_matches: prefix/ancestor matching of dotted import paths ---
+
+
+@pytest.mark.parametrize(
+    ("imported", "provided", "expect"),
+    [
+        ("foo", "foo", True),
+        ("foo.bar", "foo", True),  # submodule of a provided top-level package
+        ("foo.bar.baz", "foo.bar", True),  # deeper submodule
+        ("foo", "foo.bar", False),  # a parent namespace is not "provided"
+        ("foobar", "foo", False),  # prefix string, but not a module ancestor
+        ("google.cloud.bigquery", "google.cloud.storage", False),  # the headline case
+        ("google.cloud.storage", "google.cloud.storage", True),
+        ("google.cloud.storage.blob", "google.cloud.storage", True),
+    ],
+)
+def test_module_matches(imported, provided, expect):
+    assert module_matches(imported, provided) is expect
+
+
+# --- Inferring a distribution's provided modules from its file list ---
+
+
+class FakeDist:
+    """A minimal stand-in for an importlib_metadata Distribution."""
+
+    def __init__(self, files, top_level=None):
+        self.files = [PurePosixPath(f) for f in files]
+        self._top_level = top_level
+
+    def read_text(self, filename):
+        return self._top_level if filename == "top_level.txt" else None
+
+
+@pytest.mark.parametrize(
+    ("files", "expect"),
+    [
+        pytest.param(
+            ["numpy/__init__.py", "numpy/linalg/__init__.py", "numpy/core.py"],
+            {"numpy"},
+            id="regular_package__reports_topmost_package_only",
+        ),
+        pytest.param(
+            ["six.py"],
+            {"six"},
+            id="single_module__reports_module",
+        ),
+        pytest.param(
+            ["google/cloud/storage/__init__.py", "google/cloud/storage/blob.py"],
+            {"google.cloud.storage"},
+            id="namespace_package__descends_to_regular_package",
+        ),
+        pytest.param(
+            ["google/cloud/bigquery/__init__.py", "google/cloud/bigquery/client.py"],
+            {"google.cloud.bigquery"},
+            id="other_namespace_package__yields_distinct_full_path",
+        ),
+        pytest.param(
+            ["foo-stubs/__init__.pyi", "foo-stubs/bar.pyi"],
+            {"foo-stubs"},
+            id="stub_only_package__keeps_stubs_suffix",
+        ),
+        pytest.param(
+            ["pkg-1.0.dist-info/RECORD", "pkg-1.0.dist-info/METADATA"],
+            set(),
+            id="dist_info_files__are_ignored",
+        ),
+    ],
+)
+def test_modules_from_files(files, expect):
+    assert _modules_from_files(FakeDist(files)) == expect
+
+
+def test_provided_imports__refines_declared_top_level_into_full_path():
+    dist = FakeDist(
+        ["google/cloud/storage/__init__.py", "google/cloud/storage/blob.py"],
+        top_level="google\n",
+    )
+    assert _provided_imports(dist) == ["google.cloud.storage"]
+
+
+def test_provided_imports__falls_back_to_top_level_when_no_files():
+    # An installed dist without a usable RECORD (no .files) should still resolve
+    # to its declared top-level name(s).
+    dist = FakeDist([], top_level="google\n")
+    assert _provided_imports(dist) == ["google"]
+
+
+# --- Package matching against full import paths ---
+
+
+def test_package_provides__namespace_package_does_not_cover_sibling():
+    storage = Package("google-cloud-storage", {"google.cloud.storage"}, IdentityMapping)
+    assert storage.provides("google.cloud.storage")
+    assert storage.provides("google.cloud.storage.blob")
+    assert not storage.provides("google.cloud.bigquery")
+    assert not storage.provides("google.cloud")  # bare namespace is not provided
+
+
+def test_package_is_used__matches_submodule_imports():
+    pkg = Package("numpy", {"numpy"}, IdentityMapping)
+    assert pkg.is_used(["numpy.linalg"])
+    assert not pkg.is_used(["numpyfoo"])
+
+
+# --- Parsing records the fully-qualified import paths ---
+
+
+def test_parse_code__from_import_records_qualified_submodules():
+    code = "from google.cloud import storage, bigquery\n"
+    [imp] = list(parse_code(code, source=Location("<stdin>")))
+    assert imp.name == "google"  # top-level, as shown to the user
+    assert set(imp.qualified) == {
+        "google.cloud.storage",
+        "google.cloud.bigquery",
+    }
+    assert set(imp.match_keys) == {
+        "google.cloud.storage",
+        "google.cloud.bigquery",
+    }
+
+
+def test_parse_code__plain_dotted_import_records_full_path():
+    code = "import google.cloud.bigquery\n"
+    [imp] = list(parse_code(code, source=Location("<stdin>")))
+    assert imp.name == "google"
+    assert imp.qualified == ("google.cloud.bigquery",)
+
+
+def test_parse_code__star_import_falls_back_to_module():
+    code = "from google.cloud import *\n"
+    [imp] = list(parse_code(code, source=Location("<stdin>")))
+    assert imp.qualified == ("google.cloud",)
+
+
+# --- End-to-end undeclared / unused detection across a shared namespace ---
+
+
+def _dep(name):
+    return DeclaredDependency(name, Location("requirements.txt"))
+
+
+def _import(*qualified, name=None, lineno=1):
+    return ParsedImport(
+        name=name or qualified[0].split(".", 1)[0],
+        source=Location("code.py", lineno=lineno),
+        qualified=tuple(qualified),
+    )
+
+
+def test_undeclared__sibling_namespace_import_is_flagged():
+    # We declare google-cloud-storage but import google.cloud.bigquery. Even
+    # though both share the "google" prefix, the bigquery import is undeclared.
+    resolved = {
+        "google-cloud-storage": Package(
+            "google-cloud-storage", {"google.cloud.storage"}, IdentityMapping
+        ),
+    }
+    imports = [
+        _import("google.cloud.storage"),  # declared -> OK
+        _import("google.cloud.bigquery", name="google", lineno=2),  # undeclared
+    ]
+    actual = calculate_undeclared(imports, resolved, [], Settings())
+    assert actual == [
+        UndeclaredDependency(
+            "google.cloud.bigquery",
+            [Location("code.py", lineno=2)],
+            set(),
+        )
+    ]
+
+
+def test_unused__declared_sibling_namespace_is_reported():
+    # google-cloud-storage is declared but only google.cloud.bigquery is used.
+    resolved = {
+        "google-cloud-storage": Package(
+            "google-cloud-storage", {"google.cloud.storage"}, IdentityMapping
+        ),
+    }
+    declared = [_dep("google-cloud-storage")]
+    imports = [_import("google.cloud.bigquery", name="google")]
+    actual = calculate_unused(imports, declared, resolved, Settings())
+    assert actual == [
+        UnusedDependency("google-cloud-storage", [Location("requirements.txt")])
+    ]
+
+
+def test_no_issues__matching_namespace_package_is_neither_undeclared_nor_unused():
+    resolved = {
+        "google-cloud-storage": Package(
+            "google-cloud-storage", {"google.cloud.storage"}, IdentityMapping
+        ),
+    }
+    declared = [_dep("google-cloud-storage")]
+    imports = [_import("google.cloud.storage", name="google")]
+    assert calculate_undeclared(imports, resolved, [], Settings()) == []
+    assert calculate_unused(imports, declared, resolved, Settings()) == []
+
+
+# --- Integration: on-disk namespace packages via LocalPackageResolver ---
+
+
+def _write_namespace_env(site_dir: Path, dists: dict) -> None:
+    """Create namespace packages + *.dist-info (with RECORD) under site_dir.
+
+    'dists' maps a distribution name to a list of regular packages it provides
+    (as dotted module paths). Each such package is materialized as a PEP 420
+    namespace path ending in a regular package (with __init__.py).
+    """
+    for dist_name, modules in dists.items():
+        record_lines = []
+        top_levels = set()
+        for module in modules:
+            parts = module.split(".")
+            top_levels.add(parts[0])
+            pkg_dir = site_dir.joinpath(*parts)
+            pkg_dir.mkdir(parents=True, exist_ok=True)
+            init = pkg_dir / "__init__.py"
+            init.touch()
+            record_lines.append(f"{init.relative_to(site_dir).as_posix()},,")
+        dist_info = site_dir / f"{dist_name}-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(f"Name: {dist_name}\nVersion: 1.0\n")
+        (dist_info / "top_level.txt").write_text(
+            "".join(f"{t}\n" for t in sorted(top_levels))
+        )
+        record_lines.append(
+            f"{(dist_info / 'METADATA').relative_to(site_dir).as_posix()},,"
+        )
+        (dist_info / "RECORD").write_text("\n".join(record_lines) + "\n")
+
+
+def test_local_resolver__distinguishes_shared_namespace_distributions(fake_venv):
+    _venv_dir, site_dir = fake_venv({})  # a valid, empty venv site-packages dir
+    _write_namespace_env(
+        site_dir,
+        {
+            "google-cloud-storage": ["google.cloud.storage"],
+            "google-cloud-bigquery": ["google.cloud.bigquery"],
+        },
+    )
+
+    resolver = LocalPackageResolver({PyEnvSource(site_dir)})
+    resolved = resolver.lookup_packages(
+        {"google-cloud-storage", "google-cloud-bigquery"}
+    )
+
+    assert resolved["google-cloud-storage"].import_names == {"google.cloud.storage"}
+    assert resolved["google-cloud-bigquery"].import_names == {"google.cloud.bigquery"}
+
+    # Importing only bigquery, while declaring only storage, must be detected.
+    imports = list(
+        parse_code(
+            dedent("from google.cloud import bigquery\n"),
+            source=Location("code.py"),
+        )
+    )
+    only_storage = {"google-cloud-storage": resolved["google-cloud-storage"]}
+    undeclared = calculate_undeclared(imports, only_storage, [resolver], Settings())
+    assert [u.name for u in undeclared] == ["google.cloud.bigquery"]
+    # And the resolver can suggest the right package for the undeclared import.
+    assert undeclared[0].candidates == {"google-cloud-bigquery"}


### PR DESCRIPTION
## Problem

FawltyDeps tracks imports and dependencies by their **top-level component only** (e.g. `google`), so it cannot distinguish distributions that share an import prefix — most notably PEP 420 namespace packages such as `google-cloud-storage` (providing `google.cloud.storage`) and `google-cloud-bigquery` (providing `google.cloud.bigquery`). Declaring one while importing the other goes undetected.

## Change

Use the **full dotted import path** as the matching key on both sides of the comparison:

* **`extract_imports`** — `ParsedImport` now carries the fully-qualified import path(s) in a new `qualified` field. `import a.b.c` → `("a.b.c",)`; `from a.b import c, d` → `("a.b.c", "a.b.d")`. The field is excluded from equality and from the serialized output, so the user-facing `name` (top-level), `--list-imports`, and the JSON schema are **unchanged**.
* **`packages`** — the installed-package resolver now infers full module paths from the distribution's file list (RECORD), descending through namespace packages (`google.cloud.storage` rather than just `google`). Matching uses a new `module_matches()` with ancestor/prefix semantics; stub (`-stubs`) handling is generalized to dotted paths.
* **`check`** — undeclared/unused detection compares full paths. Undeclared findings are reported at the *distinguishing* path (`google.cloud.bigquery`) but still collapse to the top-level name (`pandas`) when the whole top-level package is missing — so existing output is preserved except where prefix collisions are actually resolved.

## Tests

Adds `tests/test_full_import_path.py` covering path matching, namespace-aware module inference, parsing, and end-to-end undeclared/unused detection across a shared namespace (including a `LocalPackageResolver` integration test that distinguishes `google-cloud-storage` from `google-cloud-bigquery`). No existing snapshots change.

## Independence

This PR is **independent** of #512 (the isort → native classifier change): it branches from `main`, touches different regions of the shared files, and the full test suite passes on both bases. The two can be merged in either order.